### PR TITLE
fix detect Controller name

### DIFF
--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -348,7 +348,7 @@ class TestTask extends BakeTask
         if ($suffix && strpos($class, $suffix) === false) {
             $class .= $suffix;
         }
-        if ($type === 'controller' && $this->param('prefix')) {
+        if (strtolower($type) === 'controller' && $this->param('prefix')) {
             $subSpace .= '\\' . Inflector::camelize($this->param('prefix'));
         }
 


### PR DESCRIPTION
invalid result  when using 
`bin/cake bake test Controller Users --prefix=Admin`
but when using `controller` instead of  `Controller`
returned true result 