### PR TITLE
Fix fatal error when modelClass is null

### DIFF
--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -428,11 +428,14 @@ class TestTask extends BakeTask
      * Process a model recursively and pull out all the
      * model names converting them to fixture names.
      *
-     * @param Model $subject A Model class to scan for associations and pull fixtures off of.
+     * @param \Cake\ORM\Table $subject A Model class to scan for associations and pull fixtures off of.
      * @return void
      */
     protected function _processModel($subject)
     {
+        if (!$subject instanceof Table) {
+            return;
+        }
         $this->_addFixture($subject->alias());
         foreach ($subject->associations()->keys() as $alias) {
             $assoc = $subject->association($alias);

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -274,13 +274,27 @@ class TestTaskTest extends TestCase
      *
      * @return void
      */
-    public function testFixtureArrayGenerationFromController()
+    public function testFixtureGenerationFromController()
     {
         $subject = new PostsController(new Request(), new Response());
         $result = $this->Task->generateFixtureList($subject);
         $expected = [
             'app.posts',
         ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test generation of fixtures skips invalid modelClass
+     *
+     * @return void
+     */
+    public function testFixtureGenerationFromControllerInvalid()
+    {
+        $subject = new PostsController(new Request(), new Response());
+        $subject->modelClass = 'View';
+        $result = $this->Task->generateFixtureList($subject);
+        $expected = [];
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
When the controller's `modelClass` overlaps an existing public property, baking a test case would fail. We should be doing an instance check to prevent such errors. I've not used a typehint as those create fatal errors in PHP5 that we cannot catch.

Refs #254