### PR TITLE
Fix tests & Fix version requirements.

### DIFF
--- a/src/Template/Bake/Plugin/composer.json.ctp
+++ b/src/Template/Bake/Plugin/composer.json.ctp
@@ -20,7 +20,7 @@ $namespace = str_replace('\\', '\\\\', $namespace);
     "type": "cakephp-plugin",
     "require": {
         "php": ">=5.5.9",
-        "cakephp/cakephp": "3.3.*"
+        "cakephp/cakephp": ">=3.3.0 <4.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/src/Template/Bake/Plugin/composer.json.ctp
+++ b/src/Template/Bake/Plugin/composer.json.ctp
@@ -20,7 +20,7 @@ $namespace = str_replace('\\', '\\\\', $namespace);
     "type": "cakephp-plugin",
     "require": {
         "php": ">=5.5.9",
-        "cakephp/cakephp": ">=3.3.0 <4.0.0"
+        "cakephp/cakephp": ">=3.3.2 <4.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/src/Template/Bake/Plugin/config/routes.php.ctp
+++ b/src/Template/Bake/Plugin/config/routes.php.ctp
@@ -15,8 +15,8 @@
 %>
 <?php
 use Cake\Routing\RouteBuilder;
-use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\Router;
+use Cake\Routing\Route\DashedRoute;
 
 Router::plugin(
     '<%= $plugin %>',

--- a/tests/comparisons/Plugin/Company/Example/composer.json
+++ b/tests/comparisons/Plugin/Company/Example/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "require": {
         "php": ">=5.5.9",
-        "cakephp/cakephp": ">=3.3.0 <4.0.0"
+        "cakephp/cakephp": ">=3.3.2 <4.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/tests/comparisons/Plugin/Company/Example/composer.json
+++ b/tests/comparisons/Plugin/Company/Example/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "require": {
         "php": ">=5.5.9",
-        "cakephp/cakephp": "3.3.*"
+        "cakephp/cakephp": ">=3.3.0 <4.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/tests/comparisons/Plugin/Company/Example/composer.json
+++ b/tests/comparisons/Plugin/Company/Example/composer.json
@@ -3,8 +3,8 @@
     "description": "Company/Example plugin for CakePHP",
     "type": "cakephp-plugin",
     "require": {
-        "php": ">=5.4.16",
-        "cakephp/cakephp": "~3.0"
+        "php": ">=5.5.9",
+        "cakephp/cakephp": "3.3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/tests/comparisons/Plugin/Company/Example/config/routes.php
+++ b/tests/comparisons/Plugin/Company/Example/config/routes.php
@@ -1,11 +1,12 @@
 <?php
 use Cake\Routing\RouteBuilder;
+use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\Router;
 
 Router::plugin(
     'Company/Example',
     ['path' => '/company/example'],
     function (RouteBuilder $routes) {
-        $routes->fallbacks('DashedRoute');
+        $routes->fallbacks(DashedRoute::class);
     }
 );

--- a/tests/comparisons/Plugin/Company/Example/config/routes.php
+++ b/tests/comparisons/Plugin/Company/Example/config/routes.php
@@ -1,7 +1,7 @@
 <?php
 use Cake\Routing\RouteBuilder;
-use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\Router;
+use Cake\Routing\Route\DashedRoute;
 
 Router::plugin(
     'Company/Example',

--- a/tests/comparisons/Plugin/SimpleExample/composer.json
+++ b/tests/comparisons/Plugin/SimpleExample/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "require": {
         "php": ">=5.5.9",
-        "cakephp/cakephp": ">=3.3.0 <4.0.0"
+        "cakephp/cakephp": ">=3.3.2 <4.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/tests/comparisons/Plugin/SimpleExample/composer.json
+++ b/tests/comparisons/Plugin/SimpleExample/composer.json
@@ -3,8 +3,8 @@
     "description": "SimpleExample plugin for CakePHP",
     "type": "cakephp-plugin",
     "require": {
-        "php": ">=5.4.16",
-        "cakephp/cakephp": "~3.0"
+        "php": ">=5.5.9",
+        "cakephp/cakephp": "3.3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/tests/comparisons/Plugin/SimpleExample/composer.json
+++ b/tests/comparisons/Plugin/SimpleExample/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "require": {
         "php": ">=5.5.9",
-        "cakephp/cakephp": "3.3.*"
+        "cakephp/cakephp": ">=3.3.0 <4.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/tests/comparisons/Plugin/SimpleExample/config/routes.php
+++ b/tests/comparisons/Plugin/SimpleExample/config/routes.php
@@ -1,7 +1,7 @@
 <?php
 use Cake\Routing\RouteBuilder;
-use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\Router;
+use Cake\Routing\Route\DashedRoute;
 
 Router::plugin(
     'SimpleExample',

--- a/tests/comparisons/Plugin/SimpleExample/config/routes.php
+++ b/tests/comparisons/Plugin/SimpleExample/config/routes.php
@@ -1,11 +1,12 @@
 <?php
 use Cake\Routing\RouteBuilder;
+use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\Router;
 
 Router::plugin(
     'SimpleExample',
     ['path' => '/simple-example'],
     function (RouteBuilder $routes) {
-        $routes->fallbacks('DashedRoute');
+        $routes->fallbacks(DashedRoute::class);
     }
 );


### PR DESCRIPTION
Pinning to 3.3.* in a plugin makes upgrading a pain, as we'll need plugin authors to continuously do releases as CakePHP does new versions. Instead it is better if we set sane minimum versions and exclude backwards incompatible milestones.