### PR TITLE
fix `bake controller all` and `bake template all`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
 
 sudo: false
 
@@ -19,7 +20,7 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 5.4
+    - php: 7.0
       env: RUN_CS=1 RUN_TESTS=0
 
     - php: 5.4

--- a/src/Shell/Task/ControllerTask.php
+++ b/src/Shell/Task/ControllerTask.php
@@ -72,7 +72,8 @@ class ControllerTask extends BakeTask
      */
     public function all()
     {
-        foreach ($this->listAll() as $table) {
+        $tables = $this->listAll();
+        foreach ($tables as $table) {
             TableRegistry::clear();
             $this->main($table);
         }
@@ -243,7 +244,7 @@ class ControllerTask extends BakeTask
     public function listAll()
     {
         $this->Model->connection = $this->connection;
-        return $this->Model->listAll();
+        return $this->Model->listUnskipped();
     }
 
     /**

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -142,11 +142,8 @@ class ModelTask extends BakeTask
      */
     public function all()
     {
-        $this->listAll($this->connection, false);
-        foreach ($this->_tables as $table) {
-            if (in_array($table, $this->skipTables)) {
-                continue;
-            }
+        $tables = $this->listAllBakable();
+        foreach ($tables as $table) {
             TableRegistry::clear();
             $this->main($table);
         }
@@ -797,6 +794,16 @@ class ModelTask extends BakeTask
             $this->_modelNames[] = $this->_camelize($table);
         }
         return $this->_tables;
+    }
+
+    /**
+     * Outputs the a list of bakable models or controllers from database
+     *
+     * @return array
+     */
+    public function listAllBakable() {
+        $this->listAll();
+        return array_diff($this->_tables, $this->skipTables);
     }
 
     /**

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -51,7 +51,7 @@ class ModelTask extends BakeTask
      *
      * @var array
      */
-    public $skipTables = ['i18n'];
+    public $skipTables = ['i18n', 'phinxlog'];
 
     /**
      * Holds tables found on connection.
@@ -292,7 +292,7 @@ class ModelTask extends BakeTask
     public function findTableReferencedBy($schema, $keyField)
     {
         if (!$schema->column($keyField)) {
-             return null;
+            return null;
         }
         foreach ($schema->constraints() as $constraint) {
             $constraintInfo = $schema->constraint($constraint);

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -143,7 +143,6 @@ class ModelTask extends BakeTask
     public function all()
     {
         $tables = $this->listUnskipped();
-        $tables = $this->listUnskipped();
         foreach ($tables as $table) {
             TableRegistry::clear();
             $this->main($table);

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -142,7 +142,8 @@ class ModelTask extends BakeTask
      */
     public function all()
     {
-        $tables = $this->listAllBakable();
+        $tables = $this->listUnskipped();
+        $tables = $this->listUnskipped();
         foreach ($tables as $table) {
             TableRegistry::clear();
             $this->main($table);
@@ -797,11 +798,12 @@ class ModelTask extends BakeTask
     }
 
     /**
-     * Outputs the a list of bakable models or controllers from database
+     * Outputs the a list of unskipped models or controllers from database
      *
      * @return array
      */
-    public function listAllBakable() {
+    public function listUnskipped()
+    {
         $this->listAll();
         return array_diff($this->_tables, $this->skipTables);
     }

--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -246,7 +246,7 @@ class TemplateTask extends BakeTask
     public function all()
     {
         $this->Model->connection = $this->connection;
-        $tables = $this->Model->listAll();
+        $tables = $this->Model->listUnskipped();
 
         foreach ($tables as $table) {
             $this->main($table);

--- a/tests/TestCase/Shell/Task/ControllerTaskTest.php
+++ b/tests/TestCase/Shell/Task/ControllerTaskTest.php
@@ -102,6 +102,21 @@ class ControllerTaskTest extends TestCase
     }
 
     /**
+     * test ListAll
+     *
+     * @return void
+     */
+    public function testListAllWithSkippedTable()
+    {
+        $this->Task->Model->skipTables = ['bake_articles', 'bake_comments'];
+        $result = $this->Task->listAll();
+        $this->assertNotContains('bake_articles', $result);
+        $this->assertNotContains('bake_comments', $result);
+        $this->assertContains('bake_articles_bake_tags', $result);
+        $this->assertContains('bake_tags', $result);
+    }
+
+    /**
      * test component generation
      *
      * @return void

--- a/tests/TestCase/Shell/Task/TemplateTaskTest.php
+++ b/tests/TestCase/Shell/Task/TemplateTaskTest.php
@@ -588,7 +588,7 @@ class TemplateTaskTest extends TestCase
         $this->_setupTask(['in', 'err', 'createFile', 'main', '_stop']);
 
         $this->Task->Model->expects($this->once())
-            ->method('listAll')
+            ->method('listUnskipped')
             ->will($this->returnValue(['comments', 'articles']));
 
         $this->Task->expects($this->exactly(2))


### PR DESCRIPTION
Actually the tables declared to be skipped are skipped only when bakin all models but still used when using the following command : 
```

bin/cake bake controller all
bin/cake bake template all
```

I also added the `phinxlog` table to the skipped table and also add PHP7.0 to the travis build.