### PR TITLE
Fix phpstan errors

### DIFF
--- a/src/Shell/Task/BakeTemplateTask.php
+++ b/src/Shell/Task/BakeTemplateTask.php
@@ -36,7 +36,7 @@ class BakeTemplateTask extends Shell
     /**
      * BakeView instance
      *
-     * @var \Cake\View\BakeView
+     * @var \Bake\View\BakeView
      */
     public $View;
 

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -953,13 +953,13 @@ class ModelTask extends BakeTask
             $this->err(
                 'Connections need to implement schemaCollection() to be used with bake.'
             );
-            $this->_stop();
+            return $this->_stop();
         }
         $schema = $db->schemaCollection();
         $tables = $schema->listTables();
         if (empty($tables)) {
             $this->err('Your database does not have any tables.');
-            $this->_stop();
+            return $this->_stop();
         }
         sort($tables);
 

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -953,12 +953,14 @@ class ModelTask extends BakeTask
             $this->err(
                 'Connections need to implement schemaCollection() to be used with bake.'
             );
+
             return $this->_stop();
         }
         $schema = $db->schemaCollection();
         $tables = $schema->listTables();
         if (empty($tables)) {
             $this->err('Your database does not have any tables.');
+
             return $this->_stop();
         }
         sort($tables);

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -953,15 +953,13 @@ class ModelTask extends BakeTask
             $this->err(
                 'Connections need to implement schemaCollection() to be used with bake.'
             );
-
-            return $this->_stop();
+            $this->_stop();
         }
         $schema = $db->schemaCollection();
         $tables = $schema->listTables();
         if (empty($tables)) {
             $this->err('Your database does not have any tables.');
-
-            return $this->_stop();
+            $this->_stop();
         }
         sort($tables);
 

--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -235,7 +235,7 @@ class TestTask extends BakeTask
         if (class_exists($fullClassName)) {
             $methods = $this->getTestableMethods($fullClassName);
         }
-        $mock = $this->hasMockClass($type, $fullClassName);
+        $mock = $this->hasMockClass($type);
         list($preConstruct, $construction, $postConstruct) = $this->generateConstructor($type, $fullClassName);
         $uses = $this->generateUses($type, $fullClassName);
 


### PR DESCRIPTION
Fixed some errors which came up with phpstan.

Wrong FQDN in a docblock.
`\Cake\Console\Shell::_stop();` throws an exception, so no need to return here.
`\Bake\Shell\Task\TestTask::hasMockClass ()` only accepts one parameter.


