### PR TITLE
Remove dead options from fixture task.

### DIFF
--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -82,9 +82,6 @@ class FixtureTask extends BakeTask
             ' Used with --count and --conditions to limit which records are added to the fixture.',
             'short' => 'r',
             'boolean' => true
-        ])->addOption('import-records', [
-            'help' => 'Set to true to import records from the live table when the generated fixture is used.',
-            'boolean' => true
         ])->addOption('conditions', [
             'help' => 'The SQL snippet to use when importing records.',
             'default' => '1=1',
@@ -158,10 +155,7 @@ class FixtureTask extends BakeTask
         $importBits = [];
         if (!empty($this->params['schema'])) {
             $modelImport = true;
-            $importBits[] = "'model' => '{$model}'";
-        }
-        if (!empty($this->params['import-records'])) {
-            $importBits[] = "'records' => true";
+            $importBits[] = "'table' => '{$useTable}'";
         }
         if (!empty($importBits) && $this->connection !== 'default') {
             $importBits[] = "'connection' => '{$this->connection}'";
@@ -189,14 +183,14 @@ class FixtureTask extends BakeTask
             $schema = $this->_generateSchema($data);
         }
 
-        if (empty($this->params['records']) && empty($this->params['import-records'])) {
+        if (empty($this->params['records'])) {
             $recordCount = 1;
             if (isset($this->params['count'])) {
                 $recordCount = $this->params['count'];
             }
             $records = $this->_makeRecordString($this->_generateRecords($data, $recordCount));
         }
-        if (!empty($this->params['records']) && empty($this->params['import-records'])) {
+        if (!empty($this->params['records'])) {
             $records = $this->_makeRecordString($this->_getRecordsFromTable($model, $useTable));
         }
         return $this->generateFixtureFile($model, compact('records', 'table', 'schema', 'import'));

--- a/src/View/BakeView.php
+++ b/src/View/BakeView.php
@@ -124,7 +124,11 @@ class BakeView extends View
     public function render($view = null, $layout = null)
     {
         $viewFileName = $this->_getViewFileName($view);
-        $templateEventName = str_replace(['.ctp', DS], ['', '.'], explode('Template/Bake/', $viewFileName)[1]);
+        $templateEventName = str_replace(
+            ['.ctp', DS],
+            ['', '.'],
+            explode('Template' . DS . 'Bake' . DS, $viewFileName)[1]
+        );
 
         $this->_currentType = static::TYPE_VIEW;
         $this->dispatchEvent('View.beforeRender', [$viewFileName]);

--- a/tests/TestCase/Shell/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Shell/Task/FixtureTaskTest.php
@@ -266,11 +266,11 @@ class FixtureTaskTest extends TestCase
 
         $filename = $this->_normalizePath(ROOT . DS . 'tests' . DS . 'Fixture/ArticlesFixture.php');
         $this->Task->expects($this->at(0))->method('createFile')
-            ->with($filename, $this->stringContains("public \$import = ['model' => 'Articles'"));
+            ->with($filename, $this->stringContains("public \$import = ['table' => 'articles'"));
 
         $filename = $this->_normalizePath(ROOT . DS . 'tests' . DS . 'Fixture/CommentsFixture.php');
         $this->Task->expects($this->at(1))->method('createFile')
-            ->with($filename, $this->stringContains("public \$import = ['model' => 'Comments'"));
+            ->with($filename, $this->stringContains("public \$import = ['table' => 'comments'"));
         $this->Task->expects($this->exactly(2))->method('createFile');
 
         $this->Task->all();
@@ -317,26 +317,6 @@ class FixtureTaskTest extends TestCase
     }
 
     /**
-     * test main() with importing records
-     *
-     * @return void
-     */
-    public function testMainImportRecords()
-    {
-        $this->Task->connection = 'test';
-        $this->Task->params = ['import-records' => true];
-
-        $this->Task->expects($this->at(0))
-            ->method('createFile')
-            ->with($this->anything(), $this->logicalAnd(
-                $this->stringContains("public \$import = ['records' => true, 'connection' => 'test'];"),
-                $this->logicalNot($this->stringContains('public $records'))
-            ));
-
-        $this->Task->main('Article');
-    }
-
-    /**
      * test main() with importing schema.
      *
      * @return void
@@ -344,15 +324,15 @@ class FixtureTaskTest extends TestCase
     public function testMainImportSchema()
     {
         $this->Task->connection = 'test';
-        $this->Task->params = ['schema' => true, 'import-records' => true];
+        $this->Task->params = ['schema' => true];
 
-        $importString = "public \$import = ['model' => 'Article', 'records' => true, 'connection' => 'test'];";
+        $importString = "public \$import = ['table' => 'comments', 'connection' => 'test'];";
         $this->Task->expects($this->once())
             ->method('createFile')
             ->with($this->anything(), $this->logicalAnd(
                 $this->stringContains($importString),
                 $this->logicalNot($this->stringContains('public $fields')),
-                $this->logicalNot($this->stringContains('public $records'))
+                $this->stringContains('public $records')
             ));
         $this->Task->bake('Article', 'comments');
     }

--- a/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
+++ b/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
@@ -15,7 +15,7 @@ class UsersFixture extends TestFixture
      *
      * @var array
      */
-    public $import = ['model' => 'Users', 'connection' => 'test'];
+    public $import = ['table' => 'users', 'connection' => 'test'];
 
     /**
      * Records


### PR DESCRIPTION
The `import-records` option doesn't actually do anything anymore, so we don't need it. The generated import property is now correct as well.

Refs #192