### PR TITLE
Don't assume there will always be a bootstrap file

### DIFF
--- a/src/Template/Bake/tests/bootstrap.ctp
+++ b/src/Template/Bake/tests/bootstrap.ctp
@@ -38,4 +38,10 @@ $root = $findRoot(__FILE__);
 unset($findRoot);
 
 chdir($root);
-require $root . '/config/bootstrap.php';
+
+if (file_exists($root . '/config/bootstrap.php')) {
+    require $root . '/config/bootstrap.php';
+    return;
+}
+
+require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';


### PR DESCRIPTION
If plugin does not have a bootstrap file load the core tests bootstrap.