### PR TITLE
Add ability to bake all tests for a given type

### DIFF
--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -94,6 +94,10 @@ class TestTask extends BakeTask
             return $this->outputTypeChoices();
         }
 
+        if ($this->param('all')) {
+            return $this->_bakeAll($type);
+        }
+
         if (empty($name)) {
             return $this->outputClassChoices($type);
         }
@@ -144,6 +148,26 @@ class TestTask extends BakeTask
         $this->out('Re-run your command as `cake bake ' . $type . ' <classname>`');
 
         return $options;
+    }
+
+    /**
+     * @param string $type The typename to get bake all classes for.
+     * @return void
+     */
+    protected function _bakeAll($type)
+    {
+        $mapped_type = $this->mapType($type);
+        $classes = $this->_getClassOptions($mapped_type);
+
+        foreach ($classes as $class) {
+            if ($this->bake($type, $class)) {
+                $this->out('<success>Done - ' . $class . '</success>');
+            } else {
+                $this->out('<error>Failed - ' . $class . '</error>');
+            }
+        }
+
+        $this->out('<info>Bake finished</info>');
     }
 
     /**
@@ -572,6 +596,9 @@ class TestTask extends BakeTask
             'help' => 'An existing class to bake tests for.'
         ])->addOption('fixtures', [
             'help' => 'A comma separated list of fixture names you want to include.'
+        ])->addOption('all', [
+            'boolean' => true,
+            'help' => 'Bake all classes of the given type'
         ]);
 
         return $parser;

--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -156,8 +156,8 @@ class TestTask extends BakeTask
      */
     protected function _bakeAll($type)
     {
-        $mapped_type = $this->mapType($type);
-        $classes = $this->_getClassOptions($mapped_type);
+        $mappedType = $this->mapType($type);
+        $classes = $this->_getClassOptions($mappedType);
 
         foreach ($classes as $class) {
             if ($this->bake($type, $class)) {

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -156,6 +156,28 @@ class TestTaskTest extends TestCase
     }
 
     /**
+     * test execute with type and class name defined
+     *
+     * @return void
+     */
+    public function testExecuteWithAll()
+    {
+        $this->Task->expects($this->exactly(2))->method('createFile')
+            ->withConsecutive(
+                [
+                    $this->stringContains('TestCase' . DS . 'Model' . DS . 'Table' . DS . 'ArticlesTableTest.php'),
+                    $this->stringContains('class ArticlesTableTest extends TestCase')
+                ],
+                [
+                    $this->stringContains('TestCase' . DS . 'Model' . DS . 'Table' . DS . 'CategoryThreadsTableTest.php'),
+                    $this->stringContains('class CategoryThreadsTableTest extends TestCase')
+                ]
+            );
+        $this->Task->params['all'] = true;
+        $this->Task->main('Table');
+    }
+
+    /**
      * Test generating class options for table.
      *
      * @return void


### PR DESCRIPTION
Allow running on `bin/cake bake tests <type> --all` for generating tests for all classes of the given type. Reason for using a option rather than a argument (`name == 'all'), is to prevent problems with classes called `All`.