### PR TITLE
doc return tag sync with code

### DIFF
--- a/src/Shell/Task/SimpleBakeTask.php
+++ b/src/Shell/Task/SimpleBakeTask.php
@@ -90,7 +90,7 @@ abstract class SimpleBakeTask extends BakeTask
      * Generate a class stub
      *
      * @param string $name The classname to generate.
-     * @return void
+     * @return string
      */
     public function bake($name)
     {
@@ -109,7 +109,7 @@ abstract class SimpleBakeTask extends BakeTask
      * Generate a test case.
      *
      * @param string $className The class to bake a test for.
-     * @return void
+     * @return string
      */
     public function bakeTest($className)
     {

--- a/src/Shell/Task/SimpleBakeTask.php
+++ b/src/Shell/Task/SimpleBakeTask.php
@@ -109,7 +109,7 @@ abstract class SimpleBakeTask extends BakeTask
      * Generate a test case.
      *
      * @param string $className The class to bake a test for.
-     * @return string
+     * @return string|bool
      */
     public function bakeTest($className)
     {


### PR DESCRIPTION
`bake()` and `bakeTest()` return type is a string (baked file contents), so doc tag return type should be string.