### PR TITLE
Fix `bake template index listing` not generating the right file.

### DIFF
--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -70,13 +70,6 @@ class TemplateTask extends BakeTask
     public $modelName = null;
 
     /**
-     * The template file to use
-     *
-     * @var string
-     */
-    public $template = null;
-
-    /**
      * Actions to use for scaffolding
      *
      * @var array
@@ -120,7 +113,7 @@ class TemplateTask extends BakeTask
      *
      * @param string|null $name The name of the controller to bake view templates for.
      * @param string|null $template The template to bake with.
-     * @param string|null $action The action to bake with.
+     * @param string|null $action The output action name. Defaults to $template.
      * @return mixed
      */
     public function main($name = null, $template = null, $action = null)
@@ -145,14 +138,11 @@ class TemplateTask extends BakeTask
         $this->controller($name, $controller);
         $this->model($name);
 
-        if (isset($template)) {
-            $this->template = $template;
+        if ($template && $action === null) {
+            $action = $template;
         }
-        if (!$action) {
-            $action = $this->template;
-        }
-        if ($action) {
-            return $this->bake($action, true);
+        if ($template) {
+            return $this->bake($template, true, $action);
         }
 
         $vars = $this->_loadController();
@@ -396,23 +386,27 @@ class TemplateTask extends BakeTask
     /**
      * Assembles and writes bakes the view file.
      *
-     * @param string $action Action to bake.
+     * @param string $template Template file to use.
      * @param string $content Content to write.
+     * @param string $outputFile The output file to create. If null will use `$template`
      * @return string|false Generated file content.
      */
-    public function bake($action, $content = '')
+    public function bake($template, $content = '', $outputFile = null)
     {
+        if ($outputFile === null) {
+            $outputFile = $template;
+        }
         if ($content === true) {
-            $content = $this->getContent($action);
+            $content = $this->getContent($template);
         }
         if (empty($content)) {
-            $this->err("<warning>No generated content for '{$action}.ctp', not generating template.</warning>");
+            $this->err("<warning>No generated content for '{$template}.ctp', not generating template.</warning>");
 
             return false;
         }
-        $this->out("\n" . sprintf('Baking `%s` view template file...', $action), 1, Shell::QUIET);
+        $this->out("\n" . sprintf('Baking `%s` view template file...', $outputFile), 1, Shell::QUIET);
         $path = $this->getPath();
-        $filename = $path . Inflector::underscore($action) . '.ctp';
+        $filename = $path . Inflector::underscore($outputFile) . '.ctp';
         $this->createFile($filename, $content);
 
         return $content;

--- a/tests/TestCase/Shell/Task/TemplateTaskTest.php
+++ b/tests/TestCase/Shell/Task/TemplateTaskTest.php
@@ -715,7 +715,7 @@ class TemplateTaskTest extends TestCase
 
         $this->Task->expects($this->once())
             ->method('bake')
-            ->with('view', true);
+            ->with('view', true, 'view');
 
         $this->Task->main('TemplateTaskComments', 'view');
     }
@@ -836,14 +836,18 @@ class TemplateTaskTest extends TestCase
      */
     public function testMainWithAlternateTemplates()
     {
-        $this->_setupTask(['in', 'err', 'createFile', 'bake', '_stop']);
+        $this->_setupTask(['in', 'err', 'createFile', '_stop']);
 
         $this->Task->connection = 'test';
         $this->Task->params = [];
 
         $this->Task->expects($this->once())
-            ->method('bake')
-            ->with('list', true);
+            ->method('createFile')
+            ->with(
+                $this->_normalizePath(APP . 'Template/TemplateTaskComments/list.ctp'),
+                $this->stringContains('Template Task Comments')
+            );
+
         $this->Task->main('TemplateTaskComments', 'index', 'list');
     }
 }


### PR DESCRIPTION
Previously bake would use the `listing.twig` and created `index.ctp` when it should have used `index.twig` and created `listing.ctp` based on the help information.

This currently causes a strict error with TwigView, but I'll be opening a pull request to fix that as well.

Refs #395