### PR TITLE
Allow the hidden option to work when baking entities

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -132,6 +132,7 @@ class ModelTask extends BakeTask
         $rulesChecker = $this->getRules($tableObject, $associations);
         $behaviors = $this->getBehaviors($tableObject);
         $connection = $this->connection;
+        $hidden = $this->getHiddenFields($tableObject);
 
         return compact(
             'associations',
@@ -143,7 +144,8 @@ class ModelTask extends BakeTask
             'validation',
             'rulesChecker',
             'behaviors',
-            'connection'
+            'connection',
+            'hidden'
         );
     }
 
@@ -785,7 +787,7 @@ class ModelTask extends BakeTask
             'namespace' => $namespace,
             'plugin' => $this->plugin,
             'pluginPath' => $pluginPath,
-            'primaryKey' => [],
+            'primaryKey' => []
         ];
 
         $this->BakeTemplate->set($data);

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -1149,6 +1149,21 @@ class ModelTaskTest extends TestCase
     }
 
     /**
+     * test baking an entity with non whitelisted hidden fields.
+     *
+     * @return void
+     */
+    public function testBakeEntityCustomHidden()
+    {
+        $model = TableRegistry::get('BakeUsers');
+        $config = [
+            'hidden' => ['foo', 'bar'],
+        ];
+        $result = $this->Task->bakeEntity($model, $config);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    /**
      * test bake() with a -plugin param
      *
      * @return void

--- a/tests/comparisons/Model/testBakeEntityCustomHidden.php
+++ b/tests/comparisons/Model/testBakeEntityCustomHidden.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * BakeUser Entity.
+ */
+class BakeUser extends Entity
+{
+
+    /**
+     * Fields that are excluded from JSON an array versions of the entity.
+     *
+     * @var array
+     */
+    protected $_hidden = [
+        'foo',
+        'bar'
+    ];
+}


### PR DESCRIPTION
Fixed baking entities with non whitelisted hidden fields, and added a test case.

`$ bin/cake bake model -f --no-table --hidden _matchingData,foo --no-test --no-fixture Examples`

Would not create a `$_hidden` field in the entity.