### PR TITLE
Generate one row by default.

### DIFF
--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -72,7 +72,7 @@ class FixtureTask extends BakeTask
         ])->addOption('count', [
             'help' => 'When using generated data, the number of records to include in the fixture(s).',
             'short' => 'n',
-            'default' => 10
+            'default' => 1
         ])->addOption('schema', [
             'help' => 'Create a fixture that imports schema, instead of dumping a schema snapshot into the fixture.',
             'short' => 's',


### PR DESCRIPTION
Instead of 10 rows, we should generate 1. This makes the fixtures
generated by `bake model` and `bake fixture` consistent.

Refs #146