### PR TITLE
Fix datetime field generation, and entity usage.

### DIFF
--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -22,6 +22,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use Cake\Utility\Text;
+use DateTime;
 
 /**
  * Task class for creating and updating fixtures files.
@@ -386,6 +387,9 @@ class FixtureTask extends BakeTask
         foreach ($records as $record) {
             $values = [];
             foreach ($record as $field => $value) {
+                if ($value instanceof DateTime) {
+                    $value = $value->format('Y-m-d H:i:s');
+                }
                 $val = var_export($value, true);
                 if ($val === 'NULL') {
                     $val = 'null';
@@ -420,15 +424,11 @@ class FixtureTask extends BakeTask
                 'connection' => ConnectionManager::get($this->connection)
             ]);
         }
-        $records = $model->find('all', [
-            'conditions' => $conditions,
-            'limit' => $recordCount
-        ]);
+        $records = $model->find('all')
+            ->where($conditions)
+            ->limit($recordCount)
+            ->hydrate(false);
 
-        $out = [];
-        foreach ($records as $record) {
-            $out[] = $record->toArray();
-        }
-        return $out;
+        return $records;
     }
 }

--- a/tests/TestCase/Shell/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Shell/Task/FixtureTaskTest.php
@@ -62,6 +62,8 @@ class FixtureTaskTest extends TestCase
         $this->Task->BakeTemplate = new BakeTemplateTask($io);
         $this->Task->BakeTemplate->interactive = false;
         $this->Task->BakeTemplate->initialize();
+
+        $this->_compareBasePath = Plugin::path('Bake') . 'tests' . DS . 'comparisons' . DS . 'Fixture' . DS;
     }
 
     /**
@@ -100,25 +102,17 @@ class FixtureTaskTest extends TestCase
     }
 
     /**
-     * test generating a fixture with database conditions.
+     * test generating a fixture with database rows.
      *
      * @return void
      */
-    public function testImportRecordsFromDatabaseWithConditionsPoo()
+    public function testImportRecordsFromDatabase()
     {
         $this->Task->connection = 'test';
         $this->Task->params = ['schema' => true, 'records' => true];
 
-        $result = $this->Task->bake('Articles');
-
-        $this->assertContains('namespace App\Test\Fixture;', $result);
-        $this->assertContains('use Cake\TestSuite\Fixture\TestFixture;', $result);
-        $this->assertContains('class ArticlesFixture extends TestFixture', $result);
-        $this->assertContains('public $records', $result);
-        $this->assertContains('public $import', $result);
-        $this->assertContains("'title' => 'First Article'", $result, 'Missing import data %s');
-        $this->assertContains('Second Article', $result, 'Missing import data %s');
-        $this->assertContains('Third Article', $result, 'Missing import data %s');
+        $result = $this->Task->bake('Users');
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }
 
     /**

--- a/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
+++ b/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
@@ -1,0 +1,55 @@
+<?php
+namespace App\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * UsersFixture
+ *
+ */
+class UsersFixture extends TestFixture
+{
+
+    /**
+     * Import
+     *
+     * @var array
+     */
+    public $import = ['model' => 'Users', 'connection' => 'test'];
+
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'id' => 1,
+            'username' => 'mariano',
+            'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
+            'created' => '2007-03-17 01:16:23',
+            'updated' => '2007-03-17 01:18:31'
+        ],
+        [
+            'id' => 2,
+            'username' => 'nate',
+            'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
+            'created' => '2008-03-17 01:18:23',
+            'updated' => '2008-03-17 01:20:31'
+        ],
+        [
+            'id' => 3,
+            'username' => 'larry',
+            'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
+            'created' => '2010-05-10 01:20:23',
+            'updated' => '2010-05-10 01:22:31'
+        ],
+        [
+            'id' => 4,
+            'username' => 'garrett',
+            'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
+            'created' => '2012-06-10 01:22:23',
+            'updated' => '2012-06-12 01:24:31'
+        ],
+    ];
+}


### PR DESCRIPTION
Fixtures should be generated with string datetime values, not object instances. Using strings matches the format people would normally author fixtures in. Using hydrate(false) means fixture generation will not be impacted by any virtual, hidden, or accessors on the fixtures.

Refs #97
Refs #98