### PR TITLE
Fixtures generation is now using filtered table

### DIFF
--- a/src/Shell/BakeShell.php
+++ b/src/Shell/BakeShell.php
@@ -225,7 +225,7 @@ class BakeShell extends Shell
         if (empty($name) && !$this->param('everything')) {
             $this->Model->connection = $this->connection;
             $this->out('Possible model names based on your database:');
-            foreach ($this->Model->listAll() as $table) {
+            foreach ($this->Model->listUnskipped() as $table) {
                 $this->out('- ' . $table);
             }
             $this->out('Run <info>`cake bake all [name]`</info> to generate skeleton files.');
@@ -237,11 +237,7 @@ class BakeShell extends Shell
 
         if ($this->param('everything')) {
             $this->Model->connection = $this->connection;
-            $allTables = collection($this->Model->listAll());
-            $filteredTables = $allTables->reject(function ($tableName) {
-                $ignoredTables = ['i18n', 'cake_sessions', 'phinxlog', 'users_phinxlog'];
-                return in_array($tableName, $ignoredTables);
-            });
+            $filteredTables = collection($this->Model->listUnskipped());
         }
 
         $filteredTables->each(function ($tableName) {

--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -109,7 +109,7 @@ class FixtureTask extends BakeTask
 
         if (empty($name)) {
             $this->out('Choose a fixture to bake from the following:');
-            foreach ($this->Model->listAll() as $table) {
+            foreach ($this->Model->listUnskipped() as $table) {
                 $this->out('- ' . $this->_camelize($table));
             }
             return true;
@@ -130,7 +130,7 @@ class FixtureTask extends BakeTask
      */
     public function all()
     {
-        $tables = $this->Model->listAll($this->connection, false);
+        $tables = $this->Model->listUnskipped($this->connection, false);
 
         foreach ($tables as $table) {
             $this->main($table);

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -51,7 +51,7 @@ class ModelTask extends BakeTask
      *
      * @var array
      */
-    public $skipTables = ['i18n', 'phinxlog'];
+    public $skipTables = ['i18n', 'cake_sessions', 'phinxlog', 'users_phinxlog'];
 
     /**
      * Holds tables found on connection.
@@ -87,7 +87,7 @@ class ModelTask extends BakeTask
 
         if (empty($name)) {
             $this->out('Choose a model to bake from the following:');
-            foreach ($this->listAll() as $table) {
+            foreach ($this->listUnskipped() as $table) {
                 $this->out('- ' . $this->_camelize($table));
             }
             return true;

--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -120,7 +120,7 @@ class TemplateTask extends BakeTask
         if (empty($name)) {
             $this->out('Possible tables to bake views for based on your current database:');
             $this->Model->connection = $this->connection;
-            foreach ($this->Model->listAll() as $table) {
+            foreach ($this->Model->listUnskipped() as $table) {
                 $this->out('- ' . $this->_camelize($table));
             }
             return true;

--- a/tests/TestCase/Shell/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Shell/Task/FixtureTaskTest.php
@@ -56,7 +56,7 @@ class FixtureTaskTest extends TestCase
         );
         $this->Task->Model = $this->getMock(
             'Bake\Shell\Task\ModelTask',
-            ['in', 'out', 'err', 'createFile', 'getName', 'getTable', 'listAll'],
+            ['in', 'out', 'err', 'createFile', 'getName', 'getTable', 'listUnskipped'],
             [$io]
         );
         $this->Task->BakeTemplate = new BakeTemplateTask($io);
@@ -207,7 +207,7 @@ class FixtureTaskTest extends TestCase
     {
         $this->Task->connection = 'test';
         $this->Task->Model->expects($this->any())
-            ->method('listAll')
+            ->method('listUnskipped')
             ->will($this->returnValue(['articles', 'comments']));
 
         $filename = $this->_normalizePath(ROOT . DS . 'tests' . DS . 'Fixture/ArticlesFixture.php');
@@ -233,7 +233,7 @@ class FixtureTaskTest extends TestCase
         $this->Task->connection = 'test';
         $this->Task->params = ['count' => 10, 'records' => true];
 
-        $this->Task->Model->expects($this->any())->method('listAll')
+        $this->Task->Model->expects($this->any())->method('listUnskipped')
             ->will($this->returnValue(['Articles', 'comments']));
 
         $filename = $this->_normalizePath(ROOT . DS . 'tests' . DS . 'Fixture/ArticlesFixture.php');
@@ -261,7 +261,7 @@ class FixtureTaskTest extends TestCase
         $this->Task->connection = 'test';
         $this->Task->params = ['schema' => true];
 
-        $this->Task->Model->expects($this->any())->method('listAll')
+        $this->Task->Model->expects($this->any())->method('listUnskipped')
             ->will($this->returnValue(['Articles', 'comments']));
 
         $filename = $this->_normalizePath(ROOT . DS . 'tests' . DS . 'Fixture/ArticlesFixture.php');
@@ -286,7 +286,7 @@ class FixtureTaskTest extends TestCase
         $this->Task->connection = 'test';
 
         $this->Task->Model->expects($this->any())
-            ->method('listAll')
+            ->method('listUnskipped')
             ->will($this->returnValue(['articles', 'comments']));
 
         $filename = $this->_normalizePath(ROOT . '/tests/Fixture/ArticlesFixture.php');

--- a/tests/TestCase/Shell/Task/TemplateTaskTest.php
+++ b/tests/TestCase/Shell/Task/TemplateTaskTest.php
@@ -569,7 +569,7 @@ class TemplateTaskTest extends TestCase
         $this->_setupTask(['in', 'err', 'bake', 'createFile', '_stop']);
 
         $this->Task->Model->expects($this->once())
-            ->method('listAll')
+            ->method('listUnskipped')
             ->will($this->returnValue(['comments', 'articles']));
 
         $this->Task->expects($this->never())


### PR DESCRIPTION
follows #149 

- fix the list generated by `bin/cake bake model`
- filter the tables to generate fixtures
- use the same table list to be skipped when using `bin/cake bake all --everything`