### PR TITLE
Fix up non interactive mode using -q quit and -f force params.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "cakephp/cakephp": "^3.5",
+        "cakephp/cakephp": "^3.5.10",
         "cakephp/plugin-installer": "^1.0",
         "wyrihaximus/twig-view": "^4.2.1"
     },

--- a/src/Shell/BakeShell.php
+++ b/src/Shell/BakeShell.php
@@ -73,6 +73,13 @@ class BakeShell extends Shell
         if (isset($this->params['connection'])) {
             $this->connection = $this->params['connection'];
         }
+
+        if ($this->params['quiet']) {
+            $this->interactive = false;
+            if (isset($this->{$task}) && !in_array($task, ['Project'])) {
+                $this->{$task}->interactive = false;
+            }
+        }
     }
 
     /**
@@ -261,6 +268,7 @@ class BakeShell extends Shell
             $filteredTables->each(function ($tableName) use ($task) {
                 $tableName = $this->_camelize($tableName);
                 $this->{$task}->connection = $this->connection;
+                $this->{$task}->interactive = $this->interactive;
                 $this->{$task}->main($tableName);
             });
         }
@@ -288,7 +296,7 @@ class BakeShell extends Shell
             'help' => 'Bake a complete MVC skeleton.',
         ])->addOption('everything', [
             'help' => 'Bake a complete MVC skeleton, using all the available tables. ' .
-            'Usage: "bake all --everything"',
+                'Usage: "bake all --everything"',
             'default' => false,
             'boolean' => true,
         ])->addOption('prefix', [
@@ -302,6 +310,7 @@ class BakeShell extends Shell
 
         foreach ($this->_taskMap as $task => $config) {
             $taskParser = $this->{$task}->getOptionParser();
+            $this->{$task}->interactive = $this->interactive;
             $parser->addSubcommand(Inflector::underscore($task), [
                 'help' => $taskParser->getDescription(),
                 'parser' => $taskParser

--- a/src/Shell/Task/ControllerTask.php
+++ b/src/Shell/Task/ControllerTask.php
@@ -209,6 +209,7 @@ class ControllerTask extends BakeTask
         }
         $this->Test->plugin = $this->plugin;
         $this->Test->connection = $this->connection;
+        $this->Test->interactive = $this->interactive;
 
         return $this->Test->bake('Controller', $className);
     }

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -1134,6 +1134,7 @@ class ModelTask extends BakeTask
         }
         $this->Fixture->connection = $this->connection;
         $this->Fixture->plugin = $this->plugin;
+        $this->Fixture->interactive = $this->interactive;
         $this->Fixture->bake($className, $useTable);
     }
 
@@ -1149,6 +1150,7 @@ class ModelTask extends BakeTask
             return null;
         }
         $this->Test->plugin = $this->plugin;
+        $this->Test->interactive = $this->interactive;
         $this->Test->connection = $this->connection;
 
         return $this->Test->bake('Table', $className);

--- a/tests/TestCase/Shell/BakeShellTest.php
+++ b/tests/TestCase/Shell/BakeShellTest.php
@@ -265,15 +265,6 @@ class BakeShellTest extends TestCase
         $path = APP;
         $testsPath = ROOT . 'tests' . DS;
 
-        $existingFile = $path . 'Controller/CommentsController.php';
-        $this->assertFileExists($existingFile);
-        $content = file_get_contents($existingFile);
-
-        $this->Shell->runCommand(['all', 'Comments'], false, ['quiet' => true]);
-        $output = $this->out->messages();
-
-        $this->assertContains('<success>Bake All complete.</success>', implode(' ', $output));
-
         // We ignore our existing CommentsController test file
         $files = [
             $path . 'Template/Comments/add.ctp',
@@ -286,12 +277,24 @@ class BakeShellTest extends TestCase
             $testsPath . 'TestCase/Model/Table/CommentsTableTest.php',
             $testsPath . 'TestCase/Controller/CommentsControllerTest.php',
         ];
+        foreach ($files as $file) {
+            $this->assertFileNotExists($file, 'File should not yet exist before `bake all`.');
+        }
+
+        $existingFile = $path . 'Controller/CommentsController.php';
+        $this->assertFileExists($existingFile);
+        $content = file_get_contents($existingFile);
+
+        $this->Shell->runCommand(['all', 'Comments'], false, ['quiet' => true]);
+        $output = $this->out->messages();
+
+        $this->assertContains('<success>Bake All complete.</success>', implode(' ', $output));
 
         foreach ($files as $file) {
-            $this->assertFileExists($file);
+            $this->assertFileExists($file, 'File should exist after `bake all`.');
             unlink($file);
         }
 
-        $this->assertSame($content, file_get_contents($existingFile));
+        $this->assertSame($content, file_get_contents($existingFile), 'File got overwritten, but should not have.');
     }
 }

--- a/tests/TestCase/Shell/BakeShellTest.php
+++ b/tests/TestCase/Shell/BakeShellTest.php
@@ -231,6 +231,7 @@ class BakeShellTest extends TestCase
         $this->assertContains('BakeTest.Widget', $this->Shell->tasks);
         $this->assertContains('BakeTest.Zerg', $this->Shell->tasks);
     }
+
     /**
      * Test loading tasks from vendored plugins
      *
@@ -249,5 +250,48 @@ class BakeShellTest extends TestCase
         $this->Shell->main();
         $output = $this->out->messages();
         $this->assertContains("apple_pie", implode(' ', $output));
+    }
+
+    /**
+     * Tests that quiet mode does not ask interactively and does not silently overwrite anywhere.
+     * -f would be needed for that.
+     *
+     * @return void
+     */
+    public function testBakeAllNonInteractive()
+    {
+        $this->Shell->loadTasks();
+
+        $path = APP;
+        $testsPath = ROOT . 'tests' . DS;
+
+        $existingFile = $path . 'Controller/CommentsController.php';
+        $this->assertFileExists($existingFile);
+        $content = file_get_contents($existingFile);
+
+        $this->Shell->runCommand(['all', 'Comments'], false, ['quiet' => true]);
+        $output = $this->out->messages();
+
+        $this->assertContains('<success>Bake All complete.</success>', implode(' ', $output));
+
+        // We ignore our existing CommentsController test file
+        $files = [
+            $path . 'Template/Comments/add.ctp',
+            $path . 'Template/Comments/edit.ctp',
+            $path . 'Template/Comments/index.ctp',
+            $path . 'Template/Comments/view.ctp',
+            $path . 'Model/Table/CommentsTable.php',
+            $path . 'Model/Entity/Comment.php',
+            $testsPath . 'Fixture/CommentsFixture.php',
+            $testsPath . 'TestCase/Model/Table/CommentsTableTest.php',
+            $testsPath . 'TestCase/Controller/CommentsControllerTest.php',
+        ];
+
+        foreach ($files as $file) {
+            $this->assertFileExists($file);
+            unlink($file);
+        }
+
+        $this->assertSame($content, file_get_contents($existingFile));
     }
 }


### PR DESCRIPTION
Following https://github.com/cakephp/cakephp/pull/11574 this fixes up the non interactive mode.

Currently -q would prompt for sth but you are not able to see for what. So it just endless runs.

It now properly
- uses -q (quit) as non-interactive mode and silently ignores all existent files (no accidental overwrite anymore).
- uses -f (force) to force overwrite in -q non-interactive mode as specific in help.

This should use 3.5.10 release as before it always silently overwrote the files. Thus the composer constraint.