### PR TITLE
BakeHelper.php optionize indent string

### DIFF
--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -64,7 +64,7 @@ class BakeHelper extends Helper
         $options += [
             'indent' => 2,
             'tab' => '    ',
-            'commaAtEnd' => false,
+            'trailingComma' => false,
         ];
 
         if (!$list) {
@@ -87,7 +87,7 @@ class BakeHelper extends Helper
             $end = "\n" . str_repeat($options['tab'], $options['indent'] - 1);
         }
         
-        if ($options['commaAtEnd']) {
+        if ($options['trailingComma']) {
             $end = "," . $end;
         }
 

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -62,7 +62,8 @@ class BakeHelper extends Helper
     public function stringifyList(array $list, array $options = [])
     {
         $options += [
-            'indent' => 2
+            'indent' => 2,
+            'tab' => '    ',
         ];
 
         if (!$list) {
@@ -80,9 +81,9 @@ class BakeHelper extends Helper
         $join = ', ';
         if ($options['indent']) {
             $join = ',';
-            $start = "\n" . str_repeat("    ", $options['indent']);
+            $start = "\n" . str_repeat($options['tab'], $options['indent']);
             $join .= $start;
-            $end = "\n" . str_repeat("    ", $options['indent'] - 1);
+            $end = "\n" . str_repeat($options['tab'], $options['indent'] - 1);
         }
 
         return $start . implode($join, $list) . $end;

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -64,6 +64,7 @@ class BakeHelper extends Helper
         $options += [
             'indent' => 2,
             'tab' => '    ',
+            'comma_at_end' => false,
         ];
 
         if (!$list) {
@@ -84,6 +85,10 @@ class BakeHelper extends Helper
             $start = "\n" . str_repeat($options['tab'], $options['indent']);
             $join .= $start;
             $end = "\n" . str_repeat($options['tab'], $options['indent'] - 1);
+        }
+        
+        if ($options['comma_at_end']) {
+            $end = ",".$end;
         }
 
         return $start . implode($join, $list) . $end;

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -64,7 +64,7 @@ class BakeHelper extends Helper
         $options += [
             'indent' => 2,
             'tab' => '    ',
-            'comma_at_end' => false,
+            'commaAtEnd' => false,
         ];
 
         if (!$list) {
@@ -87,8 +87,8 @@ class BakeHelper extends Helper
             $end = "\n" . str_repeat($options['tab'], $options['indent'] - 1);
         }
         
-        if ($options['comma_at_end']) {
-            $end = ",".$end;
+        if ($options['commaAtEnd']) {
+            $end = "," . $end;
         }
 
         return $start . implode($join, $list) . $end;

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -144,7 +144,7 @@ class BakeHelperTest extends TestCase
         $spaces = '    ';
         $expected = "\n" .
             $spaces . $spaces . "'one' => 'foo',\n" .
-            $spaces . $spaces . "'two' => 'bar'\n" .
+            $spaces . $spaces . "'two' => 'bar',\n" .
             $spaces . $spaces . "'three'\n" .
             $spaces;
         $this->assertSame($expected, $result);

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -119,4 +119,93 @@ class BakeHelperTest extends TestCase
         $expected = ['tags'];
         $this->assertSame($expected, $result);
     }
+    
+    /**
+     * test stringifyList defaults
+     *
+     * @return void
+     */
+    public function testStringifyListDefaults()
+    {
+        $list = ['one' => 'foo', 'two' => 'bar', 'three'];
+        $result = $this->BakeHelper->stringifyList($list);
+        $spaces = '    ';
+        $expected = "\n".
+            $spaces.$spaces."'one' => 'foo',\n".
+            $spaces.$spaces."'two' => 'bar'\n".
+            $spaces.$spaces."'three'\n".
+            $spaces;
+        $this->assertSame($expected, $result);
+    }
+    
+    /**
+     * test stringifyList indent is false
+     *
+     * @return void
+     */
+    public function testStringifyListIndentIsFalse()
+    {
+        $list = ['one' => 'foo', 'two' => 'bar', 'three'];
+        $result = $this->BakeHelper->stringifyList($list,['indent' => false]);
+        $expected = "'one' => 'foo', 'two' => 'bar', 'three'";
+        $this->assertSame($expected, $result);
+    }
+    
+    /**
+     * test stringifyList deeper indent
+     *
+     * @return void
+     */
+    public function testStringifyListDeeperIndent()
+    {
+        $list = ['one' => 'foo', 'two' => 'bar', 'three'];
+        $result = $this->BakeHelper->stringifyList($list, ['indent' => 3]);
+        $spaces = '    ';
+        $expected = "\n".
+            $spaces.$spaces.$spaces."'one' => 'foo',\n".
+            $spaces.$spaces.$spaces."'two' => 'bar',\n".
+            $spaces.$spaces.$spaces."'three'\n".
+            $spaces.$spaces;
+        $this->assertSame($expected, $result);
+    }
+    
+    /**
+     * test stringifyList other tab
+     *
+     * @return void
+     */
+    public function testStringifyListOtherTab()
+    {
+        $list = ['one' => 'foo', 'two' => 'bar', 'three'];
+        $result = $this->BakeHelper->stringifyList($list, ['indent' => 3, 'tab' => "\t"]);
+        $spaces = "\t";
+        $expected = "\n".
+            $spaces.$spaces.$spaces."'one' => 'foo',\n".
+            $spaces.$spaces.$spaces."'two' => 'bar',\n".
+            $spaces.$spaces.$spaces."'three'\n".
+            $spaces.$spaces;
+        $this->assertSame($expected, $result);
+    }
+    
+    /**
+     * test stringifyList with comma at end
+     *
+     * @return void
+     */
+    public function testStringifyListWithCommaAtEnd()
+    {
+        $list = ['one' => 'foo', 'two' => 'bar', 'three'];
+        $result = $this->BakeHelper->stringifyList($list, [
+            'indent' => 3,
+            'tab' => "\t",
+            'comma_at_end' => true,
+        ]);
+        $spaces = "\t";
+        $expected = "\n".
+            $spaces.$spaces.$spaces."'one' => 'foo',\n".
+            $spaces.$spaces.$spaces."'two' => 'bar',\n".
+            $spaces.$spaces.$spaces."'three',\n".
+            $spaces.$spaces;
+        $this->assertSame($expected, $result);
+    }
 }

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -121,6 +121,18 @@ class BakeHelperTest extends TestCase
     }
     
     /**
+     * test stringifyList empty
+     *
+     * @return void
+     */
+    public function testStringifyListEmpty()
+    {
+        $result = $this->BakeHelper->stringifyList([]);
+        $expected = '';
+        $this->assertSame($expected, $result);
+    }
+    
+    /**
      * test stringifyList defaults
      *
      * @return void

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -158,7 +158,7 @@ class BakeHelperTest extends TestCase
     public function testStringifyListIndentIsFalse()
     {
         $list = ['one' => 'foo', 'two' => 'bar', 'three'];
-        $result = $this->BakeHelper->stringifyList($list,['indent' => false]);
+        $result = $this->BakeHelper->stringifyList($list, ['indent' => false]);
         $expected = "'one' => 'foo', 'two' => 'bar', 'three'";
         $this->assertSame($expected, $result);
     }

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -142,10 +142,10 @@ class BakeHelperTest extends TestCase
         $list = ['one' => 'foo', 'two' => 'bar', 'three'];
         $result = $this->BakeHelper->stringifyList($list);
         $spaces = '    ';
-        $expected = "\n".
-            $spaces.$spaces."'one' => 'foo',\n".
-            $spaces.$spaces."'two' => 'bar'\n".
-            $spaces.$spaces."'three'\n".
+        $expected = "\n" .
+            $spaces . $spaces . "'one' => 'foo',\n" .
+            $spaces . $spaces . "'two' => 'bar'\n" .
+            $spaces . $spaces . "'three'\n" .
             $spaces;
         $this->assertSame($expected, $result);
     }
@@ -173,11 +173,11 @@ class BakeHelperTest extends TestCase
         $list = ['one' => 'foo', 'two' => 'bar', 'three'];
         $result = $this->BakeHelper->stringifyList($list, ['indent' => 3]);
         $spaces = '    ';
-        $expected = "\n".
-            $spaces.$spaces.$spaces."'one' => 'foo',\n".
-            $spaces.$spaces.$spaces."'two' => 'bar',\n".
-            $spaces.$spaces.$spaces."'three'\n".
-            $spaces.$spaces;
+        $expected = "\n" .
+            $spaces . $spaces . $spaces . "'one' => 'foo',\n" .
+            $spaces . $spaces . $spaces . "'two' => 'bar',\n" .
+            $spaces . $spaces . $spaces . "'three'\n" .
+            $spaces . $spaces;
         $this->assertSame($expected, $result);
     }
     
@@ -191,16 +191,16 @@ class BakeHelperTest extends TestCase
         $list = ['one' => 'foo', 'two' => 'bar', 'three'];
         $result = $this->BakeHelper->stringifyList($list, ['indent' => 3, 'tab' => "\t"]);
         $spaces = "\t";
-        $expected = "\n".
-            $spaces.$spaces.$spaces."'one' => 'foo',\n".
-            $spaces.$spaces.$spaces."'two' => 'bar',\n".
-            $spaces.$spaces.$spaces."'three'\n".
-            $spaces.$spaces;
+        $expected = "\n" .
+            $spaces . $spaces . $spaces . "'one' => 'foo',\n" .
+            $spaces . $spaces . $spaces . "'two' => 'bar',\n" .
+            $spaces . $spaces . $spaces . "'three'\n" .
+            $spaces . $spaces;
         $this->assertSame($expected, $result);
     }
     
     /**
-     * test stringifyList with comma at end
+     * test stringifyList with commaAtEnd
      *
      * @return void
      */
@@ -210,14 +210,14 @@ class BakeHelperTest extends TestCase
         $result = $this->BakeHelper->stringifyList($list, [
             'indent' => 3,
             'tab' => "\t",
-            'comma_at_end' => true,
+            'commaAtEnd' => true,
         ]);
         $spaces = "\t";
-        $expected = "\n".
-            $spaces.$spaces.$spaces."'one' => 'foo',\n".
-            $spaces.$spaces.$spaces."'two' => 'bar',\n".
-            $spaces.$spaces.$spaces."'three',\n".
-            $spaces.$spaces;
+        $expected = "\n" .
+            $spaces . $spaces . $spaces . "'one' => 'foo',\n" .
+            $spaces . $spaces . $spaces . "'two' => 'bar',\n" .
+            $spaces . $spaces . $spaces . "'three',\n" .
+            $spaces . $spaces;
         $this->assertSame($expected, $result);
     }
 }

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -200,7 +200,7 @@ class BakeHelperTest extends TestCase
     }
     
     /**
-     * test stringifyList with commaAtEnd
+     * test stringifyList with trailingComma
      *
      * @return void
      */
@@ -210,7 +210,7 @@ class BakeHelperTest extends TestCase
         $result = $this->BakeHelper->stringifyList($list, [
             'indent' => 3,
             'tab' => "\t",
-            'commaAtEnd' => true,
+            'trailingComma' => true,
         ]);
         $spaces = "\t";
         $expected = "\n" .


### PR DESCRIPTION
Make the indent-string an option to give users, who want to use their own Theme, the ability to justify the indentation, e.g. indent by tab instead of four spaces.