### PR TITLE
Move CommonOptionsTrait.

### DIFF
--- a/src/Shell/BakeShell.php
+++ b/src/Shell/BakeShell.php
@@ -14,6 +14,7 @@
  */
 namespace Bake\Shell;
 
+use Bake\Utility\CommonOptionsTrait;
 use Cake\Cache\Cache;
 use Cake\Console\Shell;
 use Cake\Core\Configure;

--- a/src/Shell/Task/BakeTask.php
+++ b/src/Shell/Task/BakeTask.php
@@ -14,7 +14,7 @@
  */
 namespace Bake\Shell\Task;
 
-use Bake\Shell\CommonOptionsTrait;
+use Bake\Utility\CommonOptionsTrait;
 use Cake\Cache\Cache;
 use Cake\Console\Shell;
 use Cake\Core\Configure;

--- a/src/Utility/CommonOptionsTrait.php
+++ b/src/Utility/CommonOptionsTrait.php
@@ -12,7 +12,7 @@
  * @since         1.4.3
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Bake\Shell;
+namespace Bake\Utility;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;


### PR DESCRIPTION
This fixes a compatibility issue that will exist for all of 3.5.x so I think fixing bake is the better option. I'll also fix up the CommandScanner so this doesn't happen in the future.

Refs cakephp/cakephp#11326