### PR TITLE
Camelize each part of the plugin name.

### DIFF
--- a/src/Shell/Task/BakeTask.php
+++ b/src/Shell/Task/BakeTask.php
@@ -130,7 +130,8 @@ class BakeTask extends Shell
     public function main()
     {
         if (isset($this->params['plugin'])) {
-            $this->plugin = $this->params['plugin'];
+            $parts = explode('/', $this->params['plugin']);
+            $this->plugin = implode('/', array_map([$this, '_camelize'], $parts));
             if (strpos($this->plugin, '\\')) {
                 $this->abort('Invalid plugin namespace separator, please use / instead of \ for plugins.');
 

--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -68,7 +68,9 @@ class PluginTask extends BakeTask
 
             return false;
         }
-        $plugin = $this->_camelize($name);
+        $parts = explode('/', $name);
+        $plugin = implode('/', array_map([$this, '_camelize'], $parts));
+
         $pluginPath = $this->_pluginPath($plugin);
         if (is_dir($pluginPath)) {
             $this->out(sprintf('Plugin: %s already exists, no action taken', $plugin));

--- a/tests/TestCase/Shell/Task/ControllerTaskTest.php
+++ b/tests/TestCase/Shell/Task/ControllerTaskTest.php
@@ -90,6 +90,7 @@ class ControllerTaskTest extends TestCase
         TableRegistry::clear();
         parent::tearDown();
         Plugin::unload('ControllerTest');
+        Plugin::unload('Company/Pastry');
     }
 
     /**
@@ -439,5 +440,28 @@ class ControllerTaskTest extends TestCase
             )->will($this->returnValue(true));
 
         $this->Task->main('ControllerTest.BakeArticles');
+    }
+
+    /**
+     * test main with plugin.name
+     *
+     * @return void
+     */
+    public function testMainWithPluginOption()
+    {
+        $this->Task->connection = 'test';
+        $this->Task->params['plugin'] = 'company/pastry';
+
+        Plugin::load('Company/Pastry', ['path' => APP . 'Plugin/Company/Pastry/']);
+        $path = APP . 'Plugin/Company/Pastry/src/Controller/BakeArticlesController.php';
+
+        $this->Task->expects($this->at(1))
+            ->method('createFile')
+            ->with(
+                $this->_normalizePath($path),
+                $this->stringContains('BakeArticlesController extends AppController')
+            )->will($this->returnValue(true));
+
+        $this->Task->main('bake_articles');
     }
 }

--- a/tests/TestCase/Shell/Task/PluginTaskTest.php
+++ b/tests/TestCase/Shell/Task/PluginTaskTest.php
@@ -143,6 +143,20 @@ class PluginTaskTest extends TestCase
     }
 
     /**
+     * test main with vendor plugin and incorrect casing
+     *
+     * @return void
+     */
+    public function testMainVendorNameCasingFix()
+    {
+        $this->Task->expects($this->at(0))->method('in')
+            ->will($this->returnValue('y'));
+
+        $this->Task->main('company/example');
+        $this->assertPluginContents('Company/Example');
+    }
+
+    /**
      * With no args, main should do nothing
      *
      * @return void


### PR DESCRIPTION
Make it safer to generate plugins by automatically fixing the name/namespace/directories that bake will generate.

Also update tasks that use the `--plugin` option and autocorrect camelization there as well.

Refs #351