### PR TITLE
Do not exclude /src/Template/Bake/Plugin/tests/* from `git archive`.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -38,4 +38,3 @@ CONTRIBUTING.md export-ignore
 Makefile export-ignore
 phpunit.xml.dist export-ignore
 .travis.yml export-ignore
-/tests export-ignore


### PR DESCRIPTION
See #248