### PR TITLE
Bake defaultConnectionName method for tables.

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -115,6 +115,7 @@ class ModelTask extends BakeTask
         $validation = $this->getValidation($model, $associations);
         $rulesChecker = $this->getRules($model, $associations);
         $behaviors = $this->getBehaviors($model);
+        $connection = $this->connection;
 
         $data = compact(
             'associations',
@@ -124,7 +125,8 @@ class ModelTask extends BakeTask
             'fields',
             'validation',
             'rulesChecker',
-            'behaviors'
+            'behaviors',
+            'connection'
         );
         $this->bakeTable($model, $data);
         $this->bakeEntity($model, $data);
@@ -706,6 +708,7 @@ class ModelTask extends BakeTask
             'validation' => [],
             'rulesChecker' => [],
             'behaviors' => [],
+            'connection' => $this->connection,
         ];
 
         $this->BakeTemplate->set($data);

--- a/src/Template/Bake/Model/table.ctp
+++ b/src/Template/Bake/Model/table.ctp
@@ -150,4 +150,16 @@ endforeach;
         return $rules;
     }
 <% endif; %>
+<% if ($connection != 'default'): %>
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName()
+    {
+        return '<%= $connection %>';
+    }
+<% endif; %>
 }

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -896,6 +896,7 @@ class ModelTaskTest extends TestCase
             'primaryKey' => ['id'],
             'displayField' => 'title',
             'behaviors' => ['Timestamp' => ''],
+            'connection' => 'website',
         ];
         $model = TableRegistry::get('BakeArticles');
         $result = $this->Task->bakeTable($model, $config);

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -26,4 +26,14 @@ class BakeArticlesTable extends Table
         $this->primaryKey('id');
         $this->addBehavior('Timestamp');
     }
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName()
+    {
+        return 'website';
+    }
 }

--- a/tests/comparisons/Model/testBakeTableRelations.php
+++ b/tests/comparisons/Model/testBakeTableRelations.php
@@ -37,4 +37,14 @@ class BakeArticlesTable extends Table
             'targetForeignKey' => 'bake_tag_id'
         ]);
     }
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName()
+    {
+        return 'test';
+    }
 }

--- a/tests/comparisons/Model/testBakeTableValidation.php
+++ b/tests/comparisons/Model/testBakeTableValidation.php
@@ -43,4 +43,14 @@ class BakeArticlesTable extends Table
 
         return $validator;
     }
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName()
+    {
+        return 'test';
+    }
 }

--- a/tests/comparisons/Model/testBakeTableWithPlugin.php
+++ b/tests/comparisons/Model/testBakeTableWithPlugin.php
@@ -23,4 +23,14 @@ class BakeArticlesTable extends Table
     {
         $this->primaryKey('id');
     }
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName()
+    {
+        return 'test';
+    }
 }

--- a/tests/comparisons/Model/testBakeWithRules.php
+++ b/tests/comparisons/Model/testBakeWithRules.php
@@ -38,4 +38,14 @@ class UsersTable extends Table
         $rules->add($rules->existsIn(['site_id'], 'Sites'));
         return $rules;
     }
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName()
+    {
+        return 'test';
+    }
 }


### PR DESCRIPTION
Doing this fixes baking controllers, and templates that use models that connect to non-default sources.

Refs #63