### PR TITLE
Using inner joins when the belongs to association is mandatory

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -259,6 +259,10 @@ class ModelTask extends BakeTask
                     'alias' => $tmpModelName,
                     'foreignKey' => $fieldName
                 ];
+                if ($schema->column($fieldName)['null'] === false) {
+                    $assoc['joinType'] = 'INNER';
+                }
+
             }
 
             if ($this->plugin && empty($assoc['className'])) {

--- a/tests/Fixture/CategoryThreadsFixture.php
+++ b/tests/Fixture/CategoryThreadsFixture.php
@@ -29,7 +29,7 @@ class CategoryThreadsFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'integer'],
-        'parent_id' => ['type' => 'integer', 'null' => false],
+        'parent_id' => ['type' => 'integer'],
         'name' => ['type' => 'string', 'null' => false],
         'created' => 'datetime',
         'updated' => 'datetime',

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -263,7 +263,8 @@ class ModelTaskTest extends TestCase
             'belongsTo' => [
                 [
                     'alias' => 'BakeUsers',
-                    'foreignKey' => 'bake_user_id'
+                    'foreignKey' => 'bake_user_id',
+                    'joinType' => 'INNER'
                 ],
             ],
             'hasMany' => [
@@ -300,7 +301,8 @@ class ModelTaskTest extends TestCase
                 [
                     'alias' => 'BakeUsers',
                     'className' => 'TestBake.BakeUsers',
-                    'foreignKey' => 'bake_user_id'
+                    'foreignKey' => 'bake_user_id',
+                    'joinType' => 'INNER'
                 ],
             ],
             'hasMany' => [
@@ -336,11 +338,13 @@ class ModelTaskTest extends TestCase
             'belongsTo' => [
                 [
                     'alias' => 'BakeArticles',
-                    'foreignKey' => 'bake_article_id'
+                    'foreignKey' => 'bake_article_id',
+                    'joinType' => 'INNER'
                 ],
                 [
                     'alias' => 'BakeUsers',
-                    'foreignKey' => 'bake_user_id'
+                    'foreignKey' => 'bake_user_id',
+                    'joinType' => 'INNER'
                 ],
             ]
         ];
@@ -387,11 +391,13 @@ class ModelTaskTest extends TestCase
             'belongsTo' => [
                 [
                     'alias' => 'Articles',
-                    'foreignKey' => 'article_id'
+                    'foreignKey' => 'article_id',
+                    'joinType' => 'INNER'
                 ],
                 [
                     'alias' => 'Tags',
-                    'foreignKey' => 'tag_id'
+                    'foreignKey' => 'tag_id',
+                    'joinType' => 'INNER'
                 ]
             ]
         ];


### PR DESCRIPTION
If the field is not null and it is an association the join type can be inner. It gives a better performance on database.