### PR TITLE
Adds the ability to write bake output to clipboard.

### DIFF
--- a/src/Shell/RedirectClipboardTrait.php
+++ b/src/Shell/RedirectClipboardTrait.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         1.1.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Shell;
+
+use Cake\Filesystem\File;
+
+/**
+ * Redirects the file output of a Shell to the clipboard. All files are copied to the clipboard
+ * in the order they are written.
+ *
+ * @see \Cake\Console\Shell This traits works only on Shell classes.
+ */
+trait RedirectClipboardTrait
+{
+
+    /**
+     * @var null|string Name of the temp file used for clipboard output.
+     */
+    private static $_clipboardTemp = null;
+
+    /**
+     * @var null|File File handle used for clipboard output.
+     */
+    private static $_clipboardFile = null;
+
+    /**
+     * Opens the temporary file that receives clipboard contents.
+     *
+     * @return bool
+     */
+    private static function openClipboardFile()
+    {
+        if (self::$_clipboardFile !== null) {
+            return true;
+        }
+        self::$_clipboardTemp = tempnam(sys_get_temp_dir(), "tmp");
+        self::$_clipboardFile = new File(self::$_clipboardTemp, true);
+        return self::$_clipboardFile->exists() || self::$_clipboardFile->writable();
+    }
+
+    /**
+     * Tests if a command line tool can be found on Linux.
+     *
+     * @param string $cmd The command to locate.
+     * @return bool
+     */
+    private static function which($cmd)
+    {
+        $code = 0;
+        $output = null;
+        exec("which {$cmd}", $output, $code);
+        return $code == 0;
+    }
+
+    /**
+     * Sends the temporary file to the clipboard.
+     *
+     * @return bool
+     */
+    private static function sendClipboardFile()
+    {
+        if (self::$_clipboardFile == null) {
+            return false;
+        }
+        $fileName = self::$_clipboardTemp;
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            // Windows
+            return trim(shell_exec("clip < {$fileName}")) == '';
+        }
+        if (self::which('pbcopy')) {
+            // OSX
+            return trim(shell_exec("pbcopy < {$fileName}")) == '';
+        }
+        if (self::which('xclip')) {
+            // Linux
+            return trim(shell_exec("xclip -selection clipboard < {$fileName}")) == '';
+        }
+        return false;
+    }
+
+    /**
+     * Closes the temporary file and deletes it.
+     */
+    private static function closeClipboardFile()
+    {
+        if (self::$_clipboardFile == null) {
+            return;
+        }
+        self::$_clipboardFile->close();
+        self::$_clipboardFile = null;
+        if (file_exists(self::$_clipboardTemp)) {
+            unlink(self::$_clipboardTemp);
+        }
+    }
+
+    /**
+     * Runs the Shell with the provided argv.
+     *
+     * @param array $argv Array of arguments.
+     * @param bool $autoMethod Set to true to allow any public methods
+     * @param array $extra Extra parameters.
+     * @return mixed
+     * @see \Cake\Console\Shell::runCommand
+     */
+    public function runCommand($argv, $autoMethod = false, $extra = [])
+    {
+        if (!self::openClipboardFile()) {
+            $this->abort('Could not open temp file required for clipboard.');
+        }
+
+        try {
+            $res = parent::runCommand($argv, $autoMethod = false, $extra = []);
+            if (self::sendClipboardFile()) {
+                $this->_io->out('<success>Copy to clipboard</success>');
+            } else {
+                $this->_io->out('<error>Failed to send to clipboard</error>');
+                $this->_io->out('');
+                $this->_io->out('Linux users need to install xclip.');
+                $this->_io->out('   sudo apt-get install xclip');
+            }
+        } finally {
+            self::closeClipboardFile();
+        }
+
+        return $res;
+    }
+
+    /**
+     * Optionally redirects file output to the clipboard.
+     *
+     * @param string $path Where to put the file.
+     * @param string $contents Content to put in the file.
+     * @return bool Success
+     */
+    public function createFile($path, $contents)
+    {
+        if (empty($this->params['clipboard'])) {
+            return parent::createFile($path, $contents);
+        }
+        if (self::$_clipboardFile == null) {
+            $this->abort('Handle to clipboard is missing.');
+        }
+
+        self::$_clipboardFile->write("// {$path}" . PHP_EOL);
+        self::$_clipboardFile->write($contents);
+        self::$_clipboardFile->write(PHP_EOL);
+        return true;
+    }
+}

--- a/src/Shell/Task/BakeTask.php
+++ b/src/Shell/Task/BakeTask.php
@@ -14,6 +14,7 @@
  */
 namespace Bake\Shell\Task;
 
+use Bake\Shell\RedirectClipboardTrait;
 use Cake\Cache\Cache;
 use Cake\Console\Shell;
 use Cake\Core\Configure;
@@ -28,6 +29,7 @@ use Cake\Filesystem\File;
 class BakeTask extends Shell
 {
     use ConventionsTrait;
+    use RedirectClipboardTrait;
 
     /**
      * The pathFragment appended to the plugin/app path.
@@ -237,6 +239,10 @@ class BakeTask extends Shell
             'short' => 't',
             'help' => 'The theme to use when baking code.',
             'choices' => $bakeThemes
+        ])->addOption('clipboard', [
+            'short' => 'c',
+            'boolean' => true,
+            'help' => 'Write bake output to clipboard.'
         ]);
 
         return $parser;


### PR DESCRIPTION
This PR adds a new feature to bake. 

I wanted a way to update existing files with changes from the database, but didn't want to overwrite my files, and it had to work on the different OS platforms that I use. So this PR allows you to write all bake changes to the clipboard instead of files.

- Adds a new `--clipboard` or `-c` option for all bake commands.
- Redirects file writes to a temp file.
- After baking is finished the temp file is sent to the clipboard.
- Works on Windows, Linux and Mac.

I have not tested this with all bake commands. It works by overriding the `createFile` method in `Shell` from `BakeShell`. This should cover all commands.