### PR TITLE
Fixed "all" Task to allow plugin baking.

### DIFF
--- a/src/Shell/BakeShell.php
+++ b/src/Shell/BakeShell.php
@@ -54,6 +54,7 @@ class BakeShell extends Shell
         Cache::disable();
 
         $task = $this->_camelize($this->command);
+
         if (isset($this->{$task}) && !in_array($task, ['Project'])) {
             if (isset($this->params['connection'])) {
                 $this->{$task}->connection = $this->params['connection'];
@@ -223,8 +224,8 @@ class BakeShell extends Shell
 
         $name = $this->_camelize($name);
 
-        $this->Model->bake($name);
-        $this->Controller->bake($name);
+        $this->Model->main($name);
+        $this->Controller->main($name);
 
         $this->View->main($name);
 

--- a/src/Template/Bake/Element/Controller/add.ctp
+++ b/src/Template/Bake/Element/Controller/add.ctp
@@ -47,4 +47,5 @@ $compact = ["'" . $singularName . "'"];
         endforeach;
 %>
         $this->set(compact(<%= join(', ', $compact) %>));
+        $this->set('_serialize', [<%= join("', '", $compact) %>]);
     }

--- a/src/Template/Bake/Element/Controller/add.ctp
+++ b/src/Template/Bake/Element/Controller/add.ctp
@@ -47,5 +47,5 @@ $compact = ["'" . $singularName . "'"];
         endforeach;
 %>
         $this->set(compact(<%= join(', ', $compact) %>));
-        $this->set('_serialize', [<%= join(', ', $compact) %>]);
+        $this->set('_serialize', [<%=$singularName%>]);
     }

--- a/src/Template/Bake/Element/Controller/add.ctp
+++ b/src/Template/Bake/Element/Controller/add.ctp
@@ -47,5 +47,5 @@ $compact = ["'" . $singularName . "'"];
         endforeach;
 %>
         $this->set(compact(<%= join(', ', $compact) %>));
-        $this->set('_serialize', [<%=$singularName%>]);
+        $this->set('_serialize', ['<%=$singularName%>']);
     }

--- a/src/Template/Bake/Element/Controller/add.ctp
+++ b/src/Template/Bake/Element/Controller/add.ctp
@@ -47,5 +47,5 @@ $compact = ["'" . $singularName . "'"];
         endforeach;
 %>
         $this->set(compact(<%= join(', ', $compact) %>));
-        $this->set('_serialize', [<%= join("', '", $compact) %>]);
+        $this->set('_serialize', [<%= join(', ', $compact) %>]);
     }

--- a/src/Template/Bake/Element/Controller/edit.ctp
+++ b/src/Template/Bake/Element/Controller/edit.ctp
@@ -51,5 +51,5 @@ $compact = ["'" . $singularName . "'"];
         endforeach;
 %>
         $this->set(compact(<%= join(', ', $compact) %>));
-        $this->set('_serialize', [<%= join(', ', $compact) %>]);
+        $this->set('_serialize', [<%=$singularName%>]);
     }

--- a/src/Template/Bake/Element/Controller/edit.ctp
+++ b/src/Template/Bake/Element/Controller/edit.ctp
@@ -51,5 +51,5 @@ $compact = ["'" . $singularName . "'"];
         endforeach;
 %>
         $this->set(compact(<%= join(', ', $compact) %>));
-        $this->set('_serialize', [<%= join("', '", $compact) %>]);
+        $this->set('_serialize', [<%= join(', ', $compact) %>]);
     }

--- a/src/Template/Bake/Element/Controller/edit.ctp
+++ b/src/Template/Bake/Element/Controller/edit.ctp
@@ -51,4 +51,5 @@ $compact = ["'" . $singularName . "'"];
         endforeach;
 %>
         $this->set(compact(<%= join(', ', $compact) %>));
+        $this->set('_serialize', [<%= join("', '", $compact) %>]);
     }

--- a/src/Template/Bake/Element/Controller/edit.ctp
+++ b/src/Template/Bake/Element/Controller/edit.ctp
@@ -51,5 +51,5 @@ $compact = ["'" . $singularName . "'"];
         endforeach;
 %>
         $this->set(compact(<%= join(', ', $compact) %>));
-        $this->set('_serialize', [<%=$singularName%>]);
+        $this->set('_serialize', ['<%=$singularName%>']);
     }

--- a/src/Template/Bake/Element/Controller/index.ctp
+++ b/src/Template/Bake/Element/Controller/index.ctp
@@ -28,4 +28,5 @@
         ];
 <% endif; %>
         $this->set('<%= $pluralName %>', $this->paginate($this-><%= $currentModelName %>));
+        $this->set('_serialize', ['<%= $pluralName %>']);
     }

--- a/src/Template/Bake/Element/Controller/view.ctp
+++ b/src/Template/Bake/Element/Controller/view.ctp
@@ -33,4 +33,5 @@ $allAssociations = array_merge(
             'contain' => [<%= $this->Bake->stringifyList($allAssociations, ['indent' => false]) %>]
         ]);
         $this->set('<%= $singularName %>', $<%= $singularName %>);
+        $this->set('_serialize', ['<%= $singularName %>']);
     }

--- a/tests/TestCase/Shell/BakeShellTest.php
+++ b/tests/TestCase/Shell/BakeShellTest.php
@@ -69,12 +69,12 @@ class BakeShellTest extends TestCase
         $this->Shell->View = $this->getMock('Bake\Shell\Task\ModelTask');
 
         $this->Shell->Model->expects($this->once())
-            ->method('bake')
+            ->method('main')
             ->with('Comments')
             ->will($this->returnValue(true));
 
         $this->Shell->Controller->expects($this->once())
-            ->method('bake')
+            ->method('main')
             ->with('Comments')
             ->will($this->returnValue(true));
 

--- a/tests/comparisons/Controller/testBakeActions.php
+++ b/tests/comparisons/Controller/testBakeActions.php
@@ -38,6 +38,7 @@ class BakeArticlesController extends AppController
             'contain' => ['BakeUsers']
         ];
         $this->set('bakeArticles', $this->paginate($this->BakeArticles));
+        $this->set('_serialize', ['bakeArticles']);
     }
 
     /**
@@ -53,6 +54,7 @@ class BakeArticlesController extends AppController
             'contain' => ['BakeUsers', 'BakeTags', 'BakeComments']
         ]);
         $this->set('bakeArticle', $bakeArticle);
+        $this->set('_serialize', ['bakeArticle']);
     }
 
     /**
@@ -74,6 +76,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
+        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
     }
 
     /**
@@ -100,6 +103,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
+        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
     }
 
     /**

--- a/tests/comparisons/Controller/testBakeActions.php
+++ b/tests/comparisons/Controller/testBakeActions.php
@@ -76,7 +76,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
-        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
+        $this->set('_serialize', ['bakeArticle']);
     }
 
     /**
@@ -103,7 +103,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
-        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
+        $this->set('_serialize', ['bakeArticle']);
     }
 
     /**

--- a/tests/comparisons/Controller/testBakeActionsContent.php
+++ b/tests/comparisons/Controller/testBakeActionsContent.php
@@ -22,6 +22,7 @@ class BakeArticlesController extends AppController
             'contain' => ['BakeUsers']
         ];
         $this->set('bakeArticles', $this->paginate($this->BakeArticles));
+        $this->set('_serialize', ['bakeArticles']);
     }
 
     /**
@@ -37,6 +38,7 @@ class BakeArticlesController extends AppController
             'contain' => ['BakeUsers', 'BakeTags', 'BakeComments']
         ]);
         $this->set('bakeArticle', $bakeArticle);
+        $this->set('_serialize', ['bakeArticle']);
     }
 
     /**
@@ -58,6 +60,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
+        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
     }
 
     /**
@@ -84,6 +87,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
+        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
     }
 
     /**

--- a/tests/comparisons/Controller/testBakeActionsContent.php
+++ b/tests/comparisons/Controller/testBakeActionsContent.php
@@ -60,7 +60,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
-        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
+        $this->set('_serialize', ['bakeArticle']);
     }
 
     /**
@@ -87,7 +87,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
-        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
+        $this->set('_serialize', ['bakeArticle']);
     }
 
     /**

--- a/tests/comparisons/Controller/testBakeWithPlugin.php
+++ b/tests/comparisons/Controller/testBakeWithPlugin.php
@@ -22,6 +22,7 @@ class BakeArticlesController extends AppController
             'contain' => ['BakeUsers']
         ];
         $this->set('bakeArticles', $this->paginate($this->BakeArticles));
+        $this->set('_serialize', ['bakeArticles']);
     }
 
     /**
@@ -37,6 +38,7 @@ class BakeArticlesController extends AppController
             'contain' => ['BakeUsers', 'BakeTags', 'BakeComments']
         ]);
         $this->set('bakeArticle', $bakeArticle);
+        $this->set('_serialize', ['bakeArticle']);
     }
 
     /**
@@ -58,6 +60,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
+        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
     }
 
     /**
@@ -84,6 +87,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
+        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
     }
 
     /**

--- a/tests/comparisons/Controller/testBakeWithPlugin.php
+++ b/tests/comparisons/Controller/testBakeWithPlugin.php
@@ -60,7 +60,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
-        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
+        $this->set('_serialize', ['bakeArticle']);
     }
 
     /**
@@ -87,7 +87,7 @@ class BakeArticlesController extends AppController
         $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200]);
         $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200]);
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
-        $this->set('_serialize', ['bakeArticle', 'bakeUsers', 'bakeTags']);
+        $this->set('_serialize', ['bakeArticle']);
     }
 
     /**


### PR DESCRIPTION
Calling "bake" directly in the Tasks skips the $this->_getName(); function call, which separates Plugin from Name. Fix is to call main(); instead of bake();.