### PR TITLE
Add warning when no template is rendered.

### DIFF
--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -368,6 +368,7 @@ class TemplateTask extends BakeTask
             $content = $this->getContent($action);
         }
         if (empty($content)) {
+            $this->err("<warning>No generated content for '{$action}.ctp', not generating template.");
             return false;
         }
         $this->out("\n" . sprintf('Baking `%s` view file...', $action), 1, Shell::QUIET);


### PR DESCRIPTION
While looking into #89, I noticed that bake would silently fail if the template template was missing. This was unexpected and confusing.