### PR TITLE
Exclude lft/rght from baked output.

### DIFF
--- a/src/Template/Bake/Element/form.ctp
+++ b/src/Template/Bake/Element/form.ctp
@@ -18,6 +18,12 @@ $fields = collection($fields)
     ->filter(function($field) use ($schema) {
         return $schema->columnType($field) !== 'binary';
     });
+
+if (isset($modelObject) && $modelObject->behaviors()->has('Tree')) {
+    $fields = $fields->reject(function ($field) {
+        return $field === 'lft' || $field === 'rght';
+    });
+}
 %>
 <nav class="large-3 medium-4 columns" id="actions-sidebar">
     <ul class="side-nav">

--- a/src/Template/Bake/Template/index.ctp
+++ b/src/Template/Bake/Template/index.ctp
@@ -19,6 +19,12 @@ $fields = collection($fields)
         return !in_array($schema->columnType($field), ['binary', 'text']);
     })
     ->take(7);
+
+if (isset($modelObject) && $modelObject->behaviors()->has('Tree')) {
+    $fields = $fields->reject(function ($field) {
+        return $field === 'lft' || $field === 'rght';
+    });
+}
 %>
 <nav class="large-3 medium-4 columns" id="actions-sidebar">
     <ul class="side-nav">

--- a/tests/Fixture/CategoryThreadsFixture.php
+++ b/tests/Fixture/CategoryThreadsFixture.php
@@ -31,6 +31,8 @@ class CategoryThreadsFixture extends TestFixture
         'id' => ['type' => 'integer'],
         'parent_id' => ['type' => 'integer'],
         'name' => ['type' => 'string', 'null' => false],
+        'lft' => ['type' => 'integer'],
+        'rght' => ['type' => 'integer'],
         'created' => 'datetime',
         'updated' => 'datetime',
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
@@ -42,12 +44,12 @@ class CategoryThreadsFixture extends TestFixture
      * @var array
      */
     public $records = [
-        ['parent_id' => 0, 'name' => 'Category 1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
-        ['parent_id' => 1, 'name' => 'Category 1.1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
-        ['parent_id' => 2, 'name' => 'Category 1.1.1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
-        ['parent_id' => 3, 'name' => 'Category 1.1.2', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
-        ['parent_id' => 4, 'name' => 'Category 1.1.1.1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
-        ['parent_id' => 5, 'name' => 'Category 2', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
-        ['parent_id' => 6, 'name' => 'Category 2.1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31']
+        ['parent_id' => 0, 'name' => 'Category 1', 'lft' => 1, 'rght' => 14, 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
+        ['parent_id' => 1, 'name' => 'Category 1.1', 'lft' => 2, 'rght' => 9, 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
+        ['parent_id' => 2, 'name' => 'Category 1.1.1', 'lft' => 3, 'rght' => 8, 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
+        ['parent_id' => 3, 'name' => 'Category 1.1.2', 'lft' => 4, 'rght' => 7, 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
+        ['parent_id' => 4, 'name' => 'Category 1.1.1.1', 'lft' => 5, 'rght' => 6, 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
+        ['parent_id' => 5, 'name' => 'Category 2', 'lft' => 10, 'rght' => 13, 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'],
+        ['parent_id' => 6, 'name' => 'Category 2.1', 'lft' => 11, 'rght' => 12, 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31']
     ];
 }

--- a/tests/TestCase/Shell/Task/TemplateTaskTest.php
+++ b/tests/TestCase/Shell/Task/TemplateTaskTest.php
@@ -442,6 +442,43 @@ class TemplateTaskTest extends TestCase
     }
 
     /**
+     * Ensure that models in a tree don't include form fields for lft/rght
+     *
+     * @return void
+     */
+    public function testBakeTreeNoLftOrRght()
+    {
+        $this->Task->controllerName = 'CategoryThreads';
+        $this->Task->modelName = 'Bake\Test\App\Model\Table\CategoryThreadsTable';
+
+        $this->Task->expects($this->at(0))
+            ->method('createFile')
+            ->with(
+                $this->_normalizePath(APP . 'Template/CategoryThreads/add.ctp'),
+                $this->logicalNot(
+                    $this->logicalAnd(
+                        $this->stringContains('rght'),
+                        $this->stringContains('lft')
+                    )
+                )
+            );
+        $this->Task->expects($this->at(1))
+            ->method('createFile')
+            ->with(
+                $this->_normalizePath(APP . 'Template/CategoryThreads/index.ctp'),
+                $this->logicalNot(
+                    $this->logicalAnd(
+                        $this->stringContains('rght'),
+                        $this->stringContains('lft')
+                    )
+                )
+            );
+
+        $this->Task->bake('add', true);
+        $this->Task->bake('index', true);
+    }
+
+    /**
      * Ensure that models associated with themselves do not have action
      * links generated.
      *
@@ -459,7 +496,9 @@ class TemplateTaskTest extends TestCase
                 $this->logicalNot(
                     $this->logicalAnd(
                         $this->stringContains('New Parent Category Thread'),
-                        $this->stringContains('List Parent Category Threads')
+                        $this->stringContains('List Parent Category Threads'),
+                        $this->stringContains('rght'),
+                        $this->stringContains('lft')
                     )
                 )
             );

--- a/tests/test_app/App/Model/Table/CategoryThreadsTable.php
+++ b/tests/test_app/App/Model/Table/CategoryThreadsTable.php
@@ -38,5 +38,6 @@ class CategoryThreadsTable extends Table
             'foreignKey' => 'parent_id'
             ]
         );
+        $this->addBehavior('Tree');
     }
 }


### PR DESCRIPTION
When baking forms and list pages for tree models, we should exclude the lft/rght fields. The treebehavior manages these fields on add/update and they are not very useful on the list page.

Refs #155