### PR TITLE
Allow for singular table names when baking fixtures

### DIFF
--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -16,6 +16,7 @@ namespace Bake\Shell\Task;
 
 use Cake\Console\Shell;
 use Cake\Core\Configure;
+use Cake\Database\Exception;
 use Cake\Database\Schema\Table;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
@@ -175,7 +176,13 @@ class FixtureTask extends BakeTask
             );
         }
         $schemaCollection = $connection->schemaCollection();
-        $data = $schemaCollection->describe($useTable);
+        try {
+            $data = $schemaCollection->describe($useTable);
+        } catch (Exception $e) {
+            $useTable = Inflector::underscore($model);
+            $table = $useTable;
+            $data = $schemaCollection->describe($useTable);
+        }
 
         if ($modelImport === null) {
             $schema = $this->_generateSchema($data);

--- a/tests/Fixture/BakeCarFixture.php
+++ b/tests/Fixture/BakeCarFixture.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         0.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * BakeCarFixture
+ *
+ */
+class BakeCarFixture extends TestFixture
+{
+
+    /**
+     * @var string
+     */
+    public $table = 'car';
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'bake_user_id' => ['type' => 'integer', 'null' => false],
+        'title' => ['type' => 'string', 'null' => false],
+        'body' => 'text',
+        'published' => ['type' => 'boolean', 'length' => 1, 'default' => false],
+        'created' => 'datetime',
+        'updated' => 'datetime',
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [];
+}

--- a/tests/TestCase/Shell/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Shell/Task/FixtureTaskTest.php
@@ -35,6 +35,7 @@ class FixtureTaskTest extends TestCase
         'core.comments',
         'plugin.bake.datatypes',
         'plugin.bake.binary_tests',
+        'plugin.bake.bake_car',
         'core.users'
     ];
 
@@ -165,6 +166,23 @@ class FixtureTaskTest extends TestCase
             ->with($filename, $this->stringContains("public \$table = 'comments';"));
 
         $this->Task->main('articles');
+    }
+
+    /**
+     * Test a singular table
+     *
+     * @return void
+     */
+    public function testMainWithSingularTable()
+    {
+        $this->Task->connection = 'test';
+        $filename = $this->_normalizePath(ROOT . DS . 'tests' . DS . 'Fixture/CarFixture.php');
+
+        $this->Task->expects($this->at(0))
+            ->method('createFile')
+            ->with($filename, $this->stringContains("public \$table = 'car';"));
+
+        $this->Task->main('car');
     }
 
     /**


### PR DESCRIPTION
Encountered a use case where I am baking fixtures for all my tables. I have a few tables where the table name is singular. This PR adds in the ability to fallback to a singular table if the plural version does not exist.