### PR TITLE
Remove argument typehint.

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -694,7 +694,7 @@ class ModelTask extends BakeTask
      * @param array $primaryKey The primary key field
      * @return array Array of validation for the field.
      */
-    public function fieldValidation($schema, $fieldName, array $metaData, array $primaryKey)
+    public function fieldValidation($schema, $fieldName, array $metaData, $primaryKey)
     {
         $ignoreFields = ['lft', 'rght', 'created', 'modified', 'updated'];
         if (in_array($fieldName, $ignoreFields)) {


### PR DESCRIPTION
This ensures method signature's backwards compatibility. Refs #380