### PR TITLE
Exclude foriegn keys from validation rules.

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -112,7 +112,7 @@ class ModelTask extends BakeTask
         $primaryKey = $this->getPrimaryKey($model);
         $displayField = $this->getDisplayField($model);
         $fields = $this->getFields($model);
-        $validation = $this->getValidation($model);
+        $validation = $this->getValidation($model, $associations);
         $rulesChecker = $this->getRules($model, $associations);
         $behaviors = $this->getBehaviors($model);
 
@@ -444,9 +444,10 @@ class ModelTask extends BakeTask
      * Generate default validation rules.
      *
      * @param \Cake\ORM\Table $model The model to introspect.
+     * @param array $associations The associations list.
      * @return array The validation rules.
      */
-    public function getValidation($model)
+    public function getValidation($model, $associations = [])
     {
         if (!empty($this->params['no-validation'])) {
             return [];
@@ -459,8 +460,16 @@ class ModelTask extends BakeTask
 
         $validate = [];
         $primaryKey = (array)$schema->primaryKey();
-
+        $foreignKeys = [];
+        if (isset($associations['belongsTo'])) {
+            foreach ($associations['belongsTo'] as $assoc) {
+                $foreignKeys[] = $assoc['foreignKey'];
+            }
+        }
         foreach ($fields as $fieldName) {
+            if (in_array($fieldName, $foreignKeys)) {
+                continue;
+            }
             $field = $schema->column($fieldName);
             $validation = $this->fieldValidation($fieldName, $field, $primaryKey);
             if (!empty($validation)) {

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -661,6 +661,29 @@ class ModelTaskTest extends TestCase
     }
 
     /**
+     * test getting validation rules and exempting foreign keys
+     *
+     * @return void
+     */
+    public function testGetValidationExcludeForeignKeys()
+    {
+        $model = TableRegistry::get('BakeArticles');
+        $associations = [
+            'belongsTo' => [
+                'BakeUsers' => ['foreignKey' => 'bake_user_id'],
+            ]
+        ];
+        $result = $this->Task->getValidation($model, $associations);
+        $expected = [
+            'title' => ['valid' => ['rule' => false, 'allowEmpty' => false]],
+            'body' => ['valid' => ['rule' => false, 'allowEmpty' => true]],
+            'published' => ['valid' => ['rule' => 'boolean', 'allowEmpty' => true]],
+            'id' => ['valid' => ['rule' => 'numeric', 'allowEmpty' => 'create']]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * test getting validation rules with the no-rules param.
      *
      * @return void


### PR DESCRIPTION
When generating validation rules, we can use the associations to exclude foreign key columns from the generated rules. These columns will already have RulesChecker rules created.

Refs #61