### PR TITLE
bump min php version for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ init:
 
 install:
   - cd c:\
-  - appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.5.8-nts-Win32-VC11-x86.zip -FileName php.zip
+  - appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.5.10-nts-Win32-VC11-x86.zip -FileName php.zip
   - 7z x php.zip -oc:\php
   - appveyor DownloadFile https://dl.dropboxusercontent.com/s/euip490d9183jkr/SQLSRV32.cab -FileName sqlsrv.cab
   - 7z x sqlsrv.cab -oc:\php\ext php*_55_nts.dll

--- a/tests/Fixture/CategoriesFixture.php
+++ b/tests/Fixture/CategoriesFixture.php
@@ -51,7 +51,6 @@ class CategoriesFixture extends TestFixture
      */
     public $records = [
         [
-            'id' => 1,
             'created' => '2015-12-30 18:11:36',
             'modified' => '2015-12-30 18:11:36',
             'name' => 'Lorem ipsum dolor sit amet'

--- a/tests/Fixture/OldProductsFixture.php
+++ b/tests/Fixture/OldProductsFixture.php
@@ -51,7 +51,6 @@ class OldProductsFixture extends TestFixture
      */
     public $records = [
         [
-            'id' => 1,
             'created' => '2015-12-30 18:11:36',
             'modified' => '2015-12-30 18:11:36',
             'name' => 'Lorem ipsum dolor sit amet'

--- a/tests/Fixture/ProductVersionsFixture.php
+++ b/tests/Fixture/ProductVersionsFixture.php
@@ -50,7 +50,6 @@ class ProductVersionsFixture extends TestFixture
      */
     public $records = [
         [
-            'id' => 1,
             'product_id' => 1,
             'version' => '2015-12-30 18:11:37'
         ],

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -51,7 +51,6 @@ class ProductsFixture extends TestFixture
      */
     public $records = [
         [
-            'id' => 1,
             'created' => '2015-12-30 18:11:37',
             'modified' => '2015-12-30 18:11:37',
             'name' => 'Lorem ipsum dolor sit amet'


### PR DESCRIPTION
as CakePHP 3.2 requires at least 5.5.9