### PR TITLE
Only set primary key fields as non-accessible.

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -708,7 +708,7 @@ class ModelTask extends BakeTask
             'namespace' => $namespace,
             'plugin' => $this->plugin,
             'pluginPath' => $pluginPath,
-            'fields' => [],
+            'primaryKey' => [],
         ];
 
         $this->BakeTemplate->set($data);

--- a/src/Template/Bake/Model/entity.ctp
+++ b/src/Template/Bake/Model/entity.ctp
@@ -23,7 +23,7 @@ use Cake\ORM\Entity;
  */
 class <%= $name %> extends Entity
 {
-<% if (!empty($fields)): %>
+<% if (!empty($primaryKey)): %>
 
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().
@@ -31,8 +31,9 @@ class <%= $name %> extends Entity
      * @var array
      */
     protected $_accessible = [
-<% foreach ($fields as $field): %>
-        '<%= $field %>' => true,
+        '*' => true,
+<% foreach ($primaryKey as $field): %>
+        '<%= $field %>' => false,
 <% endforeach; %>
     ];
 <% endif %>
@@ -45,7 +46,7 @@ class <%= $name %> extends Entity
      */
     protected $_hidden = [<%= $this->Bake->stringifyList($hidden) %>];
 <% endif %>
-<% if (empty($fields) && empty($hidden)): %>
+<% if (empty($primaryKey) && empty($hidden)): %>
 
 <% endif %>
 }

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -981,9 +981,7 @@ class ModelTaskTest extends TestCase
      */
     public function testBakeEntity()
     {
-        $config = [
-            'fields' => []
-        ];
+        $config = [];
         $model = TableRegistry::get('BakeArticles');
         $result = $this->Task->bakeEntity($model, $config);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -997,7 +995,7 @@ class ModelTaskTest extends TestCase
     public function testBakeEntityFields()
     {
         $config = [
-            'fields' => ['title', 'body', 'published']
+            'primaryKey' => ['id']
         ];
         $model = TableRegistry::get('BakeArticles');
         $result = $this->Task->bakeEntity($model, $config);

--- a/tests/comparisons/Model/testBakeEntityFields.php
+++ b/tests/comparisons/Model/testBakeEntityFields.php
@@ -15,8 +15,7 @@ class BakeArticle extends Entity
      * @var array
      */
     protected $_accessible = [
-        'title' => true,
-        'body' => true,
-        'published' => true,
+        '*' => true,
+        'id' => false,
     ];
 }


### PR DESCRIPTION
This change avoids having to update the accessible list when new fields are added to table.

This avoids some hair pulling for new users who don't realize the entity also needs to be updated if they change table fields. I have seen newbies often struggle to figure out why their new fields are not getting saved. e.g. http://stackoverflow.com/questions/31385268/cakephp-3-new-fields-wont-save-correctly