### PR TITLE
Made generated templates more easier to localize

### DIFF
--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -300,6 +300,10 @@ class TemplateTask extends BakeTask
         $singularHumanName = $this->_singularHumanName($this->controllerName);
         $schema = $modelObject->getSchema();
         $fields = $schema->columns();
+        $fieldHumanNames = [];
+        foreach ($fields as $field) {
+            $fieldHumanNames[$field] = Inflector::humanize($field);
+        }
         $modelClass = $this->modelName;
 
         list(, $entityClass) = namespaceSplit($this->_entityName($this->modelName));
@@ -330,6 +334,7 @@ class TemplateTask extends BakeTask
             'singularHumanName',
             'pluralHumanName',
             'fields',
+            'fieldHumanNames',
             'associations',
             'keyFields',
             'namespace'

--- a/src/Template/Bake/Element/form.twig
+++ b/src/Template/Bake/Element/form.twig
@@ -49,10 +49,10 @@
     {%- if keyFields[field] %}
         {%- set fieldData = Bake.columnData(field, schema) %}
         {%- if fieldData.null %}
-            echo $this->Form->control('{{ field }}', ['options' => ${{ keyFields[field] }}, 'empty' => true]);
+            echo $this->Form->control('{{ field }}', ['options' => ${{ keyFields[field] }}, 'empty' => true, 'label' => __('{{ fieldHumanNames[field] }}')]);
             {{- "\n" }}
         {%- else %}
-            echo $this->Form->control('{{ field }}', ['options' => ${{ keyFields[field] }}]);
+            echo $this->Form->control('{{ field }}', ['options' => ${{ keyFields[field] }}, 'label' => __('{{ fieldHumanNames[field] }}')]);
             {{- "\n" }}
         {%- endif %}
     {%- elseif field not in ['created', 'modified', 'updated'] %}
@@ -61,7 +61,7 @@
             echo $this->Form->control('{{ field }}', ['empty' => true]);
             {{- "\n" }}
         {%- else %}
-            echo $this->Form->control('{{ field }}');
+            echo $this->Form->control('{{ field }}', ['label' => __('{{fieldHumanNames[field]}}')]);
     {{- "\n" }}
         {%- endif %}
     {%- endif %}

--- a/src/Template/Bake/Template/index.twig
+++ b/src/Template/Bake/Template/index.twig
@@ -42,7 +42,7 @@
         <thead>
             <tr>
 {% for field in fields %}
-                <th scope="col"><?= $this->Paginator->sort('{{ field }}') ?></th>
+                <th scope="col"><?= $this->Paginator->sort('{{ field }}', ['label' => __('{{ fieldHumanNames[field] }}')]) ?></th>
 {% endfor %}
                 <th scope="col" class="actions"><?= __('Actions') ?></th>
             </tr>

--- a/tests/comparisons/Template/testBakeEdit.ctp
+++ b/tests/comparisons/Template/testBakeEdit.ctp
@@ -27,12 +27,12 @@
     <fieldset>
         <legend><?= __('Edit Author') ?></legend>
         <?php
-            echo $this->Form->control('role_id', ['options' => $roles]);
-            echo $this->Form->control('name');
-            echo $this->Form->control('description');
-            echo $this->Form->control('member');
-            echo $this->Form->control('member_number');
-            echo $this->Form->control('account_balance');
+            echo $this->Form->control('role_id', ['options' => $roles, 'label' => __('Role Id')]);
+            echo $this->Form->control('name', ['label' => __('Name')]);
+            echo $this->Form->control('description', ['label' => __('Description')]);
+            echo $this->Form->control('member', ['label' => __('Member')]);
+            echo $this->Form->control('member_number', ['label' => __('Member Number')]);
+            echo $this->Form->control('account_balance', ['label' => __('Account Balance')]);
         ?>
     </fieldset>
     <?= $this->Form->button(__('Submit')) ?>

--- a/tests/comparisons/Template/testBakeIndex.ctp
+++ b/tests/comparisons/Template/testBakeIndex.ctp
@@ -17,12 +17,12 @@
     <table cellpadding="0" cellspacing="0">
         <thead>
             <tr>
-                <th scope="col"><?= $this->Paginator->sort('id') ?></th>
-                <th scope="col"><?= $this->Paginator->sort('article_id') ?></th>
-                <th scope="col"><?= $this->Paginator->sort('user_id') ?></th>
-                <th scope="col"><?= $this->Paginator->sort('published') ?></th>
-                <th scope="col"><?= $this->Paginator->sort('created') ?></th>
-                <th scope="col"><?= $this->Paginator->sort('updated') ?></th>
+                <th scope="col"><?= $this->Paginator->sort('id', ['label' => __('Id')]) ?></th>
+                <th scope="col"><?= $this->Paginator->sort('article_id', ['label' => __('Article Id')]) ?></th>
+                <th scope="col"><?= $this->Paginator->sort('user_id', ['label' => __('User Id')]) ?></th>
+                <th scope="col"><?= $this->Paginator->sort('published', ['label' => __('Published')]) ?></th>
+                <th scope="col"><?= $this->Paginator->sort('created', ['label' => __('Created')]) ?></th>
+                <th scope="col"><?= $this->Paginator->sort('updated', ['label' => __('Updated')]) ?></th>
                 <th scope="col" class="actions"><?= __('Actions') ?></th>
             </tr>
         </thead>

--- a/tests/comparisons/Template/testBakeIndexWithIndexLimit.ctp
+++ b/tests/comparisons/Template/testBakeIndexWithIndexLimit.ctp
@@ -17,9 +17,9 @@
     <table cellpadding="0" cellspacing="0">
         <thead>
             <tr>
-                <th scope="col"><?= $this->Paginator->sort('id') ?></th>
-                <th scope="col"><?= $this->Paginator->sort('article_id') ?></th>
-                <th scope="col"><?= $this->Paginator->sort('user_id') ?></th>
+                <th scope="col"><?= $this->Paginator->sort('id', ['label' => __('Id')]) ?></th>
+                <th scope="col"><?= $this->Paginator->sort('article_id', ['label' => __('Article Id')]) ?></th>
+                <th scope="col"><?= $this->Paginator->sort('user_id', ['label' => __('User Id')]) ?></th>
                 <th scope="col" class="actions"><?= __('Actions') ?></th>
             </tr>
         </thead>

--- a/tests/comparisons/Template/testGetContentWithRoutingPrefix-add.ctp
+++ b/tests/comparisons/Template/testGetContentWithRoutingPrefix-add.ctp
@@ -15,8 +15,8 @@
     <fieldset>
         <legend><?= __('Add Test Template Model') ?></legend>
         <?php
-            echo $this->Form->control('name');
-            echo $this->Form->control('body');
+            echo $this->Form->control('name', ['label' => __('')]);
+            echo $this->Form->control('body', ['label' => __('')]);
         ?>
     </fieldset>
     <?= $this->Form->button(__('Submit')) ?>


### PR DESCRIPTION
Added labels containing the humanized field names to the generated templates:
- To the add/edit form's inputs
- To the paginator header links in the index

As the displayed strings in the generated contents are localizable I think the fields names should be localizable as well. 