### PR TITLE
Ignore associations that point at missing tables.

### DIFF
--- a/src/Utility/Model/AssociationFilter.php
+++ b/src/Utility/Model/AssociationFilter.php
@@ -16,6 +16,7 @@ namespace Bake\Utility\Model;
 
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
+use Exception;
 
 /**
  * Utility class to filter Model Table associations
@@ -87,16 +88,20 @@ class AssociationFilter
                     $className = $alias;
                 }
 
-                $associations[$type][$assocName] = [
-                    'property' => $assoc->property(),
-                    'variable' => Inflector::variable($assocName),
-                    'primaryKey' => (array)$target->primaryKey(),
-                    'displayField' => $target->displayField(),
-                    'foreignKey' => $assoc->foreignKey(),
-                    'alias' => $alias,
-                    'controller' => $className,
-                    'fields' => $target->schema()->columns(),
-                ];
+                try {
+                    $associations[$type][$assocName] = [
+                        'property' => $assoc->property(),
+                        'variable' => Inflector::variable($assocName),
+                        'primaryKey' => (array)$target->primaryKey(),
+                        'displayField' => $target->displayField(),
+                        'foreignKey' => $assoc->foreignKey(),
+                        'alias' => $alias,
+                        'controller' => $className,
+                        'fields' => $target->schema()->columns(),
+                    ];
+                } catch (Exception $e) {
+                    // Do nothing it could be a bogus association name.
+                }
             }
         }
         return $associations;

--- a/tests/TestCase/Utility/Model/AssociationFilterTest.php
+++ b/tests/TestCase/Utility/Model/AssociationFilterTest.php
@@ -35,6 +35,8 @@ class AssociationFilterTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'core.authors',
+        'core.tags',
         'plugin.bake.bake_articles',
         'plugin.bake.bake_comments',
         'plugin.bake.bake_articles_bake_tags',
@@ -59,6 +61,7 @@ class AssociationFilterTest extends TestCase
      */
     public function tearDown()
     {
+        TableRegistry::clear();
         unset($this->associationFilter);
         parent::tearDown();
     }
@@ -129,5 +132,21 @@ class AssociationFilterTest extends TestCase
         }
         $expected = ['authors', 'tags'];
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * testFilterAssociations
+     *
+     * @return void
+     */
+    public function testFilterAssociationsMissingTable()
+    {
+        $table = TableRegistry::get('Articles', [
+            'className' => '\Bake\Test\App\Model\Table\ArticlesTable'
+        ]);
+        $table->hasMany('Nopes');
+
+        $result = $this->associationFilter->filterAssociations($table);
+        $this->assertArrayNotHasKey('HasMany', $result);
     }
 }


### PR DESCRIPTION
Bake shouldn't error out when an association references a table that doesn't exist. Instead that association should be filtered out.

Refs cakephp/cakephp#6270