### PR TITLE
Fix self associations not showing up in the related sections.

### DIFF
--- a/src/Template/Bake/Template/index.ctp
+++ b/src/Template/Bake/Template/index.ctp
@@ -28,7 +28,7 @@ $fields = collection($fields)
     $done = [];
     foreach ($associations as $type => $data):
         foreach ($data as $alias => $details):
-            if ($details['controller'] != $this->name && !in_array($details['controller'], $done)):
+            if (!empty($details['navLink']) && $details['controller'] != $this->name && !in_array($details['controller'], $done)):
 %>
         <li><?= $this->Html->link(__('List <%= $this->_pluralHumanName($alias) %>'), ['controller' => '<%= $details['controller'] %>', 'action' => 'index']) ?></li>
         <li><?= $this->Html->link(__('New <%= $this->_singularHumanName($alias) %>'), ['controller' => '<%= $details['controller'] %>', 'action' => 'add']) ?></li>

--- a/src/Template/Bake/Template/view.ctp
+++ b/src/Template/Bake/Template/view.ctp
@@ -132,7 +132,7 @@ $pk = "\$$singularVar->{$primaryKey[0]}";
 $relations = $associations['HasMany'] + $associations['BelongsToMany'];
 foreach ($relations as $alias => $details):
     $otherSingularVar = Inflector::variable($alias);
-    $otherPluralHumanName = Inflector::humanize($details['controller']);
+    $otherPluralHumanName = Inflector::humanize(Inflector::underscore($details['controller']));
     %>
 <div class="related row">
     <div class="column large-12">

--- a/src/Utility/Model/AssociationFilter.php
+++ b/src/Utility/Model/AssociationFilter.php
@@ -78,9 +78,10 @@ class AssociationFilter
                 $targetClass = get_class($target);
                 list(, $className) = namespaceSplit($targetClass);
 
+                $navLink = true;
                 $modelClass = get_class($model);
                 if ($modelClass !== 'Cake\ORM\Table' && $targetClass === $modelClass) {
-                    continue;
+                    $navLink = false;
                 }
 
                 $className = preg_replace('/(.*)Table$/', '\1', $className);
@@ -98,6 +99,7 @@ class AssociationFilter
                         'alias' => $alias,
                         'controller' => $className,
                         'fields' => $target->schema()->columns(),
+                        'navLink' => $navLink,
                     ];
                 } catch (Exception $e) {
                     // Do nothing it could be a bogus association name.

--- a/tests/TestCase/Shell/Task/TemplateTaskTest.php
+++ b/tests/TestCase/Shell/Task/TemplateTaskTest.php
@@ -447,7 +447,7 @@ class TemplateTaskTest extends TestCase
      *
      * @return void
      */
-    public function testBakeSelfAssociations()
+    public function testBakeSelfAssociationsNoNavLinks()
     {
         $this->Task->controllerName = 'CategoryThreads';
         $this->Task->modelName = 'Bake\Test\App\Model\Table\CategoryThreadsTable';
@@ -456,10 +456,39 @@ class TemplateTaskTest extends TestCase
             ->method('createFile')
             ->with(
                 $this->_normalizePath(APP . 'Template/CategoryThreads/index.ctp'),
-                $this->logicalNot($this->stringContains('ParentCategoryThread'))
+                $this->logicalNot(
+                    $this->logicalAnd(
+                        $this->stringContains('New Parent Category Thread'),
+                        $this->stringContains('List Parent Category Threads')
+                    )
+                )
             );
 
         $this->Task->bake('index', true);
+    }
+
+    /**
+     * Ensure that models associated with themselves do not have action
+     * links generated.
+     *
+     * @return void
+     */
+    public function testBakeSelfAssociationsRelatedAssociations()
+    {
+        $this->Task->controllerName = 'CategoryThreads';
+        $this->Task->modelName = 'Bake\Test\App\Model\Table\CategoryThreadsTable';
+
+        $this->Task->expects($this->once())
+            ->method('createFile')
+            ->with(
+                $this->_normalizePath(APP . 'Template/CategoryThreads/view.ctp'),
+                $this->logicalAnd(
+                    $this->stringContains('Related Category Threads'),
+                    $this->stringContains('Parent Category Thread')
+                )
+            );
+
+        $this->Task->bake('view', true);
     }
 
     /**

--- a/tests/TestCase/Utility/Model/AssociationFilterTest.php
+++ b/tests/TestCase/Utility/Model/AssociationFilterTest.php
@@ -41,6 +41,7 @@ class AssociationFilterTest extends TestCase
         'plugin.bake.bake_comments',
         'plugin.bake.bake_articles_bake_tags',
         'plugin.bake.bake_tags',
+        'plugin.bake.category_threads',
     ];
 
     /**
@@ -132,6 +133,23 @@ class AssociationFilterTest extends TestCase
         }
         $expected = ['authors', 'tags'];
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * test filtering self associations
+     *
+     * @return void
+     */
+    public function testFilterAssociationsSelf()
+    {
+        $table = TableRegistry::get('CategoryThreads', [
+            'className' => '\Bake\Test\App\Model\Table\CategoryThreadsTable'
+        ]);
+        $result = $this->associationFilter->filterAssociations($table);
+        $this->assertArrayHasKey('HasMany', $result);
+        $this->assertArrayHasKey('BelongsTo', $result);
+        $this->assertFalse($result['BelongsTo']['ParentCategoryThreads']['navLink']);
+        $this->assertFalse($result['HasMany']['ChildCategoryThreads']['navLink']);
     }
 
     /**


### PR DESCRIPTION
Self associations like child categories were not showing up in the related sections. Previously these associations was filtered out entirely to clean up the navigation. This had the unfortunate side effect of eliding them from the view page as well.

This introduces a new template variable that indicates whether or not an association should be in the nav. Self-associations are marked false. This also fixes an issue where multi word self-associations would have the wrong heading.

Refs #114