### PR TITLE
Only fail subcommands when they exit non-zero.

### DIFF
--- a/src/Shell/Task/BakeTask.php
+++ b/src/Shell/Task/BakeTask.php
@@ -141,9 +141,9 @@ class BakeTask extends Shell
 
         $error = stream_get_contents($pipes[2]);
         fclose($pipes[2]);
-        proc_close($process);
+        $exit = proc_close($process);
 
-        if ($error) {
+        if ($exit != 0) {
             throw new \RuntimeException($error);
         }
 


### PR DESCRIPTION
Instead of looking in stderr, the exit code of a process should be used to determine whether or not it worked.

Refs #51