### PR TITLE
Make isRegex not rely on errors

### DIFF
--- a/src/View/BakeView.php
+++ b/src/View/BakeView.php
@@ -33,17 +33,21 @@ class BakeView extends View
      *
      * This config is read when evaluating a template file.
      *
-     * phpTagReplacements are applied to the contents of a bake template, to allow php tags
-     * to be treated as plain text
+     * - `phpTagReplacements` are applied to the contents of a bake template, to allow php tags
+     *   to be treated as plain text
+     * - `replacements` are applied in order on the template contents before the template is evaluated.
      *
-     * replacements are applied in order on the template contents before the template is evaluated
-     * In order these:
-     *     swallow leading whitespace for <%- tags
-     *     swallow trailing whitespace for -%> tags
-     *     Add an extra newline to <%=, to counteract php automatically removing a newline
-     *     Replace remaining <=% with php short echo tags
-     *     Replace <% with php open tags
-     *     Replace %> with php close tags
+     * The default replacements are (in the following order):
+     *
+     * - swallow leading whitespace for <%- tags
+     * - swallow trailing whitespace for -%> tags
+     * - Add an extra newline to <%=, to counteract php automatically removing a newline
+     * - Replace remaining <=% with php short echo tags
+     * - Replace <% with php open tags
+     * - Replace %> with php close tags
+     *
+     * Replacements that start with `/` will be treated as regex replacements.
+     * All other values will be treated used with str_replace()
      *
      * @var array
      */
@@ -244,10 +248,6 @@ class BakeView extends View
      */
     protected function _isRegex($maybeRegex)
     {
-        // @codingStandardsIgnoreStart
-        $isRegex = @preg_match($maybeRegex, '');
-        // @codingStandardsIgnoreEnd
-
-        return $isRegex !== false;
+        return substr($maybeRegex, 0, 1) === '/';
     }
 }

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
@@ -18,7 +18,7 @@ use Cake\Validation\Validator;
  * @method \App\Model\Entity\CategoriesProduct|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \App\Model\Entity\CategoriesProduct patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \App\Model\Entity\CategoriesProduct[] patchEntities($entities, array $data, array $options = [])
- * @method \App\Model\Entity\CategoriesProduct findOrCreate($search, callable $callback = null)
+ * @method \App\Model\Entity\CategoriesProduct findOrCreate($search, callable $callback = null, $options = [])
  */
 class CategoriesProductsTable extends Table
 {

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
@@ -17,7 +17,7 @@ use Cake\Validation\Validator;
  * @method \App\Model\Entity\Category|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \App\Model\Entity\Category patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \App\Model\Entity\Category[] patchEntities($entities, array $data, array $options = [])
- * @method \App\Model\Entity\Category findOrCreate($search, callable $callback = null)
+ * @method \App\Model\Entity\Category findOrCreate($search, callable $callback = null, $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */

--- a/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
@@ -15,7 +15,7 @@ use Cake\Validation\Validator;
  * @method \App\Model\Entity\OldProduct|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \App\Model\Entity\OldProduct patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \App\Model\Entity\OldProduct[] patchEntities($entities, array $data, array $options = [])
- * @method \App\Model\Entity\OldProduct findOrCreate($search, callable $callback = null)
+ * @method \App\Model\Entity\OldProduct findOrCreate($search, callable $callback = null, $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
@@ -17,7 +17,7 @@ use Cake\Validation\Validator;
  * @method \App\Model\Entity\ProductVersion|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \App\Model\Entity\ProductVersion patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \App\Model\Entity\ProductVersion[] patchEntities($entities, array $data, array $options = [])
- * @method \App\Model\Entity\ProductVersion findOrCreate($search, callable $callback = null)
+ * @method \App\Model\Entity\ProductVersion findOrCreate($search, callable $callback = null, $options = [])
  */
 class ProductVersionsTable extends Table
 {

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductsTable.php
@@ -18,7 +18,7 @@ use Cake\Validation\Validator;
  * @method \App\Model\Entity\Product|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \App\Model\Entity\Product patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \App\Model\Entity\Product[] patchEntities($entities, array $data, array $options = [])
- * @method \App\Model\Entity\Product findOrCreate($search, callable $callback = null)
+ * @method \App\Model\Entity\Product findOrCreate($search, callable $callback = null, $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -15,7 +15,7 @@ use Cake\Validation\Validator;
  * @method \App\Model\Entity\BakeArticle|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \App\Model\Entity\BakeArticle patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \App\Model\Entity\BakeArticle[] patchEntities($entities, array $data, array $options = [])
- * @method \App\Model\Entity\BakeArticle findOrCreate($search, callable $callback = null)
+ * @method \App\Model\Entity\BakeArticle findOrCreate($search, callable $callback = null, $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */

--- a/tests/comparisons/Model/testBakeTableRelations.php
+++ b/tests/comparisons/Model/testBakeTableRelations.php
@@ -20,7 +20,7 @@ use Cake\Validation\Validator;
  * @method \App\Model\Entity\BakeArticle|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \App\Model\Entity\BakeArticle patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \App\Model\Entity\BakeArticle[] patchEntities($entities, array $data, array $options = [])
- * @method \App\Model\Entity\BakeArticle findOrCreate($search, callable $callback = null)
+ * @method \App\Model\Entity\BakeArticle findOrCreate($search, callable $callback = null, $options = [])
  */
 class BakeArticlesTable extends Table
 {

--- a/tests/comparisons/Model/testBakeTableValidation.php
+++ b/tests/comparisons/Model/testBakeTableValidation.php
@@ -15,7 +15,7 @@ use Cake\Validation\Validator;
  * @method \App\Model\Entity\BakeArticle|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \App\Model\Entity\BakeArticle patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \App\Model\Entity\BakeArticle[] patchEntities($entities, array $data, array $options = [])
- * @method \App\Model\Entity\BakeArticle findOrCreate($search, callable $callback = null)
+ * @method \App\Model\Entity\BakeArticle findOrCreate($search, callable $callback = null, $options = [])
  */
 class BakeArticlesTable extends Table
 {

--- a/tests/comparisons/Model/testBakeTableWithPlugin.php
+++ b/tests/comparisons/Model/testBakeTableWithPlugin.php
@@ -15,7 +15,7 @@ use Cake\Validation\Validator;
  * @method \ModelTest\Model\Entity\BakeArticle|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \ModelTest\Model\Entity\BakeArticle patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \ModelTest\Model\Entity\BakeArticle[] patchEntities($entities, array $data, array $options = [])
- * @method \ModelTest\Model\Entity\BakeArticle findOrCreate($search, callable $callback = null)
+ * @method \ModelTest\Model\Entity\BakeArticle findOrCreate($search, callable $callback = null, $options = [])
  */
 class BakeArticlesTable extends Table
 {

--- a/tests/comparisons/Model/testBakeWithRules.php
+++ b/tests/comparisons/Model/testBakeWithRules.php
@@ -15,7 +15,7 @@ use Cake\Validation\Validator;
  * @method \App\Model\Entity\User|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \App\Model\Entity\User patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \App\Model\Entity\User[] patchEntities($entities, array $data, array $options = [])
- * @method \App\Model\Entity\User findOrCreate($search, callable $callback = null)
+ * @method \App\Model\Entity\User findOrCreate($search, callable $callback = null, $options = [])
  */
 class UsersTable extends Table
 {


### PR DESCRIPTION
Don't rely on errors to detect whether or not a pattern is a replacement. Also fix failing tests.

Refs cakephp/cakephp#9953