### PR TITLE
TestTask::bake() should be no-op if an unknown class type is being baked

### DIFF
--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -207,6 +207,10 @@ class TestTask extends BakeTask
      */
     public function bake($type, $className)
     {
+        if (!isset($this->classSuffixes[strtolower($type)]) || !isset($this->classTypes[ucfirst($type)])) {
+            return false;
+        }
+
         $fullClassName = $this->getRealClassName($type, $className);
 
         if (!empty($this->params['fixtures'])) {

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -27,6 +27,14 @@ use Cake\Utility\ClassRegistry;
  */
 class ModelTaskTest extends TestCase
 {
+
+    /**
+     * Fixtures should be dropped after each tests
+     *
+     * @var bool
+     */
+    public $dropTables = true;
+
     /**
      * fixtures
      *
@@ -114,7 +122,6 @@ class ModelTaskTest extends TestCase
     {
         parent::tearDown();
         unset($this->Task);
-        $this->fixtureManager->shutDown();
     }
 
     /**

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -473,6 +473,17 @@ class TestTaskTest extends TestCase
     }
 
     /**
+     * Test baking an unknown class type.
+     *
+     * @return void
+     */
+    public function testBakeUnknownClass()
+    {
+        $result = $this->Task->bake('Foo', 'Example');
+        $this->assertFalse($result);
+    }
+
+    /**
      * test Constructor generation ensure that constructClasses is called for controllers
      *
      * @return void


### PR DESCRIPTION
When baking a custom type class, tests files should only be created if the class type has been declared. Otherwise, it will lead to notices and exceptions being raised.

More details here : https://github.com/cakephp/docs/issues/3435
Linked to https://github.com/cakephp/docs/pull/3438