### PR TITLE
Allow overriding plugin bake tasks within an app

### DIFF
--- a/src/Shell/BakeShell.php
+++ b/src/Shell/BakeShell.php
@@ -127,7 +127,6 @@ class BakeShell extends Shell
     {
         $tasks = [];
 
-        $tasks = $this->_findTasks($tasks, APP, Configure::read('App.namespace'));
         foreach (Plugin::loaded() as $plugin) {
             $tasks = $this->_findTasks(
                 $tasks,
@@ -136,6 +135,7 @@ class BakeShell extends Shell
                 $plugin
             );
         }
+        $tasks = $this->_findTasks($tasks, APP, Configure::read('App.namespace'));
 
         $this->tasks = array_values($tasks);
         parent::loadTasks();


### PR DESCRIPTION
**This PR is strictly for discussion. I'm not convinced this is the best way to perform what I want to do.**

This gives developers the ability to sub-class bake shells to give them new abilities.

As an example, a developer may wish to subclass the FixtureTask to disable generating certain tables, or use a custom method to generate data for the fixtures. Without the above change, they would be forced to use a different name for the task.
