### PR TITLE
Add appveyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,73 @@
+build: false
+shallow_clone: false
+platform: 'x86'
+clone_folder: c:\projects\bake
+branches:
+  only:
+    - master
+environment:
+  global:
+    PHP: "C:/PHP"
+  matrix:
+      - db: 2012
+        db_dsn: 'sqlserver://sa:Password12!@.\SQL2012SP1/cakephp?MultipleActiveResultSets=false'
+services:
+  - mssql2012sp1
+init:
+  - SET PATH=C:\php\;%PATH%
+install:
+  - cd c:\
+  - ps: Start-FileDownload 'http://ci.cakephp.org/php.zip'
+  - 7z x php.zip -oc:\php
+  - cd c:\php
+  - copy php.ini-production php.ini
+  - echo date.timezone="UTC" >> php.ini
+  - echo extension_dir=ext >> php.ini
+  - echo extension=php_openssl.dll >> php.ini
+  - echo extension=php_sqlsrv.dll >> php.ini
+  - echo extension=php_pdo_sqlsrv.dll >> php.ini
+  - echo extension=php_pdo_mysql.dll >> php.ini
+  - echo extension=php_intl.dll >> php.ini
+  - echo extension=php_mbstring.dll >> php.ini
+  - echo extension=php_fileinfo.dll >> php.ini
+  - cd C:\projects\bake
+  - php -r "readfile('https://getcomposer.org/installer');" | php
+  - php composer.phar install --prefer-dist --no-interaction --dev
+before_test:
+# This script solves the "Database 'model' is being recovered. Waiting until recovery is finished."
+# This solution comes from https://gist.github.com/jonathanhickford/1cb0d6665adab8b9c664
+# and is follow by http://help.appveyor.com/discussions/suggestions/264-database-mssqlsystemresource-is-being-recovered-waiting-for-sql-server-to-start
+- ps: >-
+    $tries = 5;
+
+    $pause = 10; # Seconds to wait between tries
+
+    While ($tries -gt 0) {
+      try {
+        $ServerConnectionString = "Data Source=(local)\SQL2012SP1;Initial Catalog=master;User Id=sa;PWD=Password12!";
+        $ServerConnection = new-object system.data.SqlClient.SqlConnection($ServerConnectionString);
+        $query = "exec sp_configure 'clr enabled', 1;`n"
+        $query = $query + "RECONFIGURE;`n"
+        $cmd = new-object system.data.sqlclient.sqlcommand($query, $ServerConnection);
+        $ServerConnection.Open();
+        "Running:"
+        $query
+        if ($cmd.ExecuteNonQuery() -ne -1) {
+          "SQL Error";
+        } else {
+          "Success"
+        }
+        $ServerConnection.Close();
+        $tries = 0;
+      } catch {
+        "Error:"
+        $_.Exception.Message
+        "Retry in $pause seconds.  Attempts left: $tries";
+        Start-Sleep -s $pause;
+      }
+      $tries = $tries -1;
+    }
+test_script:
+  - sqlcmd -S ".\SQL2012SP1" -U sa -P Password12! -Q "create database cakephp;"
+  - cd C:\projects\bake
+  - vendor\bin\phpunit.bat

--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -216,6 +216,7 @@ class PluginTask extends BakeTask
         }
 
         $autoloadPath = str_replace(ROOT, '.', $this->path);
+        $autoloadPath = str_replace('\\', '/', $autoloadPath);
 
         $config = json_decode(file_get_contents($file), true);
         $config['autoload']['psr-4'][$plugin . '\\'] = $autoloadPath . $plugin . "/src";

--- a/tests/TestCase/Shell/Task/PluginTaskTest.php
+++ b/tests/TestCase/Shell/Task/PluginTaskTest.php
@@ -44,7 +44,7 @@ class PluginTaskTest extends TestCase
 
         $this->Task = $this->getMock(
             'Bake\Shell\Task\PluginTask',
-            ['in', 'err', '_stop', 'clear', 'callProcess', '_rootComposerFilePath'],
+            ['in', 'err', '_stop', 'clear', 'callProcess', '_rootComposerFilePath', 'findComposer'],
             [$this->io]
         );
 
@@ -130,8 +130,7 @@ class PluginTaskTest extends TestCase
             ->method('askChoice')
             ->will($this->returnValue('y'));
 
-        $this->Task->Project = $this->getMock('ComposerProject', ['findComposer']);
-        $this->Task->Project->expects($this->at(0))
+        $this->Task->expects($this->any())
             ->method('findComposer')
             ->will($this->returnValue('composer.phar'));
 


### PR DESCRIPTION
- correct the composer autoloading lines generation on Windows
using 
```
 bin\cake bake plugin BestPlugin
```

would generate the following in composer.json : 
```json
"BestPlugin\\": ".\\plugins\\BestPlugin/src"
```
instead of 
```json
"BestPlugin\\": "./plugins/BestPlugin/src"
```

- re-add missing functions to bake Plugins after #43 

