### PR TITLE
Updated docblock returns to pass CakePHP coding standard

### DIFF
--- a/src/Template/Bake/Element/Controller/add.ctp
+++ b/src/Template/Bake/Element/Controller/add.ctp
@@ -18,7 +18,7 @@ $compact = ["'" . $singularName . "'"];
     /**
      * Add method
      *
-     * @return void Redirects on successful add, renders view otherwise.
+     * @return \Cake\Network\Response|void Redirects on successful add, renders view otherwise.
      */
     public function add()
     {

--- a/src/Template/Bake/Element/Controller/edit.ctp
+++ b/src/Template/Bake/Element/Controller/edit.ctp
@@ -22,7 +22,7 @@ $compact = ["'" . $singularName . "'"];
      * Edit method
      *
      * @param string|null $id <%= $singularHumanName %> id.
-     * @return void Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Network\Response|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Network\Exception\NotFoundException When record not found.
      */
     public function edit($id = null)

--- a/src/Template/Bake/Element/Controller/login.ctp
+++ b/src/Template/Bake/Element/Controller/login.ctp
@@ -17,7 +17,7 @@
     /**
      * Login method
      *
-     * @return void
+     * @return \Cake\Network\Response|void
      */
     public function login()
     {

--- a/src/Template/Bake/Element/Controller/logout.ctp
+++ b/src/Template/Bake/Element/Controller/logout.ctp
@@ -17,7 +17,7 @@
     /**
      * Logout method
      *
-     * @return void
+     * @return \Cake\Network\Response
      */
     public function logout()
     {

--- a/tests/comparisons/Controller/testBakeActions.php
+++ b/tests/comparisons/Controller/testBakeActions.php
@@ -60,7 +60,7 @@ class BakeArticlesController extends AppController
     /**
      * Add method
      *
-     * @return void Redirects on successful add, renders view otherwise.
+     * @return \Cake\Network\Response|void Redirects on successful add, renders view otherwise.
      */
     public function add()
     {
@@ -84,7 +84,7 @@ class BakeArticlesController extends AppController
      * Edit method
      *
      * @param string|null $id Bake Article id.
-     * @return void Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Network\Response|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Network\Exception\NotFoundException When record not found.
      */
     public function edit($id = null)

--- a/tests/comparisons/Controller/testBakeActionsContent.php
+++ b/tests/comparisons/Controller/testBakeActionsContent.php
@@ -44,7 +44,7 @@ class BakeArticlesController extends AppController
     /**
      * Add method
      *
-     * @return void Redirects on successful add, renders view otherwise.
+     * @return \Cake\Network\Response|void Redirects on successful add, renders view otherwise.
      */
     public function add()
     {
@@ -68,7 +68,7 @@ class BakeArticlesController extends AppController
      * Edit method
      *
      * @param string|null $id Bake Article id.
-     * @return void Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Network\Response|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Network\Exception\NotFoundException When record not found.
      */
     public function edit($id = null)

--- a/tests/comparisons/Controller/testBakeWithPlugin.php
+++ b/tests/comparisons/Controller/testBakeWithPlugin.php
@@ -44,7 +44,7 @@ class BakeArticlesController extends AppController
     /**
      * Add method
      *
-     * @return void Redirects on successful add, renders view otherwise.
+     * @return \Cake\Network\Response|void Redirects on successful add, renders view otherwise.
      */
     public function add()
     {
@@ -68,7 +68,7 @@ class BakeArticlesController extends AppController
      * Edit method
      *
      * @param string|null $id Bake Article id.
-     * @return void Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Network\Response|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Network\Exception\NotFoundException When record not found.
      */
     public function edit($id = null)


### PR DESCRIPTION
Currently the bake doc block doesn't pass the cakephp standard, as redirect returns a response