### PR TITLE
Fixed Plugin Task to deny option of ROOT/plugins and fixed Autoloading Generation

### DIFF
--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -215,9 +215,11 @@ class PluginTask extends BakeTask
             return false;
         }
 
+        $autoloadPath = str_replace(ROOT, '.', $this->path);
+
         $config = json_decode(file_get_contents($file), true);
-        $config['autoload']['psr-4'][$plugin . '\\'] = "./plugins/$plugin/src";
-        $config['autoload-dev']['psr-4'][$plugin . '\\Test\\'] = "./plugins/$plugin/tests";
+        $config['autoload']['psr-4'][$plugin . '\\'] = $autoloadPath . $plugin . "/src";
+        $config['autoload-dev']['psr-4'][$plugin . '\\Test\\'] = $autoloadPath . $plugin . "/tests";
 
         $this->out('<info>Modifying composer autoloader</info>');
 
@@ -235,7 +237,7 @@ class PluginTask extends BakeTask
             $cwd = getcwd();
 
             // Windows makes running multiple commands at once hard.
-            chdir(dirname($path));
+            chdir(ROOT);
             $command = 'php ' . escapeshellarg($composer) . ' dump-autoload';
             $this->callProcess($command);
 
@@ -284,7 +286,7 @@ class PluginTask extends BakeTask
         }
 
         if ($max === 1) {
-            $this->path=$pathOptions[0];
+            $this->path = $pathOptions[0];
             return;
         }
 

--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -273,7 +273,7 @@ class PluginTask extends BakeTask
     {
         $valid = false;
         foreach ($pathOptions as $i => $path) {
-            if (!is_dir($path) || $path == ROOT . DS . 'plugins' . DS) {
+            if (!is_dir($path)) {
                 unset($pathOptions[$i]);
             }
         }

--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -237,7 +237,7 @@ class PluginTask extends BakeTask
             $cwd = getcwd();
 
             // Windows makes running multiple commands at once hard.
-            chdir(ROOT);
+            chdir(dirname($this->_rootComposerFilePath()));
             $command = 'php ' . escapeshellarg($composer) . ' dump-autoload';
             $this->callProcess($command);
 

--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -282,7 +282,7 @@ class PluginTask extends BakeTask
 
         if ($max == 0) {
             $this->err('No valid path found!');
-            exit;
+            throw new \RuntimeException();
         }
 
         if ($max === 1) {

--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -271,13 +271,23 @@ class PluginTask extends BakeTask
     {
         $valid = false;
         foreach ($pathOptions as $i => $path) {
-            if (!is_dir($path)) {
+            if (!is_dir($path) || $path == ROOT . DS . 'plugins' . DS) {
                 unset($pathOptions[$i]);
             }
         }
         $pathOptions = array_values($pathOptions);
-
         $max = count($pathOptions);
+
+        if ($max == 0) {
+            $this->err('No valid path found!');
+            exit;
+        }
+
+        if ($max === 1) {
+            $this->path=$pathOptions[0];
+            return;
+        }
+
         while (!$valid) {
             foreach ($pathOptions as $i => $option) {
                 $this->out($i + 1 . '. ' . $option);

--- a/tests/TestCase/Shell/Task/PluginTaskTest.php
+++ b/tests/TestCase/Shell/Task/PluginTaskTest.php
@@ -160,7 +160,6 @@ class PluginTaskTest extends TestCase
     public function testFindPathNonExistent()
     {
         $paths = App::path('Plugin');
-        $last = count($paths);
 
         array_unshift($paths, '/fake/path');
         $paths[] = '/fake/path2';
@@ -172,13 +171,29 @@ class PluginTaskTest extends TestCase
         );
         $this->Task->path = TMP . 'tests' . DS;
 
-        // Make sure the added path is filtered out.
-        $this->Task->expects($this->exactly($last))
-            ->method('out');
+        $this->Task->method('findPath')
+            ->will($this->returnValue($paths[0]));
 
-        $this->Task->expects($this->once())
-            ->method('in')
-            ->will($this->returnValue($last));
+        $this->Task->findPath($paths);
+    }
+
+    /**
+     * Test that findPath throws RunTimeException when no
+     * path exists for plugins
+     *
+     * @expectedException \RunTimeException
+     * @return void
+     */
+    public function testFindPathEmpty()
+    {
+        $paths = ['/fake/path', '/fake/path2'];
+
+        $this->Task = $this->getMock(
+            'Bake\Shell\Task\PluginTask',
+            ['in', 'out', 'err', '_stop'],
+            [$this->io]
+        );
+        $this->Task->path = TMP . 'tests' . DS;
 
         $this->Task->findPath($paths);
     }

--- a/tests/TestCase/Shell/Task/PluginTaskTest.php
+++ b/tests/TestCase/Shell/Task/PluginTaskTest.php
@@ -157,7 +157,7 @@ class PluginTaskTest extends TestCase
      *
      * @return void
      */
-    public function testFindPathNonExistant()
+    public function testFindPathNonExistent()
     {
         $paths = App::path('Plugin');
         $last = count($paths);

--- a/tests/TestCase/Shell/Task/PluginTaskTest.php
+++ b/tests/TestCase/Shell/Task/PluginTaskTest.php
@@ -169,7 +169,7 @@ class PluginTaskTest extends TestCase
 
         rmdir($this->Task->path);
 
-        $this->Task->path=$savePath;
+        $this->Task->path = $savePath;
     }
 
     /**

--- a/tests/TestCase/Shell/Task/PluginTaskTest.php
+++ b/tests/TestCase/Shell/Task/PluginTaskTest.php
@@ -138,6 +138,10 @@ class PluginTaskTest extends TestCase
         $file = TMP . 'tests' . DS . 'main-composer.json';
         file_put_contents($file, '{}');
 
+        $savePath = $this->Task->path;
+
+        $this->Task->path = ROOT . DS . 'tests' . DS . 'BakedPlugins/';
+
         $this->Task->expects($this->any())
             ->method('_rootComposerFilePath')
             ->will($this->returnValue($file));
@@ -150,6 +154,22 @@ class PluginTaskTest extends TestCase
 
         $result = file_get_contents($file);
         $this->assertSameAsFile(__FUNCTION__ . '.json', $result);
+
+        //Clean Up Testfolder
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->Task->path, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $fileinfo) {
+            $todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
+            $todo($fileinfo->getRealPath());
+        }
+
+        rmdir($this->Task->path);
+
+        $this->Task->path=$savePath;
     }
 
     /**

--- a/tests/comparisons/Plugin/testMainUpdateComposer.json
+++ b/tests/comparisons/Plugin/testMainUpdateComposer.json
@@ -1,12 +1,12 @@
 {
     "autoload": {
         "psr-4": {
-            "ComposerExample\\": "./plugins/ComposerExample/src"
+            "ComposerExample\\": "/tmp/tests/BakedPlugins/plugins/ComposerExample/src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "ComposerExample\\Test\\": "./plugins/ComposerExample/tests"
+            "ComposerExample\\Test\\": "/tmp/tests/BakedPlugins/ComposerExample/tests"
         }
     }
 }

--- a/tests/comparisons/Plugin/testMainUpdateComposer.json
+++ b/tests/comparisons/Plugin/testMainUpdateComposer.json
@@ -1,12 +1,12 @@
 {
     "autoload": {
         "psr-4": {
-            "ComposerExample\\": "/tmp/tests/BakedPlugins/ComposerExample/src"
+            "ComposerExample\\": "./tests/BakedPlugins/ComposerExample/src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "ComposerExample\\Test\\": "/tmp/tests/BakedPlugins/ComposerExample/tests"
+            "ComposerExample\\Test\\": "./tests/BakedPlugins/ComposerExample/tests"
         }
     }
 }

--- a/tests/comparisons/Plugin/testMainUpdateComposer.json
+++ b/tests/comparisons/Plugin/testMainUpdateComposer.json
@@ -1,7 +1,7 @@
 {
     "autoload": {
         "psr-4": {
-            "ComposerExample\\": "/tmp/tests/BakedPlugins/plugins/ComposerExample/src"
+            "ComposerExample\\": "/tmp/tests/BakedPlugins/ComposerExample/src"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
PR related to the change: https://github.com/cakephp/app/pull/206

The first commit is filtering the ROOT/plugins path from the options and exits with an error if no other path is available, I am unsure if exit; was the correct choice in a Shell Task, I would like to get some feedback regarding that.

The second commit fixed the Autoloading Generation to allow other than the default path options to be used as plugin path, the chdir adaption was required since the old version could not deal with anything but the first child of ROOT.

Any comments are appreciated.