### PR TITLE
Fix array expectation via cast.

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -694,7 +694,7 @@ class ModelTask extends BakeTask
      * @param array $primaryKey The primary key field
      * @return array Array of validation for the field.
      */
-    public function fieldValidation($schema, $fieldName, array $metaData, $primaryKey)
+    public function fieldValidation($schema, $fieldName, array $metaData, array $primaryKey)
     {
         $ignoreFields = ['lft', 'rght', 'created', 'modified', 'updated'];
         if (in_array($fieldName, $ignoreFields)) {

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -694,7 +694,7 @@ class ModelTask extends BakeTask
      * @param array $primaryKey The primary key field
      * @return array Array of validation for the field.
      */
-    public function fieldValidation($schema, $fieldName, array $metaData, array $primaryKey)
+    public function fieldValidation($schema, $fieldName, array $metaData, $primaryKey)
     {
         $ignoreFields = ['lft', 'rght', 'created', 'modified', 'updated'];
         if (in_array($fieldName, $ignoreFields)) {
@@ -731,7 +731,7 @@ class ModelTask extends BakeTask
             }
         }
 
-        if (in_array($fieldName, $primaryKey)) {
+        if (in_array($fieldName, (array)$primaryKey)) {
             $rules['allowEmpty'] = ['create'];
         } elseif ($metaData['null'] === true) {
             $rules['allowEmpty'] = [];


### PR DESCRIPTION
Reverts cakephp/bake#382

as I explained already to @ADmad in the comment to the original and valid change to add the typehint, the internal code expects the array, thus this revert here was invalid and a bad idea.
BC has nothing to do with this :)

See if (in_array($fieldName, $primaryKey)) { usage.