### PR TITLE
Reinstate accessible field generation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 
 env:
   matrix:
-    - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+    - DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test'
     - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
     - DB=sqlite db_dsn='sqlite:///:memory:'
   global:

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -647,8 +647,19 @@ class ModelTaskTest extends TestCase
     public function testGetFields()
     {
         $model = TableRegistry::get('BakeArticles');
+        $model->belongsTo('BakeUser');
+
         $result = $this->Task->getFields($model);
-        $this->assertNull($result);
+        $expected = [
+            'bake_user_id',
+            'title',
+            'body',
+            'published',
+            'created',
+            'updated',
+            'bake_user',
+        ];
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1164,6 +1175,20 @@ class ModelTaskTest extends TestCase
         $result = $this->Task->bakeEntity($model, $config);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }
+
+    /**
+     * test baking an entity class
+     *
+     * @return void
+     */
+    public function testBakeEntityFullContext()
+    {
+        $model = TableRegistry::get('BakeArticles');
+        $context = $this->Task->getTableContext($model, 'bake_articles', 'BakeArticles');
+        $result = $this->Task->bakeEntity($model, $context);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
 
     /**
      * test baking an entity with DocBlock property type hints.

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -1189,7 +1189,6 @@ class ModelTaskTest extends TestCase
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }
 
-
     /**
      * test baking an entity with DocBlock property type hints.
      *

--- a/tests/comparisons/Model/testBakeEntityFullContext.php
+++ b/tests/comparisons/Model/testBakeEntityFullContext.php
@@ -1,0 +1,44 @@
+<?php
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * BakeArticle Entity
+ *
+ * @property int $id
+ * @property int $bake_user_id
+ * @property string $title
+ * @property string $body
+ * @property bool $published
+ * @property \Cake\I18n\Time $created
+ * @property \Cake\I18n\Time $updated
+ *
+ * @property \App\Model\Entity\BakeUser $bake_user
+ * @property \App\Model\Entity\BakeComment[] $bake_comments
+ * @property \App\Model\Entity\BakeTag[] $bake_tags
+ */
+class BakeArticle extends Entity
+{
+
+    /**
+     * Fields that can be mass assigned using newEntity() or patchEntity().
+     *
+     * Note that when '*' is set to true, this allows all unspecified fields to
+     * be mass assigned. For security purposes, it is advised to set '*' to false
+     * (or remove it), and explicitly make individual fields accessible as needed.
+     *
+     * @var array
+     */
+    protected $_accessible = [
+        'bake_user_id' => true,
+        'title' => true,
+        'body' => true,
+        'published' => true,
+        'created' => true,
+        'updated' => true,
+        'bake_user' => true,
+        'bake_comments' => true,
+        'bake_tags' => true
+    ];
+}


### PR DESCRIPTION
This was removed in #134 to make adding new fields to the database easier for new developers. This created a tradeoff with more secure defaults. I'd like to re-add more secure defaults alongside warning log messages in the marshaller during debug mode to help new developers.