### PR TITLE
Improve IDE compatibility by providing property annotations for tasks.

### DIFF
--- a/src/Shell/Task/BehaviorTask.php
+++ b/src/Shell/Task/BehaviorTask.php
@@ -16,6 +16,9 @@ namespace Bake\Shell\Task;
 
 /**
  * Behavior code generator.
+ *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class BehaviorTask extends SimpleBakeTask
 {

--- a/src/Shell/Task/CellTask.php
+++ b/src/Shell/Task/CellTask.php
@@ -16,6 +16,9 @@ namespace Bake\Shell\Task;
 
 /**
  * Task for creating cells.
+ *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class CellTask extends SimpleBakeTask
 {

--- a/src/Shell/Task/ComponentTask.php
+++ b/src/Shell/Task/ComponentTask.php
@@ -16,6 +16,9 @@ namespace Bake\Shell\Task;
 
 /**
  * Component code generator.
+ *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class ComponentTask extends SimpleBakeTask
 {

--- a/src/Shell/Task/ControllerTask.php
+++ b/src/Shell/Task/ControllerTask.php
@@ -21,6 +21,9 @@ use Cake\ORM\TableRegistry;
 /**
  * Task class for creating and updating controller files.
  *
+ * @property \Bake\Shell\Task\ModelTask $Model
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class ControllerTask extends BakeTask
 {

--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -26,6 +26,9 @@ use DateTimeInterface;
 
 /**
  * Task class for creating and updating fixtures files.
+ *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\ModelTask $Model
  */
 class FixtureTask extends BakeTask
 {

--- a/src/Shell/Task/FormTask.php
+++ b/src/Shell/Task/FormTask.php
@@ -16,6 +16,9 @@ namespace Bake\Shell\Task;
 
 /**
  * ShellHelper code generator.
+ *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class FormTask extends SimpleBakeTask
 {

--- a/src/Shell/Task/HelperTask.php
+++ b/src/Shell/Task/HelperTask.php
@@ -16,6 +16,9 @@ namespace Bake\Shell\Task;
 
 /**
  * Helper code generator.
+ *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class HelperTask extends SimpleBakeTask
 {

--- a/src/Shell/Task/MailerTask.php
+++ b/src/Shell/Task/MailerTask.php
@@ -18,6 +18,9 @@ use Cake\Utility\Inflector;
 
 /**
  * Mailer code generator.
+ *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class MailerTask extends SimpleBakeTask
 {

--- a/src/Shell/Task/MiddlewareTask.php
+++ b/src/Shell/Task/MiddlewareTask.php
@@ -16,6 +16,9 @@ namespace Bake\Shell\Task;
 
 /**
  * Middleware code generator.
+ *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class MiddlewareTask extends SimpleBakeTask
 {

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -24,6 +24,10 @@ use Cake\Utility\Inflector;
 
 /**
  * Task class for generating model files.
+ *
+ * @property \Bake\Shell\Task\FixtureTask $Fixture
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class ModelTask extends BakeTask
 {

--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -24,6 +24,7 @@ use Cake\Utility\Inflector;
 /**
  * The Plugin Task handles creating an empty plugin, ready to be used
  *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
  */
 class PluginTask extends BakeTask
 {

--- a/src/Shell/Task/ShellHelperTask.php
+++ b/src/Shell/Task/ShellHelperTask.php
@@ -16,6 +16,9 @@ namespace Bake\Shell\Task;
 
 /**
  * ShellHelper code generator.
+ *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class ShellHelperTask extends SimpleBakeTask
 {

--- a/src/Shell/Task/ShellTask.php
+++ b/src/Shell/Task/ShellTask.php
@@ -16,6 +16,9 @@ namespace Bake\Shell\Task;
 
 /**
  * Shell code generator.
+ *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class ShellTask extends SimpleBakeTask
 {

--- a/src/Shell/Task/TaskTask.php
+++ b/src/Shell/Task/TaskTask.php
@@ -16,6 +16,9 @@ namespace Bake\Shell\Task;
 
 /**
  * Shell Task code generator.
+ *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
+ * @property \Bake\Shell\Task\TestTask $Test
  */
 class TaskTask extends SimpleBakeTask
 {

--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -26,6 +26,8 @@ use Cake\Utility\Inflector;
 /**
  * Task class for creating and updating view template files.
  *
+ * @property \Bake\Shell\Task\ModelTask $Model
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
  */
 class TemplateTask extends BakeTask
 {

--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -31,6 +31,7 @@ use ReflectionClass;
 /**
  * Task class for creating and updating test files.
  *
+ * @property \Bake\Shell\Task\BakeTemplateTask $BakeTemplate
  */
 class TestTask extends BakeTask
 {


### PR DESCRIPTION
Using the new IdeHelper feature for tasks: https://github.com/dereuromark/cakephp-ide-helper/pull/62 :

    bin/cake annotations shells -v -r -p Bake
