### PR TITLE
Remove dead task.

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -40,7 +40,6 @@ class ModelTask extends BakeTask
      * @var array
      */
     public $tasks = [
-        'Bake.DbConfig',
         'Bake.Fixture',
         'Bake.BakeTemplate',
         'Bake.Test'


### PR DESCRIPTION
This task does not seem to exist..
My annotator tripped over it.

PS: This should actually throw an exception (3.6+?)! Loading invalid tasks and silently doing nothing sounds like a bad idea.