### PR TITLE
Using TESTS constants if defined

### DIFF
--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -47,7 +47,7 @@ class FixtureTask extends BakeTask
     public function getPath()
     {
         $dir = 'Fixture/';
-        $path = ROOT . DS . 'tests' . DS . $dir;
+        $path = defined('TESTS') ? TESTS . $dir : ROOT . DS . 'tests' . DS . $dir;
         if (isset($this->plugin)) {
             $path = $this->_pluginPath($this->plugin) . 'tests/' . $dir;
         }

--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -560,7 +560,7 @@ class TestTask extends BakeTask
     public function getPath()
     {
         $dir = 'TestCase/';
-        $path = ROOT . DS . 'tests' . DS . $dir;
+        $path = defined('TESTS') ? TESTS . $dir : ROOT . DS . 'tests' . DS . $dir;
         if (isset($this->plugin)) {
             $path = $this->_pluginPath($this->plugin) . 'tests/' . $dir;
         }


### PR DESCRIPTION
Using TESTS constants if defined (in `config/paths.php` file), it instead of `ROOT . DS . 'tests' . DS`