### PR TITLE
Remove duplicate prefix name being applied.

### DIFF
--- a/src/Shell/Task/ControllerTask.php
+++ b/src/Shell/Task/ControllerTask.php
@@ -209,10 +209,6 @@ class ControllerTask extends BakeTask
         }
         $this->Test->plugin = $this->plugin;
         $this->Test->connection = $this->connection;
-        $prefix = $this->_getPrefix();
-        if ($prefix) {
-            $className = str_replace('/', '\\', $prefix) . '\\' . $className;
-        }
 
         return $this->Test->bake('Controller', $className);
     }

--- a/tests/TestCase/Shell/Task/ControllerTaskTest.php
+++ b/tests/TestCase/Shell/Task/ControllerTaskTest.php
@@ -245,7 +245,7 @@ class ControllerTaskTest extends TestCase
 
         $this->Task->Test->expects($this->at(0))
             ->method('bake')
-            ->with('Controller', 'Admin\BakeArticles');
+            ->with('Controller', 'BakeArticles');
         $result = $this->Task->bake('BakeArticles');
 
         $this->assertTextContains('namespace App\Controller\Admin;', $result);
@@ -268,7 +268,7 @@ class ControllerTaskTest extends TestCase
 
         $this->Task->Test->expects($this->at(0))
             ->method('bake')
-            ->with('Controller', 'Admin\Management\BakeArticles');
+            ->with('Controller', 'BakeArticles');
         $result = $this->Task->bake('BakeArticles');
 
         $this->assertTextContains('namespace App\Controller\Admin\Management;', $result);


### PR DESCRIPTION
In #361 the type check was fixed which resulted in prefixed controllers having their prefixes doubled when tests were generated. By removing the code in ControllerTask tests generate correctly again.

Refs #377