### PR TITLE
Delete empty file when baking fixtures

### DIFF
--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -226,6 +226,8 @@ class FixtureTask extends BakeTask
 
         $this->out("\n" . sprintf('Baking test fixture for %s...', $model), 1, Shell::QUIET);
         $this->createFile($path . $filename, $content);
+        $emptyFile = $path . 'empty';
+        $this->_deleteEmptyFile($emptyFile);
         return $content;
     }
 


### PR DESCRIPTION
When executing ```cake bake model``` empty files in Entity and Table folders are removed, but it was not the case for fixture when using ```cake bake fixture```