### PR TITLE
Generate isUnique rules for single column unique key indexes.

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -650,7 +650,8 @@ class ModelTask extends BakeTask
         if (!empty($this->params['no-rules'])) {
             return [];
         }
-        $fields = $model->schema()->columns();
+        $schema = $model->schema();
+        $fields = $schema->columns();
         if (empty($fields)) {
             return [];
         }
@@ -660,6 +661,16 @@ class ModelTask extends BakeTask
             if (in_array($fieldName, ['username', 'email', 'login'])) {
                 $rules[$fieldName] = ['name' => 'isUnique'];
             }
+        }
+        foreach ($schema->constraints() as $name) {
+            $constraint = $schema->constraint($name);
+            if ($constraint['type'] !== SchemaTable::CONSTRAINT_UNIQUE) {
+                continue;
+            }
+            if (count($constraint['columns']) > 1) {
+                continue;
+            }
+            $rules[$constraint['columns'][0]] = ['name' => 'isUnique'];
         }
 
         if (empty($associations['belongsTo'])) {

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -813,6 +813,35 @@ class ModelTaskTest extends TestCase
     }
 
     /**
+     * Tests the getRules with unique keys.
+     *
+     * Multi-column constraints are ignored as they would
+     * require a break in compatibility.
+     *
+     * @return void
+     */
+    public function testGetRulesUniqueKeys()
+    {
+        $model = TableRegistry::get('BakeArticles');
+        $model->schema()->addConstraint('unique_title', [
+            'type' => 'unique',
+            'columns' => ['title']
+        ]);
+        $model->schema()->addConstraint('ignored_constraint', [
+            'type' => 'unique',
+            'columns' => ['title', 'bake_user_id']
+        ]);
+
+        $result = $this->Task->getRules($model, []);
+        $expected = [
+            'title' => [
+                'name' => 'isUnique'
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * test non interactive doActsAs
      *
      * @return void


### PR DESCRIPTION
While it is possible to add rules for multi-column unique keys, doing so would require changing the template data, which will likely break userland templates. For that reason, I'd rather not add support for multi-column unique keys at this point in time.

Refs #182