### PR TITLE
Add prefix to (classes) table/entity names

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -984,7 +984,7 @@ class ModelTask extends BakeTask
      *
      * @return string
      */
-    public function getModelPrefix()
+    protected function getModelPrefix()
     {
         return !empty($this->params['model-prefix']) ? $this->_camelize($this->params['model-prefix']) : '';
     }

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -1047,11 +1047,11 @@ class ModelTask extends BakeTask
         if (!empty($this->params['no-fixture'])) {
             return;
         }
-        
+
         if (!empty($this->params['model-prefix'])) {
             $className = $this->_camelize($this->params['model-prefix']) . $className;
         }
-        
+
         $this->Fixture->connection = $this->connection;
         $this->Fixture->plugin = $this->plugin;
         $this->Fixture->bake($className, $useTable);
@@ -1068,11 +1068,11 @@ class ModelTask extends BakeTask
         if (!empty($this->params['no-test'])) {
             return null;
         }
-        
+
         if (!empty($this->params['model-prefix'])) {
             $className = $this->_camelize($this->params['model-prefix']) . $className;
         }
-        
+
         $this->Test->plugin = $this->plugin;
         $this->Test->connection = $this->connection;
 

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -795,7 +795,7 @@ class ModelTask extends BakeTask
         if (!empty($this->params['no-entity'])) {
             return null;
         }
-        $name = $this->_entityName($model->alias());
+        $name = $this->_entityName((!empty($this->params['model-prefix'])?$this->_camelize($this->params['model-prefix']):'') . $model->alias());
 
         $namespace = Configure::read('App.namespace');
         $pluginPath = '';
@@ -844,8 +844,8 @@ class ModelTask extends BakeTask
             $namespace = $this->_pluginNamespace($this->plugin);
         }
 
-        $name = $model->alias();
-        $entity = $this->_entityName($model->alias());
+        $name = (!empty($this->params['model-prefix'])?$this->_camelize($this->params['model-prefix']):'') . $model->alias();
+        $entity = $this->_entityName((!empty($this->params['model-prefix'])?$this->_camelize($this->params['model-prefix']):'') . $model->alias());
         $data += [
             'plugin' => $this->plugin,
             'pluginPath' => $pluginPath,
@@ -989,6 +989,8 @@ class ModelTask extends BakeTask
             'help' => 'Bake all model files with associations and validation.'
         ])->addOption('table', [
             'help' => 'The table name to use if you have non-conventional table names.'
+        ])->addOption('model-prefix', [
+            'help' => 'Prefix for the name of the table and entity.'
         ])->addOption('no-entity', [
             'boolean' => true,
             'help' => 'Disable generating an entity class.'
@@ -1045,6 +1047,11 @@ class ModelTask extends BakeTask
         if (!empty($this->params['no-fixture'])) {
             return;
         }
+        
+        if (!empty($this->params['model-prefix'])) {
+	        $className = $this->_camelize($this->params['model-prefix']) . $className;
+        }
+        
         $this->Fixture->connection = $this->connection;
         $this->Fixture->plugin = $this->plugin;
         $this->Fixture->bake($className, $useTable);
@@ -1061,6 +1068,11 @@ class ModelTask extends BakeTask
         if (!empty($this->params['no-test'])) {
             return null;
         }
+        
+        if (!empty($this->params['model-prefix'])) {
+	        $className = $this->_camelize($this->params['model-prefix']) . $className;
+        }
+        
         $this->Test->plugin = $this->plugin;
         $this->Test->connection = $this->connection;
 

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -1049,7 +1049,7 @@ class ModelTask extends BakeTask
         }
         
         if (!empty($this->params['model-prefix'])) {
-	        $className = $this->_camelize($this->params['model-prefix']) . $className;
+            $className = $this->_camelize($this->params['model-prefix']) . $className;
         }
         
         $this->Fixture->connection = $this->connection;
@@ -1070,7 +1070,7 @@ class ModelTask extends BakeTask
         }
         
         if (!empty($this->params['model-prefix'])) {
-	        $className = $this->_camelize($this->params['model-prefix']) . $className;
+            $className = $this->_camelize($this->params['model-prefix']) . $className;
         }
         
         $this->Test->plugin = $this->plugin;

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -1264,8 +1264,7 @@ class ModelTaskTest extends TestCase
      */
     public function testBakeTableWithModelPrefix()
     {
-
-        $this->Task->params['model-prefix'] = 'kaas';
+        $this->Task->params['model-prefix'] = 'test';
 
         $filename = $this->_normalizePath(APP . 'Model/Table/TestBakeArticlesTable.php');
         $this->Task->expects($this->once())->method('createFile')

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -1256,6 +1256,27 @@ class ModelTaskTest extends TestCase
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }
 
+
+     /**
+     * test bake() with a -model-prefix param
+     *
+     * @return void
+     */
+    public function testBakeTableWithModelPrefix()
+    {
+
+        $this->Task->params['model-prefix'] = 'kaas';
+
+        $filename = $this->_normalizePath(APP . 'Model/Table/TestBakeArticlesTable.php');
+        $this->Task->expects($this->once())->method('createFile')
+            ->with($filename, $this->stringContains('class TestBakeArticlesTable extends'));
+
+
+        $model = TableRegistry::get('BakeArticles');
+        $result = $this->Task->bakeTable($model);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
     /**
      * Tests baking a table with rules
      *

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -1257,7 +1257,7 @@ class ModelTaskTest extends TestCase
     }
 
 
-     /**
+    /**
      * test bake() with a -model-prefix param
      *
      * @return void


### PR DESCRIPTION
We are working with multiple databases, to prevent name conflicts we have to prefix the names of the table/Entity classes.  

I've added --model-prefix to add a prefix to the name of de classes.

example:
bin/cake bake model AccessTokens -c db_oauth --model-prefix oauth
