### PR TITLE
Update more tests to use integration style

### DIFF
--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -142,7 +142,9 @@ class TemplateTask extends BakeTask
             $action = $template;
         }
         if ($template) {
-            return $this->bake($template, true, $action);
+            $this->bake($template, true, $action);
+
+            return true;
         }
 
         $vars = $this->_loadController();

--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -77,14 +77,6 @@ class TemplateTask extends BakeTask
     public $scaffoldActions = ['index', 'view', 'add', 'edit'];
 
     /**
-     * An array of action names that don't require templates. These
-     * actions will not emit errors when doing bakeActions()
-     *
-     * @var array
-     */
-    public $noTemplateActions = ['delete'];
-
-    /**
      * AssociationFilter utility
      *
      * @var AssociationFilter
@@ -333,56 +325,6 @@ class TemplateTask extends BakeTask
             'keyFields',
             'namespace'
         );
-    }
-
-    /**
-     * Bake a view file for each of the supplied actions
-     *
-     * @param array $actions Array of actions to make files for.
-     * @param array $vars The context for generating views.
-     * @return void
-     */
-    public function bakeActions(array $actions, $vars)
-    {
-        foreach ($actions as $action) {
-            $content = $this->getContent($action, $vars);
-            $this->bake($action, $content);
-        }
-    }
-
-    /**
-     * handle creation of baking a custom action view file
-     *
-     * @return void
-     */
-    public function customAction()
-    {
-        $action = '';
-        while (!$action) {
-            $action = $this->in('Action Name? (use lowercase_underscored function name)');
-            if (!$action) {
-                $this->out('The action name you supplied was empty. Please try again.');
-            }
-        }
-
-        $path = $this->getPath() . $this->controllerName . DS . Inflector::underscore($action) . ".ctp";
-
-        $this->out();
-        $this->hr();
-        $this->out('The following view will be created:');
-        $this->hr();
-        $this->out(sprintf('Controller Name: %s', $this->controllerName));
-        $this->out(sprintf('Action Name:     %s', $action));
-        $this->out(sprintf('Path:            %s', $path));
-        $this->hr();
-        $looksGood = $this->in('Look okay?', ['y', 'n'], 'y');
-        if (strtolower($looksGood) === 'y') {
-            $this->bake($action, ' ');
-            $this->_stop();
-
-            return;
-        }
-        $this->out('Bake Aborted.');
     }
 
     /**

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -1794,8 +1794,17 @@ class ModelTaskTest extends TestCase
         $result = $this->Task->getAssociationInfo($model);
 
         $expected = [
+            'Articles' => [
+                'targetFqn' => '\Bake\Test\App\Model\Table\ArticlesTable'
+            ],
             'ArticlesAlias' => [
                 'targetFqn' => '\Bake\Test\App\Model\Table\ArticlesTable'
+            ],
+            'Roles' => [
+                'targetFqn' => '\Bake\Test\App\Model\Table\RolesTable'
+            ],
+            'Profiles' => [
+                'targetFqn' => '\Bake\Test\App\Model\Table\ProfilesTable'
             ]
         ];
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/Shell/Task/TemplateTaskTest.php
+++ b/tests/TestCase/Shell/Task/TemplateTaskTest.php
@@ -16,6 +16,7 @@ namespace Bake\Test\TestCase\Shell\Task;
 
 use Bake\Shell\Task\BakeTemplateTask;
 use Bake\Test\TestCase\TestCase;
+use Cake\Console\Shell;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\ORM\TableRegistry;
@@ -59,7 +60,7 @@ class TemplateTaskTest extends TestCase
         $this->_setupTask(['in', 'err', 'error', 'createFile', '_stop']);
 
         TableRegistry::get('TemplateTaskComments', [
-            'className' => __NAMESPACE__ . '\TemplateTaskCommentsTable',
+            'className' => 'Bake\Test\App\Model\Table\TemplateTaskCommentsTable',
         ]);
     }
 
@@ -410,16 +411,13 @@ class TemplateTaskTest extends TestCase
      */
     public function testBakeView()
     {
-        $this->Task->modelName = __NAMESPACE__ . '\\TemplateTask\\AuthorsTable';
-        $this->Task->controllerName = 'Authors';
-        $this->Task->controllerClass = __NAMESPACE__ . '\\TemplateTask\\AuthorsController';
+        $this->generatedFile = APP . 'Template/Authors/view.ctp';
+        $this->exec('bake template authors view');
 
-        $this->Task
-            ->expects($this->at(0))
-            ->method('createFile')
-            ->with($this->_normalizePath(APP . 'Template/Authors/view.ctp'));
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
 
-        $result = $this->Task->bake('view', true);
+        $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.ctp', $result);
     }
 
@@ -430,15 +428,13 @@ class TemplateTaskTest extends TestCase
      */
     public function testBakeEdit()
     {
-        $this->Task->modelName = __NAMESPACE__ . '\\TemplateTask\\AuthorsTable';
-        $this->Task->controllerName = 'Authors';
-        $this->Task->controllerClass = __NAMESPACE__ . '\\TemplateTask\\AuthorsController';
+        $this->generatedFile = APP . 'Template/Authors/edit.ctp';
+        $this->exec('bake template authors edit');
 
-        $this->Task->expects($this->at(0))->method('createFile')
-            ->with(
-                $this->_normalizePath(APP . 'Template/Authors/edit.ctp')
-            );
-        $result = $this->Task->bake('edit', true);
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+
+        $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.ctp', $result);
     }
 
@@ -449,15 +445,13 @@ class TemplateTaskTest extends TestCase
      */
     public function testBakeIndex()
     {
-        $this->Task->controllerName = 'TemplateTaskComments';
-        $this->Task->modelName = 'TemplateTaskComments';
-        $this->Task->controllerClass = __NAMESPACE__ . '\TemplateTaskCommentsController';
+        $this->generatedFile = APP . 'Template/TemplateTaskComments/index.ctp';
+        $this->exec('bake template template_task_comments index');
 
-        $this->Task->expects($this->at(0))->method('createFile')
-            ->with(
-                $this->_normalizePath(APP . 'Template/TemplateTaskComments/index.ctp')
-            );
-        $result = $this->Task->bake('index', true);
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+
+        $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.ctp', $result);
     }
 
@@ -468,15 +462,13 @@ class TemplateTaskTest extends TestCase
      */
     public function testBakeIndexWithIndexLimit()
     {
-        $this->Task->controllerName = 'TemplateTaskComments';
-        $this->Task->modelName = 'TemplateTaskComments';
-        $this->Task->controllerClass = __NAMESPACE__ . '\TemplateTaskCommentsController';
-        $this->Task->params['index-columns'] = 3;
-        $this->Task->expects($this->at(0))->method('createFile')
-            ->with(
-                $this->_normalizePath(APP . 'Template/TemplateTaskComments/index.ctp')
-            );
-        $result = $this->Task->bake('index', true);
+        $this->generatedFile = APP . 'Template/TemplateTaskComments/index.ctp';
+        $this->exec('bake template template_task_comments --index-columns 3 index');
+
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+
+        $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.ctp', $result);
     }
 
@@ -487,20 +479,19 @@ class TemplateTaskTest extends TestCase
      */
     public function testBakeIndexPlugin()
     {
-        $this->Task->controllerName = 'TemplateTaskComments';
-        $this->Task->modelName = 'BakeTest.BakeTestComments';
-        $this->Task->controllerClass = __NAMESPACE__ . '\TemplateTaskCommentsController';
-        $table = TableRegistry::get('BakeTest.BakeTestComments');
-        $table->belongsTo('Articles');
+        $this->_loadTestPlugin('BakeTest');
+        $path = Plugin::path('BakeTest');
 
-        $this->Task->expects($this->at(0))
-            ->method('createFile')
-            ->with(
-                $this->_normalizePath(APP . 'Template/TemplateTaskComments/index.ctp'),
-                $this->stringContains('$templateTaskComment->article->id')
-            );
+        // Setup association to ensure properties don't have dots
+        $model = TableRegistry::get('BakeTest.Comments');
+        $model->belongsTo('Articles');
 
-        $this->Task->bake('index', true);
+        $this->generatedFile = $path . 'src/Template/Comments/index.ctp';
+        $this->exec('bake template BakeTest.comments index');
+
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+        $this->assertFileContains('$comment->article->id', $this->generatedFile);
     }
 
     /**
@@ -576,20 +567,14 @@ class TemplateTaskTest extends TestCase
      */
     public function testBakeSelfAssociationsRelatedAssociations()
     {
-        $this->Task->controllerName = 'CategoryThreads';
-        $this->Task->modelName = 'Bake\Test\App\Model\Table\CategoryThreadsTable';
+        $this->generatedFile = APP . 'Template/CategoryThreads/view.ctp';
+        $this->exec('bake template category_threads view');
 
-        $this->Task->expects($this->once())
-            ->method('createFile')
-            ->with(
-                $this->_normalizePath(APP . 'Template/CategoryThreads/view.ctp'),
-                $this->logicalAnd(
-                    $this->stringContains('Related Category Threads'),
-                    $this->stringContains('Parent Category Thread')
-                )
-            );
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
 
-        $this->Task->bake('view', true);
+        $this->assertFileContains('Related Category Threads', $this->generatedFile);
+        $this->assertFileContains('Parent Category Threads', $this->generatedFile);
     }
 
     /**
@@ -599,65 +584,10 @@ class TemplateTaskTest extends TestCase
      */
     public function testBakeWithNoTemplate()
     {
-        $this->Task->controllerName = 'TemplateTaskComments';
-        $this->Task->modelName = 'TemplateTaskComments';
-        $this->Task->controllerClass = __NAMESPACE__ . '\TemplateTaskCommentsController';
+        $this->exec('bake template template_task_comments delete');
 
-        $this->Task->expects($this->never())->method('createFile');
-        $this->Task->bake('delete', true);
-    }
-
-    /**
-     * test bake actions baking multiple actions.
-     *
-     * @return void
-     */
-    public function testBakeActions()
-    {
-        $this->Task->controllerName = 'TemplateTaskComments';
-        $this->Task->modelName = 'TemplateTaskComments';
-        $this->Task->controllerClass = __NAMESPACE__ . '\TemplateTaskCommentsController';
-
-        $this->Task->expects($this->at(0))
-            ->method('createFile')
-            ->with(
-                $this->_normalizePath(APP . 'Template/TemplateTaskComments/view.ctp'),
-                $this->stringContains('Template Task Comments')
-            );
-        $this->Task->expects($this->at(1))->method('createFile')
-            ->with(
-                $this->_normalizePath(APP . 'Template/TemplateTaskComments/edit.ctp'),
-                $this->stringContains('Edit Template Task Comment')
-            );
-        $this->Task->expects($this->at(2))->method('createFile')
-            ->with(
-                $this->_normalizePath(APP . 'Template/TemplateTaskComments/index.ctp'),
-                $this->stringContains('TemplateTaskComment')
-            );
-
-        $this->Task->bakeActions(['view', 'edit', 'index'], []);
-    }
-
-    /**
-     * test baking a customAction (non crud)
-     *
-     * @return void
-     */
-    public function testCustomAction()
-    {
-        $this->Task->controllerName = 'TemplateTaskComments';
-        $this->Task->modelName = 'TemplateTaskComments';
-        $this->Task->controllerClass = __NAMESPACE__ . '\TemplateTaskCommentsController';
-
-        $this->Task->expects($this->any())->method('in')
-            ->will($this->onConsecutiveCalls('', 'my_action', 'y'));
-
-        $this->Task->expects($this->once())->method('createFile')
-            ->with(
-                $this->_normalizePath(APP . 'Template/TemplateTaskComments/my_action.ctp')
-            );
-
-        $this->Task->customAction();
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFileNotExists(APP . 'Template/TemplateTaskComments/delete.ctp');
     }
 
     /**
@@ -667,16 +597,12 @@ class TemplateTaskTest extends TestCase
      */
     public function testMainNoArgs()
     {
-        $this->_setupTask(['in', 'err', 'bake', 'createFile', '_stop']);
+        $this->exec('bake template');
 
-        $this->Task->Model->expects($this->once())
-            ->method('listUnskipped')
-            ->will($this->returnValue(['comments', 'articles']));
-
-        $this->Task->expects($this->never())
-            ->method('bake');
-
-        $this->Task->main();
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertOutputContains('Possible tables to bake view templates for based on your current database:');
+        $this->assertOutputContains('- Comments');
+        $this->assertOutputContains('- Articles');
     }
 
     /**
@@ -711,13 +637,19 @@ class TemplateTaskTest extends TestCase
      */
     public function testMainWithActionParam()
     {
-        $this->_setupTask(['in', 'err', 'createFile', 'bake', '_stop']);
+        $this->generatedFile = APP . 'Template/TemplateTaskComments/view.ctp';
+        $this->exec('bake template TemplateTaskComments view');
 
-        $this->Task->expects($this->once())
-            ->method('bake')
-            ->with('view', true, 'view');
-
-        $this->Task->main('TemplateTaskComments', 'view');
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+        $this->assertFileNotExists(
+            APP . 'Template/TemplateTaskComments/edit.ctp',
+            'no extra files'
+        );
+        $this->assertFileNotExists(
+            APP . 'Template/TemplateTaskComments/add.ctp',
+            'no extra files'
+        );
     }
 
     /**
@@ -726,26 +658,24 @@ class TemplateTaskTest extends TestCase
      *
      * @return void
      */
-    public function testMainWithController()
+    public function testMainWithExistingController()
     {
-        $this->_setupTask(['in', 'err', 'createFile', 'getContent', '_stop']);
+        $this->generatedFiles = [
+            APP . 'Template/TemplateTaskComments/index.ctp',
+            APP . 'Template/TemplateTaskComments/add.ctp',
+        ];
+        $this->exec('bake template TemplateTaskComments');
 
-        $this->Task->expects($this->exactly(3))
-            ->method('getContent');
-
-        $this->Task->expects($this->at(0))
-            ->method('getContent')
-            ->with('index');
-
-        $this->Task->expects($this->at(1))
-            ->method('getContent')
-            ->with('add', $this->anything());
-
-        $this->Task->expects($this->at(2))
-            ->method('getContent')
-            ->with('add_comment', $this->anything());
-
-        $this->Task->main('TemplateTaskComments');
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFilesExist($this->generatedFiles);
+        $this->assertFileNotExists(
+            APP . 'Template/TemplateTaskComments/edit.ctp',
+            'no extra files'
+        );
+        $this->assertFileNotExists(
+            APP . 'Template/TemplateTaskComments/view.ctp',
+            'no extra files'
+        );
     }
 
     /**
@@ -755,24 +685,18 @@ class TemplateTaskTest extends TestCase
      */
     public function testMainWithPluginName()
     {
-        // Populate the table registry with a "plugin" model
-        TableRegistry::get('TestTemplate.TemplateTaskComments', [
-            'className' => __NAMESPACE__ . '\TemplateTaskCommentsTable',
-        ]);
+        $this->_loadTestPlugin('TestBake');
+        $path = Plugin::path('TestBake');
 
-        $this->_setupTask(['in', 'err', 'createFile']);
+        $this->generatedFile = $path . 'src/Template/Comments/index.ctp';
+        $this->exec('bake template --connection test TestBake.Comments index');
 
-        $this->Task->connection = 'test';
-        $filename = $this->_normalizePath(
-            APP . 'Plugin/TestTemplate/src/Template/TemplateTaskComments/index.ctp'
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+        $this->assertFileNotExists(
+            $path . 'src/Template/Comments/view.ctp',
+            'No other templates made'
         );
-
-        Plugin::load('TestTemplate', ['path' => APP . 'Plugin/TestTemplate/']);
-
-        $this->Task->expects($this->at(0))
-            ->method('createFile')
-            ->with($filename);
-        $this->Task->main('TestTemplate.TemplateTaskComments');
     }
 
     /**
@@ -792,19 +716,16 @@ class TemplateTaskTest extends TestCase
      */
     public function testMainWithControllerFlag()
     {
-        $this->Task->params['controller'] = 'Blog';
+        $this->generatedFiles = [
+            APP . 'Template/Blog/index.ctp',
+            APP . 'Template/Blog/view.ctp',
+            APP . 'Template/Blog/add.ctp',
+            APP . 'Template/Blog/edit.ctp',
+        ];
+        $this->exec('bake template --controller Blog Posts');
 
-        $this->Task->expects($this->exactly(4))
-            ->method('createFile');
-
-        $templates = ['index.ctp', 'view.ctp', 'add.ctp', 'edit.ctp'];
-        foreach ($templates as $i => $template) {
-            $this->Task->expects($this->at($i))->method('createFile')
-                ->with(
-                    $this->_normalizePath(APP . 'Template/Blog/' . $template)
-                );
-        }
-        $this->Task->main('Posts');
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFilesExist($this->generatedFiles);
     }
 
     /**
@@ -814,19 +735,14 @@ class TemplateTaskTest extends TestCase
      */
     public function testMainWithControllerAndAdminFlag()
     {
-        $this->Task->params['prefix'] = 'Admin';
+        $this->generatedFiles = [
+            APP . 'Template/Admin/Posts/index.ctp',
+            APP . 'Template/Admin/Posts/add.ctp'
+        ];
+        $this->exec('bake template --prefix Admin Posts');
 
-        $this->Task->expects($this->exactly(2))
-            ->method('createFile');
-
-        $templates = ['index.ctp', 'add.ctp'];
-        foreach ($templates as $i => $template) {
-            $this->Task->expects($this->at($i))->method('createFile')
-                ->with(
-                    $this->_normalizePath(APP . 'Template/Admin/Posts/' . $template)
-                );
-        }
-        $this->Task->main('Posts');
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFilesExist($this->generatedFiles);
     }
 
     /**
@@ -836,18 +752,11 @@ class TemplateTaskTest extends TestCase
      */
     public function testMainWithAlternateTemplates()
     {
-        $this->_setupTask(['in', 'err', 'createFile', '_stop']);
+        $this->generatedFile = APP . 'Template/TemplateTaskComments/list.ctp';
+        $this->exec('bake template TemplateTaskComments index list');
 
-        $this->Task->connection = 'test';
-        $this->Task->params = [];
-
-        $this->Task->expects($this->once())
-            ->method('createFile')
-            ->with(
-                $this->_normalizePath(APP . 'Template/TemplateTaskComments/list.ctp'),
-                $this->stringContains('Template Task Comments')
-            );
-
-        $this->Task->main('TemplateTaskComments', 'index', 'list');
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+        $this->assertFileContains('Template Task Comments', $this->generatedFile);
     }
 }

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -170,15 +170,23 @@ class TestTaskTest extends TestCase
      */
     public function testExecuteWithAll()
     {
-        $this->Task->expects($this->exactly(2))->method('createFile')
+        $this->Task->expects($this->exactly(4))->method('createFile')
             ->withConsecutive(
                 [
                     $this->stringContains('TestCase' . DS . 'Model' . DS . 'Table' . DS . 'ArticlesTableTest.php'),
                     $this->stringContains('class ArticlesTableTest extends TestCase')
                 ],
                 [
+                    $this->stringContains('TestCase' . DS . 'Model' . DS . 'Table' . DS . 'AuthorsTableTest.php'),
+                    $this->stringContains('class AuthorsTableTest extends TestCase')
+                ],
+                [
                     $this->stringContains('TestCase' . DS . 'Model' . DS . 'Table' . DS . 'CategoryThreadsTableTest.php'),
                     $this->stringContains('class CategoryThreadsTableTest extends TestCase')
+                ],
+                [
+                    $this->stringContains('TestCase' . DS . 'Model' . DS . 'Table' . DS . 'TemplateTaskCommentsTableTest.php'),
+                    $this->stringContains('class TemplateTaskCommentsTableTest extends TestCase')
                 ]
             );
         $this->Task->params['all'] = true;
@@ -194,15 +202,19 @@ class TestTaskTest extends TestCase
     {
         $expected = [
             'ArticlesTable',
-            'CategoryThreadsTable'
+            'AuthorsTable',
+            'CategoryThreadsTable',
+            'TemplateTaskCommentsTable'
         ];
 
-        $this->io->expects($this->exactly(5))
+        $this->io->expects($this->exactly(7))
             ->method('out')
             ->withConsecutive(
                 ['You must provide a class to bake a test for. Some possible options are:', 2],
                 ['1. ArticlesTable'],
-                ['2. CategoryThreadsTable'],
+                ['2. AuthorsTable'],
+                ['3. CategoryThreadsTable'],
+                ['4. TemplateTaskCommentsTable'],
                 [''],
                 ['Re-run your command as `cake bake Table <classname>`']
             );

--- a/tests/test_app/App/Controller/AuthorsController.php
+++ b/tests/test_app/App/Controller/AuthorsController.php
@@ -9,23 +9,33 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP Project
- * @since         0.1.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Bake\Test\TestCase\Shell\Task;
+namespace Bake\Test\App\Controller;
 
-use Cake\ORM\Table;
+use Cake\Controller\Controller;
 
 /**
- * Test Template Task Comment Model
+ * Class TemplateTaskAuthorsController
  */
-class TemplateTaskCommentsTable extends Table
+class AuthorsController extends Controller
 {
-    public function initialize(array $config)
+
+    /**
+     * Testing public controller action
+     *
+     * @return void
+     */
+    public function index()
     {
-        $this->table('comments');
-        $this->belongsTo('Articles', [
-            'foreignKey' => 'article_id'
-        ]);
+    }
+
+    /**
+     * Testing public controller action
+     *
+     * @return void
+     */
+    public function add()
+    {
     }
 }

--- a/tests/test_app/App/Controller/TemplateTaskCommentsController.php
+++ b/tests/test_app/App/Controller/TemplateTaskCommentsController.php
@@ -21,8 +21,6 @@ use Cake\Controller\Controller;
  */
 class TemplateTaskCommentsController extends Controller
 {
-    public $modelClass = 'Cake\Test\TestCase\Shell\Task\TemplateTaskCommentsTable';
-
     /**
      * Testing public controller action
      *

--- a/tests/test_app/App/Model/Table/AuthorsTable.php
+++ b/tests/test_app/App/Model/Table/AuthorsTable.php
@@ -11,31 +11,31 @@
  * @link          http://cakephp.org CakePHP Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Bake\Test\TestCase\Shell\Task\TemplateTask;
+namespace Bake\Test\App\Model\Table;
 
-use Cake\Controller\Controller;
+use Cake\ORM\Table;
 
 /**
- * Class TemplateTaskAuthorsController
+ * Class AuthorsTable
  */
-class AuthorsController extends Controller
+class AuthorsTable extends Table
 {
 
     /**
-     * Testing public controller action
-     *
+     * @param array $config
      * @return void
      */
-    public function index()
+    public function initialize(array $config)
     {
-    }
-
-    /**
-     * Testing public controller action
-     *
-     * @return void
-     */
-    public function add()
-    {
+        $this->table('bake_authors');
+        $this->belongsTo('Roles', [
+            'foreignKey' => 'role_id'
+        ]);
+        $this->hasMany('Articles', [
+            'foreignKey' => 'author_id'
+        ]);
+        $this->hasOne('Profiles', [
+            'foreignKey' => 'author_id'
+        ]);
     }
 }

--- a/tests/test_app/App/Model/Table/TemplateTaskCommentsTable.php
+++ b/tests/test_app/App/Model/Table/TemplateTaskCommentsTable.php
@@ -9,33 +9,23 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP Project
+ * @since         0.1.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Bake\Test\TestCase\Shell\Task\TemplateTask;
+namespace Bake\Test\App\Model\Table;
 
 use Cake\ORM\Table;
 
 /**
- * Class AuthorsTable
+ * Test Template Task Comment Model
  */
-class AuthorsTable extends Table
+class TemplateTaskCommentsTable extends Table
 {
-
-    /**
-     * @param array $config
-     * @return void
-     */
     public function initialize(array $config)
     {
-        $this->table('bake_authors');
-        $this->belongsTo('Roles', [
-            'foreignKey' => 'role_id'
-        ]);
-        $this->hasMany('Articles', [
-            'foreignKey' => 'author_id'
-        ]);
-        $this->hasOne('Profiles', [
-            'foreignKey' => 'author_id'
+        $this->table('comments');
+        $this->belongsTo('Articles', [
+            'foreignKey' => 'article_id'
         ]);
     }
 }


### PR DESCRIPTION
Move more tests to the integration style.

I had to move fixture files into locations that follow conventions.

I've deleted a few dead methods (bakeAction, customMethod) as they cannot be reached through the CLI interface and have no callers in `bake`. This could be construed as a breaking change but to me, the 'interface' of bake is its CLI interface and the base classes it provides. Template Task is a highly specific job of bake and isn't part of the 'public' interface.