### PR TITLE
Add a basic OptionParser into the baked shell, for ease of customisation

### DIFF
--- a/src/Template/Bake/Shell/shell.ctp
+++ b/src/Template/Bake/Shell/shell.ctp
@@ -25,11 +25,26 @@ class <%= $name %>Shell extends Shell
 {
 
     /**
+     * Manage the available sub-commands along with their arguments and help
+     *
+     * @see http://book.cakephp.org/3.0/en/console-and-shells.html#configuring-options-and-generating-help
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+
+        return $parser;
+    }
+
+    /**
      * main() method.
      *
      * @return bool|int Success or error code.
      */
     public function main() 
     {
+        $this->out($this->OptionParser->help());
     }
 }


### PR DESCRIPTION
I always have to look this up, so figured it'd sure be handy to have it right there in the baked shell with a link to the docs.

I have run the test suite and everything passed. Let me know if you'd like me to make an attempt at including a new test case.