### PR TITLE
Filter HasMany associations if already exist as BelongsToMany

### DIFF
--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -433,7 +433,7 @@ class TemplateTask extends BakeTask
      * Get filtered associations
      * To be mocked...
      *
-     * @param Table $model
+     * @param Table $model Table
      */
     protected function _filteredAssociations(Table $model)
     {

--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -14,13 +14,13 @@
  */
 namespace Bake\Shell\Task;
 
+use Bake\Utility\Model\AssociationFilter;
 use Cake\Console\Shell;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
-use Bake\Utility\Model\AssociationFilter;
 
 /**
  * Task class for creating and updating view files.
@@ -87,6 +87,13 @@ class TemplateTask extends BakeTask
      * @var array
      */
     public $noTemplateActions = ['delete'];
+
+    /**
+     * AssociationFilter utility
+     *
+     * @var AssociationFilter
+     */
+    protected $_associationFilter = null;
 
     /**
      * Override initialize
@@ -425,10 +432,14 @@ class TemplateTask extends BakeTask
     /**
      * Get filtered associations
      * To be mocked...
+     *
      * @param Table $model
      */
     protected function _filteredAssociations(Table $model)
     {
-        return AssociationFilter::filterAssociations($model);
+        if (is_null($this->_associationFilter)) {
+            $this->_associationFilter = new AssociationFilter();
+        }
+        return $this->_associationFilter->filterAssociations($model);
     }
 }

--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -433,7 +433,8 @@ class TemplateTask extends BakeTask
      * Get filtered associations
      * To be mocked...
      *
-     * @param Table $model Table
+     * @param \Cake\ORM\Table $model Table
+     * @return array associations
      */
     protected function _filteredAssociations(Table $model)
     {

--- a/src/Utility/Model/AssociationFilter.php
+++ b/src/Utility/Model/AssociationFilter.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Utility\Model;
+
+use \Cake\ORM\Table;
+
+/**
+ * Utility class to filter Model Table associations
+ *
+ */
+class AssociationFilter {
+
+/**
+ * Detect existing belongsToMany associations and cleanup the hasMany aliases based on existing
+ * belongsToMany associations provided
+ *
+ * @param \Cake\ORM\Table $table
+ * @param array $aliases
+ * @return array $aliases
+ */
+    public static function filterHasManyAssociationsAliases(Table $table, array $aliases) {
+        $extractor = function ($val) {
+            return $val->junction()->alias();
+        };
+        $belongsToManyJunctionsAliases = array_map($extractor, $table->associations()->type('BelongsToMany'));
+        return array_values(array_diff($aliases, $belongsToManyJunctionsAliases));
+    }
+
+
+}

--- a/src/Utility/Model/AssociationFilter.php
+++ b/src/Utility/Model/AssociationFilter.php
@@ -14,29 +14,90 @@
  */
 namespace Bake\Utility\Model;
 
-use \Cake\ORM\Table;
+use Cake\ORM\Table;
+use Cake\Utility\Inflector;
 
 /**
  * Utility class to filter Model Table associations
  *
  */
-class AssociationFilter {
+class AssociationFilter
+{
 
-/**
- * Detect existing belongsToMany associations and cleanup the hasMany aliases based on existing
- * belongsToMany associations provided
- *
- * @param \Cake\ORM\Table $table
- * @param array $aliases
- * @return array $aliases
- */
-    public static function filterHasManyAssociationsAliases(Table $table, array $aliases) {
-        $extractor = function ($val) {
-            return $val->junction()->alias();
-        };
-        $belongsToManyJunctionsAliases = array_map($extractor, $table->associations()->type('BelongsToMany'));
+    /**
+     * Detect existing belongsToMany associations and cleanup the hasMany aliases based on existing
+     * belongsToMany associations provided
+     *
+     * @param \Cake\ORM\Table $table
+     * @param array $aliases
+     * @return array $aliases
+     */
+    public static function filterHasManyAssociationsAliases(Table $table, array $aliases)
+    {
+        $belongsToManyJunctionsAliases = self::belongsToManyJunctionAliases($table);
         return array_values(array_diff($aliases, $belongsToManyJunctionsAliases));
     }
 
+    /**
+     * Get the array of junction aliases for all the BelongsToMany associations
+     * @param Table $table
+     * @return array junction aliases of all the BelongsToMany associations
+     */
+    public static function belongsToManyJunctionAliases(Table $table)
+    {
+        $extractor = function ($val) {
+            return $val->junction()->alias();
+        };
+        return array_map($extractor, $table->associations()->type('BelongsToMany'));
+    }
 
+    /**
+     * Returns filtered associations for controllers models. HasMany association are filtered if
+     * already existing in BelongsToMany
+     *
+     * @param Table $model The model to build associations for.
+     * @return array associations
+     */
+    public static function filterAssociations(Table $model)
+    {
+        $belongsToManyJunctionsAliases = self::belongsToManyJunctionAliases($model);
+        $keys = ['BelongsTo', 'HasOne', 'HasMany', 'BelongsToMany'];
+        $associations = [];
+
+        foreach ($keys as $type) {
+            foreach ($model->associations()->type($type) as $assoc) {
+                $target = $assoc->target();
+                $assocName = $assoc->name();
+                $alias = $target->alias();
+                //filter existing HasMany
+                if ($type === 'HasMany' && in_array($alias, $belongsToManyJunctionsAliases)) {
+                    continue;
+                }
+                $targetClass = get_class($target);
+                list(, $className) = namespaceSplit($targetClass);
+
+                $modelClass = get_class($model);
+                if ($modelClass !== 'Cake\ORM\Table' && $targetClass === $modelClass) {
+                    continue;
+                }
+
+                $className = preg_replace('/(.*)Table$/', '\1', $className);
+                if ($className === '') {
+                    $className = $alias;
+                }
+
+                $associations[$type][$assocName] = [
+                    'property' => $assoc->property(),
+                    'variable' => Inflector::variable($assocName),
+                    'primaryKey' => (array)$target->primaryKey(),
+                    'displayField' => $target->displayField(),
+                    'foreignKey' => $assoc->foreignKey(),
+                    'alias' => $alias,
+                    'controller' => $className,
+                    'fields' => $target->schema()->columns(),
+                ];
+            }
+        }
+        return $associations;
+    }
 }

--- a/src/Utility/Model/AssociationFilter.php
+++ b/src/Utility/Model/AssociationFilter.php
@@ -28,22 +28,23 @@ class AssociationFilter
      * Detect existing belongsToMany associations and cleanup the hasMany aliases based on existing
      * belongsToMany associations provided
      *
-     * @param \Cake\ORM\Table $table
-     * @param array $aliases
+     * @param \Cake\ORM\Table $table Table
+     * @param array $aliases array of aliases
      * @return array $aliases
      */
-    public static function filterHasManyAssociationsAliases(Table $table, array $aliases)
+    public function filterHasManyAssociationsAliases(Table $table, array $aliases)
     {
-        $belongsToManyJunctionsAliases = self::belongsToManyJunctionAliases($table);
+        $belongsToManyJunctionsAliases = $this->belongsToManyJunctionAliases($table);
         return array_values(array_diff($aliases, $belongsToManyJunctionsAliases));
     }
 
     /**
      * Get the array of junction aliases for all the BelongsToMany associations
-     * @param Table $table
+     *
+     * @param Table $table Table
      * @return array junction aliases of all the BelongsToMany associations
      */
-    public static function belongsToManyJunctionAliases(Table $table)
+    public function belongsToManyJunctionAliases(Table $table)
     {
         $extractor = function ($val) {
             return $val->junction()->alias();
@@ -58,9 +59,9 @@ class AssociationFilter
      * @param Table $model The model to build associations for.
      * @return array associations
      */
-    public static function filterAssociations(Table $model)
+    public function filterAssociations(Table $model)
     {
-        $belongsToManyJunctionsAliases = self::belongsToManyJunctionAliases($model);
+        $belongsToManyJunctionsAliases = $this->belongsToManyJunctionAliases($model);
         $keys = ['BelongsTo', 'HasOne', 'HasMany', 'BelongsToMany'];
         $associations = [];
 

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -5,6 +5,7 @@ use Cake\Core\Configure;
 use Cake\Core\ConventionsTrait;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
+use Bake\Utility\Model\AssociationFilter;
 
 /**
  * Bake helper
@@ -95,7 +96,7 @@ class BakeHelper extends Helper
         };
         $aliases = array_map($extractor, $table->associations()->type($assoc));
         if ($assoc === 'HasMany') {
-            return $this->_filtedHasManyAssociations($table, $aliases);
+            return $this->_filterHasManyAssociationsAliases($table, $aliases);
         }
 
         return $aliases;
@@ -144,20 +145,14 @@ class BakeHelper extends Helper
         ];
     }
 
-/**
- * Detect existing belongsToMany associations and cleanup the hasMany aliases based on existing
- * belongsToMany associations provided
- *
- * @param \Cake\ORM\Table $table
- * @param array $aliases
- * @return array $aliases
- */
-    protected function _filtedHasManyAssociations($table, $aliases) {
-        $extractor = function ($val) {
-            return $val->junction()->alias();
-        };
-        $belongsToManyJunctionsAliases = array_map($extractor, $table->associations()->type('BelongsToMany'));
-        return array_values(array_diff($aliases, $belongsToManyJunctionsAliases));
+    /**
+     * To be mocked elsewhere...
+     * @param $table
+     * @param $aliases
+     */
+    protected function _filterHasManyAssociationsAliases($table, $aliases)
+    {
+        return AssociationFilter::filterHasManyAssociationsAliases($table, $aliases);
     }
 
 }

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -155,8 +155,8 @@ class BakeHelper extends Helper
     /**
      * To be mocked elsewhere...
      *
-     * @param $table Table
-     * @param $aliases array of aliases
+     * @param \Cake\ORM\Table $table Table
+     * @param array $aliases array of aliases
      */
     protected function _filterHasManyAssociationsAliases($table, $aliases)
     {

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -154,5 +154,4 @@ class BakeHelper extends Helper
     {
         return AssociationFilter::filterHasManyAssociationsAliases($table, $aliases);
     }
-
 }

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -155,8 +155,8 @@ class BakeHelper extends Helper
     /**
      * To be mocked elsewhere...
      *
-     * @param $table
-     * @param $aliases
+     * @param $table Table
+     * @param $aliases array of aliases
      */
     protected function _filterHasManyAssociationsAliases($table, $aliases)
     {

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -1,11 +1,11 @@
 <?php
 namespace Bake\View\Helper;
 
+use Bake\Utility\Model\AssociationFilter;
 use Cake\Core\Configure;
 use Cake\Core\ConventionsTrait;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
-use Bake\Utility\Model\AssociationFilter;
 
 /**
  * Bake helper
@@ -20,6 +20,13 @@ class BakeHelper extends Helper
      * @var array
      */
     protected $_defaultConfig = [];
+
+    /**
+     * AssociationFilter utility
+     *
+     * @var AssociationFilter
+     */
+    protected $_associationFilter = null;
 
     /**
      * Used for generating formatted properties such as component and helper arrays
@@ -147,11 +154,15 @@ class BakeHelper extends Helper
 
     /**
      * To be mocked elsewhere...
+     *
      * @param $table
      * @param $aliases
      */
     protected function _filterHasManyAssociationsAliases($table, $aliases)
     {
-        return AssociationFilter::filterHasManyAssociationsAliases($table, $aliases);
+        if (is_null($this->_associationFilter)) {
+            $this->_associationFilter = new AssociationFilter();
+        }
+        return $this->_associationFilter->filterHasManyAssociationsAliases($table, $aliases);
     }
 }

--- a/tests/TestCase/Utility/Model/AssociationFilterTest.php
+++ b/tests/TestCase/Utility/Model/AssociationFilterTest.php
@@ -14,9 +14,10 @@
  */
 namespace Bake\Test\TestCase\Utility\Model;
 
+use Bake\Utility\Model\AssociationFilter;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use Bake\Utility\Model\AssociationFilter;
+use Cake\Utility\Hash;
 
 /**
  * BakeViewTest class
@@ -73,9 +74,10 @@ class AssociationFilterTest extends TestCase
         $result = AssociationFilter::filterHasManyAssociationsAliases($table, ['ArticlesTags']);
         $expected = [];
         $this->assertSame(
-                $expected,
-                $result,
-                'hasMany should filter results based on belongsToMany existing aliases');
+            $expected,
+            $result,
+            'hasMany should filter results based on belongsToMany existing aliases'
+        );
     }
 
     /**
@@ -91,13 +93,39 @@ class AssociationFilterTest extends TestCase
         $table->hasMany('ExtraArticles', [
             'className' => 'Articles'
         ]);
-        $result = AssociationFilter::filterHasManyAssociationsAliases($table, ['ExtraArticles', 'ArticlesTags', 'AnotherHasMany']);
+        $result = AssociationFilter::filterHasManyAssociationsAliases($table, [
+            'ExtraArticles',
+            'ArticlesTags',
+            'AnotherHasMany'
+        ]);
         $expected = ['ExtraArticles', 'AnotherHasMany'];
         $this->assertSame(
-                $expected,
-                $result,
-                'hasMany should filter results based on belongsToMany existing aliases');
+            $expected,
+            $result,
+            'hasMany should filter results based on belongsToMany existing aliases'
+        );
         $table->associations()->remove('ExtraArticles');
     }
 
+    /**
+     * testFilterAssociations
+     *
+     * @return void
+     */
+    public function testFilterAssociations()
+    {
+        $table = TableRegistry::get('Articles', [
+            'className' => '\Bake\Test\App\Model\Table\ArticlesTable'
+        ]);
+        $resultAssociations = AssociationFilter::filterAssociations($table);
+        $result = [];
+        foreach ($resultAssociations as $assoc) {
+            $aliases = array_keys($assoc);
+            foreach ($aliases as $alias) {
+                $result[] = $alias;
+            }
+        }
+        $expected = ['authors', 'tags'];
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/TestCase/Utility/Model/AssociationFilterTest.php
+++ b/tests/TestCase/Utility/Model/AssociationFilterTest.php
@@ -49,6 +49,7 @@ class AssociationFilterTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+        $this->associationFilter = new AssociationFilter();
     }
 
     /**
@@ -58,6 +59,7 @@ class AssociationFilterTest extends TestCase
      */
     public function tearDown()
     {
+        unset($this->associationFilter);
         parent::tearDown();
     }
 
@@ -71,7 +73,7 @@ class AssociationFilterTest extends TestCase
         $table = TableRegistry::get('Articles', [
             'className' => '\Bake\Test\App\Model\Table\ArticlesTable'
         ]);
-        $result = AssociationFilter::filterHasManyAssociationsAliases($table, ['ArticlesTags']);
+        $result = $this->associationFilter->filterHasManyAssociationsAliases($table, ['ArticlesTags']);
         $expected = [];
         $this->assertSame(
             $expected,
@@ -93,7 +95,7 @@ class AssociationFilterTest extends TestCase
         $table->hasMany('ExtraArticles', [
             'className' => 'Articles'
         ]);
-        $result = AssociationFilter::filterHasManyAssociationsAliases($table, [
+        $result = $this->associationFilter->filterHasManyAssociationsAliases($table, [
             'ExtraArticles',
             'ArticlesTags',
             'AnotherHasMany'
@@ -117,7 +119,7 @@ class AssociationFilterTest extends TestCase
         $table = TableRegistry::get('Articles', [
             'className' => '\Bake\Test\App\Model\Table\ArticlesTable'
         ]);
-        $resultAssociations = AssociationFilter::filterAssociations($table);
+        $resultAssociations = $this->associationFilter->filterAssociations($table);
         $result = [];
         foreach ($resultAssociations as $assoc) {
             $aliases = array_keys($assoc);

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -96,15 +96,14 @@ class BakeHelperTest extends TestCase
      *
      * @return void
      */
-    public function testAliasExtractorBelongsTo() {
+    public function testAliasExtractorBelongsTo()
+    {
         $table = TableRegistry::get('Articles', [
                     'className' => '\Bake\Test\App\Model\Table\ArticlesTable'
         ]);
         $result = $this->BakeHelper->aliasExtractor($table, 'BelongsTo');
         $expected = ['authors'];
-        $this->assertSame(
-                $expected, $result
-        );
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -112,7 +111,8 @@ class BakeHelperTest extends TestCase
      *
      * @return void
      */
-    public function testAliasExtractorBelongsToMany() {
+    public function testAliasExtractorBelongsToMany()
+    {
         $table = TableRegistry::get('Articles', [
                     'className' => '\Bake\Test\App\Model\Table\ArticlesTable'
         ]);
@@ -120,5 +120,4 @@ class BakeHelperTest extends TestCase
         $expected = ['tags'];
         $this->assertSame($expected, $result);
     }
-
 }

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/3.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/3.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         0.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\TestCase\View\Helper;
+
+use Bake\View\BakeView;
+use Bake\View\Helper\BakeHelper;
+use Cake\Network\Request;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\Stub\Response;
+use Cake\TestSuite\TestCase;
+
+/**
+ * BakeViewTest class
+ *
+ */
+class BakeHelperTest extends TestCase
+{
+
+    /**
+     * fixtures
+     *
+     * Don't sort this list alphabetically - otherwise there are table constraints
+     * which fail when using postgres
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.bake.bake_articles',
+        'plugin.bake.bake_comments',
+        'plugin.bake.bake_articles_bake_tags',
+        'plugin.bake.bake_tags',
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $request = new Request();
+        $response = new Response();
+        $this->View = new BakeView($request, $response);
+        $this->BakeHelper = new BakeHelper($this->View);
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->BakeHelper);
+    }
+
+    /**
+     * test extracting aliases and filtering the hasMany aliases correctly based on belongsToMany
+     *
+     * @return void
+     */
+    public function testAliasExtractorFilteredHasMany()
+    {
+        $table = TableRegistry::get('Articles', [
+            'className' => '\Bake\Test\App\Model\Table\ArticlesTable'
+        ]);
+        $result = $this->BakeHelper->aliasExtractor($table, 'HasMany');
+        $expected = [];
+        $this->assertSame(
+                $expected,
+                $result,
+                'hasMany should filter results based on belongsToMany existing aliases');
+    }
+
+    /**
+     * test extracting extra HasMany
+     *
+     * @return void
+     */
+    public function testAliasExtractorFilteredHasManyExtra()
+    {
+        $table = TableRegistry::get('Articles', [
+            'className' => '\Bake\Test\App\Model\Table\ArticlesTable'
+        ]);
+        $table->hasMany('ExtraArticles', [
+            'className' => 'Articles'
+        ]);
+        $result = $this->BakeHelper->aliasExtractor($table, 'HasMany');
+        $expected = ['ExtraArticles'];
+        $this->assertSame(
+                $expected,
+                $result,
+                'hasMany should filter results based on belongsToMany existing aliases');
+    }
+
+    /**
+     * test extracting belongsTo
+     *
+     * @return void
+     */
+    public function testAliasExtractorBelongsTo() {
+        $table = TableRegistry::get('Articles', [
+                    'className' => '\Bake\Test\App\Model\Table\ArticlesTable'
+        ]);
+        $result = $this->BakeHelper->aliasExtractor($table, 'BelongsTo');
+        $expected = ['authors'];
+        $this->assertSame(
+                $expected, $result
+        );
+    }
+
+    /**
+     * test extracting belongsToMany
+     *
+     * @return void
+     */
+    public function testAliasExtractorBelongsToMany() {
+        $table = TableRegistry::get('Articles', [
+                    'className' => '\Bake\Test\App\Model\Table\ArticlesTable'
+        ]);
+        $result = $this->BakeHelper->aliasExtractor($table, 'BelongsToMany');
+        $expected = ['tags'];
+        $this->assertSame($expected, $result);
+    }
+
+}

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -88,7 +88,6 @@ class BakeHelperTest extends TestCase
                 ->with($table, ['ArticlesTags']);
         $result = $this->BakeHelper->aliasExtractor($table, 'HasMany');
         $this->assertEmpty($result);
-
     }
 
     /**


### PR DESCRIPTION
Get rid of duplicated HasMany associations already existing as BelongsToMany. Example: ArticlesTags would be removed from the list of associations used for code generation if a Articles BelongsToMany Tags association exists.