### PR TITLE
Only print header if not empty.

### DIFF
--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -23,7 +23,11 @@ class DocBlockHelper extends Helper
      */
     public function classDescription($className, $classType, array $annotations)
     {
-        $lines = ["{$className} {$classType}", ""];
+        $lines = [];
+        if ($className && $classType) {
+            $lines[] = "{$className} {$classType}";
+            $lines[] = "";
+        }
 
         $previous = false;
         foreach ($annotations as $ann) {


### PR DESCRIPTION
Avoid half valid output if the class or type gets passed as empty string.

Worst case, if both are empty:
```
'/**
 *
 *
 * @var \App\View\AppView $this
 */
```
etc