### PR TITLE
remove empty file when baking plugin

### DIFF
--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -112,6 +112,9 @@ class PluginTask extends BakeTask
         $this->hr();
         $this->out(sprintf('<success>Created:</success> %s in %s', $plugin, $this->path . $plugin), 2);
 
+        $emptyFile = $this->path . 'empty';
+        $this->_deleteEmptyFile($emptyFile);
+
         return true;
     }
 


### PR DESCRIPTION
Very minor issue, but baking a new plugin should remove `empty` file in plugins directory if it exists.