### PR TITLE
Don't generate unique validators for datetime fields.

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -670,7 +670,8 @@ class ModelTask extends BakeTask
                 continue;
             }
 
-            if ($constraint['type'] === SchemaTable::CONSTRAINT_UNIQUE) {
+            $notDatetime = !in_array($metaData['type'], ['datetime', 'timestamp', 'date', 'time']);
+            if ($constraint['type'] === SchemaTable::CONSTRAINT_UNIQUE && $notDatetime) {
                 $validation['unique'] = ['rule' => 'validateUnique', 'provider' => 'table'];
             }
         }

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -772,6 +772,27 @@ class ModelTaskTest extends TestCase
     }
 
     /**
+     * Test getting validation rules for unique date time columns
+     *
+     * @return void
+     */
+    public function testGetValidationUniqueDateField()
+    {
+        $model = TableRegistry::get('BakeComments');
+        $schema = $model->schema();
+        $schema
+            ->addColumn('release_date', ['type' => 'datetime'])
+            ->addConstraint('unique_date', [
+                'columns' => ['release_date'],
+                'type' => 'unique'
+            ]);
+        $result = $this->Task->getValidation($model);
+        $this->assertArrayHasKey('release_date', $result);
+        $expected = ['valid' => ['rule' => 'dateTime', 'allowEmpty' => false]];
+        $this->assertEquals($expected, $result['release_date']);
+    }
+
+    /**
      * test getting validation rules for tree-ish models
      *
      * @return void


### PR DESCRIPTION
Date & Time fields should how have unique validators generated, as the validator method doesn't work well on non-scalar fields.

Refs #299