### PR TITLE
Make baked tests more code-completion/inspection friendly.

### DIFF
--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -535,7 +535,7 @@ class TestTask extends BakeTask
      * - `description` (the property description)
      * - `type` (the property docblock type)
      * - `name` (the property name)
-     * - `value` (the properties initial value)
+     * - `value` (optional - the properties initial value)
      *
      * @param string $type The Type of object you are generating tests for eg. controller
      * @param string $subject The name of the test subject.
@@ -552,14 +552,12 @@ class TestTask extends BakeTask
                 $properties[] = [
                     'description' => 'Request mock',
                     'type' => '\Cake\Network\Request|\PHPUnit_Framework_MockObject_MockObject',
-                    'name' => 'request',
-                    'value' => 'null'
+                    'name' => 'request'
                 ];
                 $properties[] = [
                     'description' => 'Response mock',
                     'type' => '\Cake\Network\Response|\PHPUnit_Framework_MockObject_MockObject',
-                    'name' => 'response',
-                    'value' => 'null'
+                    'name' => 'response'
                 ];
                 break;
 
@@ -567,8 +565,7 @@ class TestTask extends BakeTask
                 $properties[] = [
                     'description' => 'ConsoleIo mock',
                     'type' => '\Cake\Console\ConsoleIo|\PHPUnit_Framework_MockObject_MockObject',
-                    'name' => 'io',
-                    'value' => 'null'
+                    'name' => 'io'
                 ];
                 break;
 
@@ -576,14 +573,12 @@ class TestTask extends BakeTask
                 $properties[] = [
                     'description' => 'ConsoleOutput stub',
                     'type' => '\Cake\TestSuite\Stub\ConsoleOutput',
-                    'name' => 'stub',
-                    'value' => 'null'
+                    'name' => 'stub'
                 ];
                 $properties[] = [
                     'description' => 'ConsoleIo mock',
                     'type' => '\Cake\Console\ConsoleIo',
-                    'name' => 'io',
-                    'value' => 'null'
+                    'name' => 'io'
                 ];
                 break;
         }
@@ -592,8 +587,7 @@ class TestTask extends BakeTask
             $properties[] = [
                 'description' => 'Test subject',
                 'type' => '\\' . $fullClassName,
-                'name' => $subject,
-                'value' => 'null'
+                'name' => $subject
             ];
         }
 

--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -239,6 +239,8 @@ class TestTask extends BakeTask
         }
         $subNamespace = substr($namespace, strlen($baseNamespace) + 1);
 
+        $properties = $this->generateProperties($type, $subject, $fullClassName);
+
         $this->out("\n" . sprintf('Baking test case for %s ...', $fullClassName), 1, Shell::QUIET);
 
         $this->BakeTemplate->set('fixtures', $this->_fixtures);
@@ -246,11 +248,12 @@ class TestTask extends BakeTask
         $this->BakeTemplate->set(compact(
             'subject',
             'className',
+            'properties',
             'methods',
             'type',
             'fullClassName',
             'mock',
-            'realType',
+            'type',
             'preConstruct',
             'postConstruct',
             'construction',
@@ -522,6 +525,79 @@ class TestTask extends BakeTask
             $construct = "new {$className}(\$this->io);";
         }
         return [$pre, $construct, $post];
+    }
+
+    /**
+     * Generate property info for the type and class name
+     *
+     * The generated property info consists of a set of arrays that hold the following keys:
+     *
+     * - `description` (the property description)
+     * - `type` (the property docblock type)
+     * - `name` (the property name)
+     * - `value` (the properties initial value)
+     *
+     * @param string $type The Type of object you are generating tests for eg. controller
+     * @param string $subject The name of the test subject.
+     * @param string $fullClassName The Classname of the class the test is being generated for.
+     * @return array An array containing property info
+     */
+    public function generateProperties($type, $subject, $fullClassName)
+    {
+        $type = strtolower($type);
+
+        $properties = [];
+        switch (strtolower($type)) {
+            case 'cell':
+                $properties[] = [
+                    'description' => 'Request mock',
+                    'type' => '\Cake\Network\Request|\PHPUnit_Framework_MockObject_MockObject',
+                    'name' => 'request',
+                    'value' => 'null'
+                ];
+                $properties[] = [
+                    'description' => 'Response mock',
+                    'type' => '\Cake\Network\Response|\PHPUnit_Framework_MockObject_MockObject',
+                    'name' => 'response',
+                    'value' => 'null'
+                ];
+                break;
+
+            case 'shell':
+                $properties[] = [
+                    'description' => 'ConsoleIo mock',
+                    'type' => '\Cake\Console\ConsoleIo|\PHPUnit_Framework_MockObject_MockObject',
+                    'name' => 'io',
+                    'value' => 'null'
+                ];
+                break;
+
+            case 'shell_helper':
+                $properties[] = [
+                    'description' => 'ConsoleOutput stub',
+                    'type' => '\Cake\TestSuite\Stub\ConsoleOutput',
+                    'name' => 'stub',
+                    'value' => 'null'
+                ];
+                $properties[] = [
+                    'description' => 'ConsoleIo mock',
+                    'type' => '\Cake\Console\ConsoleIo',
+                    'name' => 'io',
+                    'value' => 'null'
+                ];
+                break;
+        }
+
+        if ($type !== 'controller') {
+            $properties[] = [
+                'description' => 'Test subject',
+                'type' => '\\' . $fullClassName,
+                'name' => $subject,
+                'value' => 'null'
+            ];
+        }
+
+        return $properties;
     }
 
     /**

--- a/src/Template/Bake/tests/test_case.ctp
+++ b/src/Template/Bake/tests/test_case.ctp
@@ -50,7 +50,7 @@ class <%= $className %>Test extends TestCase
      *
      * @var <%= $propertyInfo['type'] %>
      */
-    public $<%= $propertyInfo['name'] %> = <%= $propertyInfo['value'] %>;
+    public $<%= $propertyInfo['name'] %><% if (isset($propertyInfo['value'])): %> = <%= $propertyInfo['value'] %><% endif; %>;
 <% endforeach; %>
 <% endif; %>
 <% if (!empty($fixtures)): %>

--- a/src/Template/Bake/tests/test_case.ctp
+++ b/src/Template/Bake/tests/test_case.ctp
@@ -42,6 +42,17 @@ class <%= $className %>Test extends IntegrationTestCase
 class <%= $className %>Test extends TestCase
 {
 <% endif; %>
+<% if (!empty($properties)): %>
+<% foreach ($properties as $propertyInfo): %>
+
+    /**
+     * <%= $propertyInfo['description'] %>
+     *
+     * @var <%= $propertyInfo['type'] %>
+     */
+    public $<%= $propertyInfo['name'] %> = <%= $propertyInfo['value'] %>;
+<% endforeach; %>
+<% endif; %>
 <% if (!empty($fixtures)): %>
 
     /**

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -473,6 +473,21 @@ class TestTaskTest extends TestCase
     }
 
     /**
+     * Test baking a test for a shell helper.
+     *
+     * @return void
+     */
+    public function testBakeShellHelperTest()
+    {
+        $this->Task->expects($this->once())
+            ->method('createFile')
+            ->will($this->returnValue(true));
+
+        $result = $this->Task->bake('Shell_helper', 'Example');
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    /**
      * Test baking an unknown class type.
      *
      * @return void

--- a/tests/comparisons/Test/testBakeBehaviorTest.php
+++ b/tests/comparisons/Test/testBakeBehaviorTest.php
@@ -15,7 +15,7 @@ class ExampleBehaviorTest extends TestCase
      *
      * @var \App\Model\Behavior\ExampleBehavior
      */
-    public $Example = null;
+    public $Example;
 
     /**
      * setUp method

--- a/tests/comparisons/Test/testBakeBehaviorTest.php
+++ b/tests/comparisons/Test/testBakeBehaviorTest.php
@@ -11,6 +11,13 @@ class ExampleBehaviorTest extends TestCase
 {
 
     /**
+     * Test subject
+     *
+     * @var \App\Model\Behavior\ExampleBehavior
+     */
+    public $Example = null;
+
+    /**
      * setUp method
      *
      * @return void

--- a/tests/comparisons/Test/testBakeCellTest.php
+++ b/tests/comparisons/Test/testBakeCellTest.php
@@ -11,6 +11,27 @@ class ArticlesCellTest extends TestCase
 {
 
     /**
+     * Request mock
+     *
+     * @var \Cake\Network\Request|\PHPUnit_Framework_MockObject_MockObject
+     */
+    public $request = null;
+
+    /**
+     * Response mock
+     *
+     * @var \Cake\Network\Response|\PHPUnit_Framework_MockObject_MockObject
+     */
+    public $response = null;
+
+    /**
+     * Test subject
+     *
+     * @var \App\View\Cell\ArticlesCell
+     */
+    public $Articles = null;
+
+    /**
      * setUp method
      *
      * @return void

--- a/tests/comparisons/Test/testBakeCellTest.php
+++ b/tests/comparisons/Test/testBakeCellTest.php
@@ -15,21 +15,21 @@ class ArticlesCellTest extends TestCase
      *
      * @var \Cake\Network\Request|\PHPUnit_Framework_MockObject_MockObject
      */
-    public $request = null;
+    public $request;
 
     /**
      * Response mock
      *
      * @var \Cake\Network\Response|\PHPUnit_Framework_MockObject_MockObject
      */
-    public $response = null;
+    public $response;
 
     /**
      * Test subject
      *
      * @var \App\View\Cell\ArticlesCell
      */
-    public $Articles = null;
+    public $Articles;
 
     /**
      * setUp method

--- a/tests/comparisons/Test/testBakeComponentTest.php
+++ b/tests/comparisons/Test/testBakeComponentTest.php
@@ -16,7 +16,7 @@ class AppleComponentTest extends TestCase
      *
      * @var \Bake\Test\App\Controller\Component\AppleComponent
      */
-    public $Apple = null;
+    public $Apple;
 
     /**
      * setUp method

--- a/tests/comparisons/Test/testBakeComponentTest.php
+++ b/tests/comparisons/Test/testBakeComponentTest.php
@@ -12,6 +12,13 @@ class AppleComponentTest extends TestCase
 {
 
     /**
+     * Test subject
+     *
+     * @var \Bake\Test\App\Controller\Component\AppleComponent
+     */
+    public $Apple = null;
+
+    /**
      * setUp method
      *
      * @return void

--- a/tests/comparisons/Test/testBakeFixturesParam.php
+++ b/tests/comparisons/Test/testBakeFixturesParam.php
@@ -16,7 +16,7 @@ class ArticlesTableTest extends TestCase
      *
      * @var \App\Model\Table\ArticlesTable
      */
-    public $Articles = null;
+    public $Articles;
 
     /**
      * Fixtures

--- a/tests/comparisons/Test/testBakeFixturesParam.php
+++ b/tests/comparisons/Test/testBakeFixturesParam.php
@@ -12,6 +12,13 @@ class ArticlesTableTest extends TestCase
 {
 
     /**
+     * Test subject
+     *
+     * @var \App\Model\Table\ArticlesTable
+     */
+    public $Articles = null;
+
+    /**
      * Fixtures
      *
      * @var array

--- a/tests/comparisons/Test/testBakeHelperTest.php
+++ b/tests/comparisons/Test/testBakeHelperTest.php
@@ -16,7 +16,7 @@ class ExampleHelperTest extends TestCase
      *
      * @var \App\View\Helper\ExampleHelper
      */
-    public $Example = null;
+    public $Example;
 
     /**
      * setUp method

--- a/tests/comparisons/Test/testBakeModelTest.php
+++ b/tests/comparisons/Test/testBakeModelTest.php
@@ -12,6 +12,13 @@ class ArticlesTableTest extends TestCase
 {
 
     /**
+     * Test subject
+     *
+     * @var \App\Model\Table\ArticlesTable
+     */
+    public $Articles = null;
+
+    /**
      * setUp method
      *
      * @return void

--- a/tests/comparisons/Test/testBakeModelTest.php
+++ b/tests/comparisons/Test/testBakeModelTest.php
@@ -16,7 +16,7 @@ class ArticlesTableTest extends TestCase
      *
      * @var \App\Model\Table\ArticlesTable
      */
-    public $Articles = null;
+    public $Articles;
 
     /**
      * setUp method

--- a/tests/comparisons/Test/testBakeShellHelperTest.php
+++ b/tests/comparisons/Test/testBakeShellHelperTest.php
@@ -17,21 +17,21 @@ class ExampleHelperTest extends TestCase
      *
      * @var \Cake\TestSuite\Stub\ConsoleOutput
      */
-    public $stub = null;
+    public $stub;
 
     /**
      * ConsoleIo mock
      *
      * @var \Cake\Console\ConsoleIo
      */
-    public $io = null;
+    public $io;
 
     /**
      * Test subject
      *
      * @var \App\Shell\Helper\ExampleHelper
      */
-    public $Example = null;
+    public $Example;
 
     /**
      * setUp method

--- a/tests/comparisons/Test/testBakeShellHelperTest.php
+++ b/tests/comparisons/Test/testBakeShellHelperTest.php
@@ -1,20 +1,35 @@
 <?php
-namespace App\Test\TestCase\View\Helper;
+namespace App\Test\TestCase\Shell\Helper;
 
-use App\View\Helper\ExampleHelper;
+use App\Shell\Helper\ExampleHelper;
+use Cake\Console\ConsoleIo;
+use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
-use Cake\View\View;
 
 /**
- * App\View\Helper\ExampleHelper Test Case
+ * App\Shell\Helper\ExampleHelper Test Case
  */
 class ExampleHelperTest extends TestCase
 {
 
     /**
+     * ConsoleOutput stub
+     *
+     * @var \Cake\TestSuite\Stub\ConsoleOutput
+     */
+    public $stub = null;
+
+    /**
+     * ConsoleIo mock
+     *
+     * @var \Cake\Console\ConsoleIo
+     */
+    public $io = null;
+
+    /**
      * Test subject
      *
-     * @var \App\View\Helper\ExampleHelper
+     * @var \App\Shell\Helper\ExampleHelper
      */
     public $Example = null;
 
@@ -26,8 +41,9 @@ class ExampleHelperTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $view = new View();
-        $this->Example = new ExampleHelper($view);
+        $this->stub = new ConsoleOutput();
+        $this->io = new ConsoleIo($this->stub);
+        $this->Example = new ExampleHelper($this->io);
     }
 
     /**

--- a/tests/comparisons/Test/testBakeShellTest.php
+++ b/tests/comparisons/Test/testBakeShellTest.php
@@ -11,6 +11,20 @@ class ArticlesShellTest extends TestCase
 {
 
     /**
+     * ConsoleIo mock
+     *
+     * @var \Cake\Console\ConsoleIo|\PHPUnit_Framework_MockObject_MockObject
+     */
+    public $io = null;
+
+    /**
+     * Test subject
+     *
+     * @var \App\Shell\ArticlesShell
+     */
+    public $Articles = null;
+
+    /**
      * setUp method
      *
      * @return void

--- a/tests/comparisons/Test/testBakeShellTest.php
+++ b/tests/comparisons/Test/testBakeShellTest.php
@@ -15,14 +15,14 @@ class ArticlesShellTest extends TestCase
      *
      * @var \Cake\Console\ConsoleIo|\PHPUnit_Framework_MockObject_MockObject
      */
-    public $io = null;
+    public $io;
 
     /**
      * Test subject
      *
      * @var \App\Shell\ArticlesShell
      */
-    public $Articles = null;
+    public $Articles;
 
     /**
      * setUp method


### PR DESCRIPTION
This PR aims to make baked tests a little more IDE friendly by adding real properties to the baked tests.

Usually every time I bake tests, the first thing I do is adding real properties for the dynamic ones set in the generated constructor, so that I get proper code-complection, and my IDE doesn't light up like a  :christmas_tree: complaining about non-existing properties :)