### PR TITLE
Fixing a bug that appears when trying to bake plugin models

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -175,6 +175,11 @@ class ModelTask extends BakeTask
      */
     public function getTableObject($className, $table)
     {
+        $plugin = $this->param('plugin');
+        if (!empty($plugin)) {
+            $className = $plugin . '.' . $className;
+        }
+
         if (TableRegistry::exists($className)) {
             return TableRegistry::get($className);
         }

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -181,6 +181,10 @@ class ModelTaskTest extends TestCase
         $this->assertInstanceOf('Cake\ORM\Table', $result);
         $this->assertEquals('bake_articles', $result->table());
         $this->assertEquals('Article', $result->alias());
+
+        $this->Task->params['plugin'] = 'BakeTest';
+        $result = $this->Task->getTableObject('Authors', 'bake_articles');
+        $this->assertInstanceOf('BakeTest\Model\Table\AuthorsTable', $result);
     }
 
     /**


### PR DESCRIPTION
This fixes a problem that happens when you already have an existing model of the same name in your app but want to bake one of the same name in your plugin. I've used as well the --table option. My main app is using an users table, now for a plugin I wanted to bake a Users model that is using the wp_users table from another DB. This was not possible without this change.

Tried this:

```sh
.\bin\cake bake model Users --table wp_fk_users -c wordpress -p Burzum/WpFrontend
```

Resulting in:

```sh
Error: [Cake\Database\Exception] SQLSTATE[42S02]: Base table or view not found: 1146 Table 'wordpressfk.users' doesn't exist
```