### PR TITLE
Inflect template names.

### DIFF
--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -223,8 +223,14 @@ class TemplateTask extends BakeTask
         $methods = [];
         if (class_exists($this->controllerClass)) {
             $methods = array_diff(
-                array_map('strtolower', get_class_methods($this->controllerClass)),
-                array_map('strtolower', get_class_methods($base . '\Controller\AppController'))
+                array_map(
+                    'Cake\Utility\Inflector::underscore',
+                    get_class_methods($this->controllerClass)
+                ),
+                array_map(
+                    'Cake\Utility\Inflector::underscore',
+                    get_class_methods($base . '\Controller\AppController')
+                )
             );
         }
         if (empty($methods)) {

--- a/tests/TestCase/Shell/Task/TemplateTaskTest.php
+++ b/tests/TestCase/Shell/Task/TemplateTaskTest.php
@@ -627,26 +627,22 @@ class TemplateTaskTest extends TestCase
      */
     public function testMainWithController()
     {
-        $this->_setupTask(['in', 'err', 'createFile', 'bake', '_stop']);
+        $this->_setupTask(['in', 'err', 'createFile', 'getContent', '_stop']);
 
-        $this->Task->expects($this->exactly(4))
-            ->method('bake');
+        $this->Task->expects($this->exactly(3))
+            ->method('getContent');
 
         $this->Task->expects($this->at(0))
-            ->method('bake')
-            ->with('index', $this->anything());
+            ->method('getContent')
+            ->with('index');
 
         $this->Task->expects($this->at(1))
-            ->method('bake')
-            ->with('view', $this->anything());
-
-        $this->Task->expects($this->at(2))
-            ->method('bake')
+            ->method('getContent')
             ->with('add', $this->anything());
 
-        $this->Task->expects($this->at(3))
-            ->method('bake')
-            ->with('edit', $this->anything());
+        $this->Task->expects($this->at(2))
+            ->method('getContent')
+            ->with('add_comment', $this->anything());
 
         $this->Task->main('TemplateTaskComments');
     }

--- a/tests/test_app/App/Controller/TemplateTaskCommentsController.php
+++ b/tests/test_app/App/Controller/TemplateTaskCommentsController.php
@@ -12,7 +12,7 @@
  * @since         0.1.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Bake\Test\TestCase\Shell\Task;
+namespace Bake\Test\App\Controller;
 
 use Cake\Controller\Controller;
 
@@ -38,6 +38,15 @@ class TemplateTaskCommentsController extends Controller
      * @return void
      */
     public function add()
+    {
+    }
+
+    /**
+     * Testing public controller action with multiple words
+     *
+     * @return void
+     */
+    public function addComment()
     {
     }
 }


### PR DESCRIPTION
Instead of strtolower, we should use underscore() as that better matches the conventions used across the framework for template names.

Refs #156