### PR TITLE
set $associations @property to \Cake\ORM\Table

### DIFF
--- a/src/Template/Bake/Model/table.ctp
+++ b/src/Template/Bake/Model/table.ctp
@@ -36,7 +36,7 @@ echo implode("\n", $uses);
  *
 <% foreach ($associations as $type => $assocs): %>
 <% foreach ($assocs as $assoc): %>
- * @property \Cake\ORM\Association\<%= Inflector::camelize($type) %> $<%= $assoc['alias'] %>
+ * @property \Cake\ORM\Table $<%= $assoc['alias'] %>
 <% endforeach %>
 <% endforeach; %>
 <% endif; %>


### PR DESCRIPTION
this is helpful for the code completion.
it is more likely if we can set the path to something like:    `\App\Model\Table\ModelTable`