### PR TITLE
Enables Fixture Task To Process Fields Of Type UUID

### DIFF
--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -367,6 +367,9 @@ class FixtureTask extends BakeTask
                         $insert .= " feugiat in taciti enim proin nibh, tempor dignissim, rhoncus";
                         $insert .= " duis vestibulum nunc mattis convallis.";
                         break;
+                    case 'uuid':
+                        $insert = Text::uuid();
+                        break;
                 }
                 $record[$field] = $insert;
             }

--- a/tests/Fixture/DatatypesFixture.php
+++ b/tests/Fixture/DatatypesFixture.php
@@ -33,6 +33,7 @@ class DatatypesFixture extends TestFixture
         'float_field' => ['type' => 'float', 'length' => '5,2', 'null' => false, 'default' => null],
         'huge_int' => ['type' => 'biginteger'],
         'bool' => ['type' => 'boolean', 'null' => false, 'default' => false],
+        'uuid' => ['type' => 'uuid'],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
     ];
 

--- a/tests/TestCase/Shell/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Shell/Task/FixtureTaskTest.php
@@ -372,6 +372,8 @@ class FixtureTaskTest extends TestCase
         $this->assertContains("_constraints", $result);
         $this->assertContains("'primary' => ['type' => 'primary'", $result);
         $this->assertContains("'columns' => ['id']", $result);
+        $this->assertContains("'uuid' => ['type' => 'uuid'", $result);
+        $this->assertRegExp("/(\s+)('uuid' => ')([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12})(')/", $result);
 
         $result = $this->Task->bake('Article', 'binary_tests');
         $this->assertContains("'data' => 'Lorem ipsum dolor sit amet'", $result);


### PR DESCRIPTION
Add Switch case to support uuid field types in FixtureTask
Adds Unit Test by modifying the Datatypes Fixture to include a uuid test case
Verifies both that the fields uses the uuid type and that the records array
generates a regexp verified uuid field

Closes #136