### PR TITLE
Fixes baking controller tests with prefix option

### DIFF
--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -349,8 +349,9 @@ class TestTask extends BakeTask
         if ($suffix && strpos($class, $suffix) === false) {
             $class .= $suffix;
         }
-        if (strtolower($type) === 'controller' && $this->param('prefix')) {
-            $subSpace .= '\\' . Inflector::camelize($this->param('prefix'));
+        $prefix = $this->_getPrefix();
+        if (strtolower($type) === 'controller' && $prefix) {
+            $subSpace .= '\\' . str_replace('/', '\\', $prefix);
         }
 
         return $namespace . '\\' . $subSpace . '\\' . $class;

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -363,6 +363,19 @@ class TestTaskTest extends TestCase
     }
 
     /**
+     * test resolving class names with prefix
+     *
+     * @return void
+     */
+    public function testGetRealClassnamePrefix()
+    {
+        $this->Task->params['prefix'] = 'Api/Public';
+        $result = $this->Task->getRealClassname('Controller', 'Posts');
+        $expected = 'App\Controller\Api\Public\PostsController';
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test baking a test for a concrete model with fixtures arg
      *
      * @return void

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -369,7 +369,7 @@ class TestTaskTest extends TestCase
      */
     public function testGetRealClassnamePrefix()
     {
-        $this->Task->params['prefix'] = 'Api/Public';
+        $this->Task->params['prefix'] = 'api/public';
         $result = $this->Task->getRealClassname('Controller', 'Posts');
         $expected = 'App\Controller\Api\Public\PostsController';
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
A test case is generated in the incorrect namespace when the `prefix` option is specified when baking the controller.

eg:

```
bin/cake bake controller --prefix Api/Public Posts
```

I expected:

tests/TestCase/Controller/Api/Public/PostsControllerTest.php

```
<?php
namespace App\Test\TestCase\Controller\Api\Public;
```


Actually I got:

```
<?php
namespace App\Test\TestCase\Controller\Api/Public;
```
