### PR TITLE
Fix method signature for annotation

### DIFF
--- a/src/Template/Bake/Model/table.ctp
+++ b/src/Template/Bake/Model/table.ctp
@@ -27,7 +27,7 @@ $annotations[] = "@method \\{$namespace}\\Model\\Entity\\{$entity}[] newEntities
 $annotations[] = "@method \\{$namespace}\\Model\\Entity\\{$entity}|bool save(\\Cake\\Datasource\\EntityInterface \$entity, \$options = [])";
 $annotations[] = "@method \\{$namespace}\\Model\\Entity\\{$entity} patchEntity(\\Cake\\Datasource\\EntityInterface \$entity, array \$data, array \$options = [])";
 $annotations[] = "@method \\{$namespace}\\Model\\Entity\\{$entity}[] patchEntities(\$entities, array \$data, array \$options = [])";
-$annotations[] = "@method \\{$namespace}\\Model\\Entity\\{$entity} findOrCreate(\$search, callable \$callback = null)";
+$annotations[] = "@method \\{$namespace}\\Model\\Entity\\{$entity} findOrCreate(\$search, callable \$callback = null, \$options = [])";
 foreach ($behaviors as $behavior => $behaviorData) {
     $annotations[] = "@mixin \Cake\ORM\Behavior\\{$behavior}Behavior";
 }


### PR DESCRIPTION
PHPStorm complains about the signature, and there indeed is the options argument missing here when baking a Table class.