### PR TITLE
RFC - Start adopting Integration tests for bake

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 The MIT License
 
 CakePHP(tm) : The Rapid Development PHP Framework (http://cakephp.org)
-Copyright (c) 2005-2016, Cake Software Foundation, Inc.
+Copyright (c) 2005-2018, Cake Software Foundation, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/tests/TestCase/Shell/BakeShellTest.php
+++ b/tests/TestCase/Shell/BakeShellTest.php
@@ -16,6 +16,7 @@ namespace Bake\Test\TestCase\Shell;
 
 use Bake\Test\TestCase\TestCase;
 use Cake\Console\ConsoleIo;
+use Cake\Console\Shell;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\Stub\ConsoleOutput;
@@ -121,10 +122,9 @@ class BakeShellTest extends TestCase
      */
     public function testMain()
     {
-        $this->Shell->loadTasks();
-        $this->Shell->main();
-
-        $output = $this->out->messages();
+        $this->exec('bake');
+        $this->assertExitCode(Shell::CODE_ERROR);
+        $output = $this->_out->messages();
 
         $expected = [
             'The following commands can be used to generate skeleton code for your application.',
@@ -149,14 +149,10 @@ class BakeShellTest extends TestCase
             '- task',
             '- template',
             '- test',
+            '- twig_template',
+            '',
+            'By using <info>`cake bake [name]`</info> you can invoke a specific bake task.'
         ];
-
-        if (Plugin::loaded('WyriHaximus/TwigView')) {
-            $expected[] = '- twig_template';
-        }
-
-        $expected[] = '';
-        $expected[] = 'By using <info>`cake bake [name]`</info> you can invoke a specific bake task.';
 
         $this->assertSame($expected, $output);
     }
@@ -210,10 +206,8 @@ class BakeShellTest extends TestCase
             'Bake.Template',
             'Controller',
             'CustomController',
+            'WyriHaximus/TwigView.TwigTemplate',
         ];
-        if (Plugin::loaded('WyriHaximus/TwigView')) {
-            $expected[] = 'WyriHaximus/TwigView.TwigTemplate';
-        }
         sort($this->Shell->tasks);
         sort($expected);
         $this->assertEquals($expected, $this->Shell->tasks);
@@ -246,8 +240,7 @@ class BakeShellTest extends TestCase
         $this->Shell->loadTasks();
         $this->assertContains('Pastry/PastryTest.ApplePie', $this->Shell->tasks);
 
-        $this->Shell->main();
-        $output = $this->out->messages();
-        $this->assertContains("apple_pie", implode(' ', $output));
+        $this->exec('bake');
+        $this->assertOutputContains('apple_pie');
     }
 }

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -17,9 +17,9 @@ namespace Bake\Test\TestCase;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\StringCompareTrait;
-use Cake\TestSuite\TestCase as ParentTestCase;
+use Cake\TestSuite\ConsoleIntegrationTestCase;
 
-abstract class TestCase extends ParentTestCase
+abstract class TestCase extends ConsoleIntegrationTestCase
 {
     use StringCompareTrait;
 

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -16,12 +16,17 @@ namespace Bake\Test\TestCase;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\TestSuite\StringCompareTrait;
 use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\TestSuite\StringCompareTrait;
 
 abstract class TestCase extends ConsoleIntegrationTestCase
 {
     use StringCompareTrait;
+
+    /**
+     * @var string
+     */
+    protected $generatedFile = '';
 
     public function setUp()
     {
@@ -30,6 +35,16 @@ abstract class TestCase extends ConsoleIntegrationTestCase
         Plugin::load('WyriHaximus/TwigView', [
             'bootstrap' => true,
         ]);
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        if ($this->generatedFile && file_exists($this->generatedFile)) {
+            unlink($this->generatedFile);
+            $this->generatedFile = '';
+        }
     }
 
     /**
@@ -47,5 +62,37 @@ abstract class TestCase extends ConsoleIntegrationTestCase
             'path' => $path,
             'autoload' => true
         ]);
+    }
+
+    /**
+     * Assert that a file contains a substring
+     *
+     * @param string $expected The expected content.
+     * @param string $path The path to check.
+     * @param string $message The error message.
+     * @return void
+     */
+    protected function assertFileContains($expected, $path, $message = '')
+    {
+        $this->assertFileExists($path, 'Cannot test contents, file does not exist.');
+
+        $contents = file_get_contents($path);
+        $this->assertContains($expected, $contents, $message);
+    }
+
+    /**
+     * Assert that a file does not contain a substring
+     *
+     * @param string $expected The expected content.
+     * @param string $path The path to check.
+     * @param string $message The error message.
+     * @return void
+     */
+    protected function assertFileNotContains($expected, $path, $message = '')
+    {
+        $this->assertFileExists($path, 'Cannot test contents, file does not exist.');
+
+        $contents = file_get_contents($path);
+        $this->assertNotContains($expected, $contents, $message);
     }
 }


### PR DESCRIPTION
Start moving bake tests to use console integration tests. This is not a complete overhaul, but I wanted to update one task's tests to solicit feedback and ask for help moving other task's tests over.

The advantages I see with these tests is that they let us ensure the CLI options/API stay consistent and do what we think. Right now we have very poor coverage around options/arguments and our tests are coupled to effectively internal APIs.