### PR TITLE
Sync with ide-helper fixing.

### DIFF
--- a/src/Template/Bake/Template/add.ctp
+++ b/src/Template/Bake/Template/add.ctp
@@ -16,6 +16,7 @@
 <?php
 /**
  * @var \<%= $namespace %>\View\AppView $this
+ * @var \<%= $entityClass %> $<%= $singularVar %>
  */
 ?>
 <%= $this->element('form');

--- a/src/Template/Bake/Template/edit.ctp
+++ b/src/Template/Bake/Template/edit.ctp
@@ -16,6 +16,7 @@
 <?php
 /**
  * @var \<%= $namespace %>\View\AppView $this
+ * @var \<%= $entityClass %> $<%= $singularVar %>
  */
 ?>
 <%= $this->element('form');

--- a/tests/comparisons/Template/testBakeEdit.ctp
+++ b/tests/comparisons/Template/testBakeEdit.ctp
@@ -1,6 +1,7 @@
 <?php
 /**
  * @var \Bake\Test\App\View\AppView $this
+ * @var \Cake\Datasource\EntityInterface $author
  */
 ?>
 <nav class="large-3 medium-4 columns" id="actions-sidebar">

--- a/tests/comparisons/Template/testGetContentWithRoutingPrefix-add.ctp
+++ b/tests/comparisons/Template/testGetContentWithRoutingPrefix-add.ctp
@@ -1,6 +1,7 @@
 <?php
 /**
  * @var \Bake\Test\App\View\AppView $this
+ * @var \Bake\Test\App\Model\Entity\TestTemplateModel $testTemplateModel
  */
 ?>
 <nav class="large-3 medium-4 columns" id="actions-sidebar">


### PR DESCRIPTION
Forms also contain entity usage:

    $this->Form->create($moduleCleanup)

The following diff is produced after "baking" and then running the [ide helper](https://github.com/dereuromark/cakephp-ide-helper/) "annotations generate":
```
/src/Template/ModuleCleanups
-> add
   |   * @var \App\View\AppView $this
   | + * @var \App\Model\Entity\ModuleCleanup $moduleCleanup
   |   */
   -> 1 annotation added.
-> edit
   |   * @var \App\View\AppView $this
   | + * @var \App\Model\Entity\ModuleCleanup $moduleCleanup
   |   */
   -> 1 annotation added.
```

With this both produce the same output - no diff anymore :)