### PR TITLE
No need to duplicate License part.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ You can find the documentation for bake [on the cookbook](http://book.cakephp.or
 
 ## License
 
-MIT, see [LICENSE.txt].
+MIT, see [LICENSE.txt](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -19,8 +19,3 @@ composer require --dev cakephp/bake
 ## Documentation
 
 You can find the documentation for bake [on the cookbook](http://book.cakephp.org/3.0/en/bake.html).
-
-
-## License
-
-MIT, see [LICENSE.txt](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -23,22 +23,4 @@ You can find the documentation for bake [on the cookbook](http://book.cakephp.or
 
 ## License
 
-Copyright (c) 2016 Cake Software Foundation, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+MIT, see [LICENSE.txt].


### PR DESCRIPTION
License is in root file LICENSE.txt already.

Or we can remove this block alltogether as the icon above states it as well as the uppercase filename in the repo as well quite clearly.