### PR TITLE
Remove unnecessary attribute from date inputs (Closes #35)

### DIFF
--- a/src/Template/Bake/Element/form.ctp
+++ b/src/Template/Bake/Element/form.ctp
@@ -74,7 +74,7 @@ $fields = collection($fields)
                 $fieldData = $schema->column($field);
                 if (($fieldData['type'] === 'date') && (!empty($fieldData['null']))) {
 %>
-            echo $this->Form->input('<%= $field %>', ['empty' => true, 'default' => '']);
+            echo $this->Form->input('<%= $field %>', ['empty' => true]);
 <%
                 } else {
 %>


### PR DESCRIPTION
This PR closes #35, which was already implemented in https://github.com/cakephp/bake/commit/a14a8adb7515727d49dc0f2f797c64a03df7d1a9 which was nowhere mentioned. 

The PR removes the default attribute since thats not required anymore as implemented in https://github.com/cakephp/cakephp/pull/6559.