### PR TITLE
Don't include keys in generated fixtures.

### DIFF
--- a/src/Template/Bake/tests/test_case.ctp
+++ b/src/Template/Bake/tests/test_case.ctp
@@ -49,7 +49,7 @@ class <%= $className %>Test extends TestCase
      *
      * @var array
      */
-    public $fixtures = [<%= $this->Bake->stringifyList($fixtures) %>];
+    public $fixtures = [<%= $this->Bake->stringifyList(array_values($fixtures)) %>];
 <% endif; %>
 <% if (!empty($construction)): %>
 

--- a/tests/comparisons/Test/testBakeControllerTest.php
+++ b/tests/comparisons/Test/testBakeControllerTest.php
@@ -16,7 +16,7 @@ class PostsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'Posts' => 'app.posts'
+        'app.posts'
     ];
 
     /**

--- a/tests/comparisons/Test/testBakePrefixControllerTest.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTest.php
@@ -16,7 +16,7 @@ class PostsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'Posts' => 'app.posts'
+        'app.posts'
     ];
 
     /**


### PR DESCRIPTION
Fixture lists do not need keys, and we shouldn't include them.