### PR TITLE
Prefix option for bake cell

### DIFF
--- a/src/Shell/Task/CellTask.php
+++ b/src/Shell/Task/CellTask.php
@@ -14,6 +14,8 @@
  */
 namespace Bake\Shell\Task;
 
+use Cake\Core\Configure;
+
 /**
  * Task for creating cells.
  *
@@ -54,6 +56,26 @@ class CellTask extends SimpleBakeTask
     }
 
     /**
+     * Get template data.
+     *
+     * @return array
+     */
+    public function templateData()
+    {
+        $prefix = $this->_getPrefix();
+        if ($prefix) {
+            $prefix = '\\' . str_replace('/', '\\', $prefix);
+        }
+
+        $namespace = Configure::read('App.namespace');
+        if ($this->plugin) {
+            $namespace = $this->_pluginNamespace($this->plugin);
+        }
+
+        return compact('namespace', 'prefix');
+    }
+
+    /**
      * Bake the Cell class and template file.
      *
      * @param string $name The name of the cell to make.
@@ -74,13 +96,30 @@ class CellTask extends SimpleBakeTask
      */
     public function bakeTemplate($name)
     {
-        $templatePath = implode(DS, ['Template', 'Cell', $name, 'display.ctp']);
         $restore = $this->pathFragment;
-        $this->pathFragment = $templatePath;
 
+        $this->pathFragment = 'Template/Cell/';
         $path = $this->getPath();
+        $path .= implode(DS, [$name, 'display.ctp']);
+
         $this->pathFragment = $restore;
 
         $this->createFile($path, '');
+    }
+
+    /**
+     * Gets the option parser instance and configures it.
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser
+        ->addOption('prefix', [
+            'help' => 'The namespace/routing prefix to use.'
+        ]);
+
+        return $parser;
     }
 }

--- a/src/Shell/Task/CellTask.php
+++ b/src/Shell/Task/CellTask.php
@@ -117,7 +117,7 @@ class CellTask extends SimpleBakeTask
         $parser = parent::getOptionParser();
         $parser
         ->addOption('prefix', [
-            'help' => 'The namespace/routing prefix to use.'
+            'help' => 'The namespace prefix to use.'
         ]);
 
         return $parser;

--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -350,7 +350,7 @@ class TestTask extends BakeTask
             $class .= $suffix;
         }
         $prefix = $this->_getPrefix();
-        if (strtolower($type) === 'controller' && $prefix) {
+        if (in_array(strtolower($type), ['controller', 'cell']) && $prefix) {
             $subSpace .= '\\' . str_replace('/', '\\', $prefix);
         }
 

--- a/src/Template/Bake/View/cell.twig
+++ b/src/Template/Bake/View/cell.twig
@@ -14,7 +14,7 @@
  */
 #}
 <?php
-namespace {{ namespace }}\View\Cell;
+namespace {{ namespace }}\View\Cell{{ prefix }};
 
 use Cake\View\Cell;
 

--- a/tests/TestCase/Shell/Task/CellTaskTest.php
+++ b/tests/TestCase/Shell/Task/CellTaskTest.php
@@ -97,4 +97,45 @@ class CellTaskTest extends TestCase
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
+
+    /**
+     * Test the excute method with prefix.
+     *
+     * @return void
+     */
+    public function testMainPrefix()
+    {
+        $this->generatedFiles = [
+            APP . 'View/Cell/Admin/ExampleCell.php',
+            ROOT . 'tests/TestCase/View/Cell/Admin/ExampleCellTest.php',
+            APP . 'Template/Cell/Admin/Example/display.ctp',
+        ];
+        $this->exec('bake cell --prefix Admin Example');
+
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFilesExist($this->generatedFiles);
+        $this->assertFileContains('class ExampleCell extends Cell', $this->generatedFiles[0]);
+    }
+
+    /**
+     * Test main within a prefix and plugin.
+     *
+     * @return void
+     */
+    public function testMainPrefixPlugin()
+    {
+        $this->_loadTestPlugin('TestBake');
+        $path = Plugin::path('TestBake');
+
+        $this->generatedFiles = [
+            $path . 'src/View/Cell/Admin/ExampleCell.php',
+            $path . 'tests/TestCase/View/Cell/Admin/ExampleCellTest.php',
+            $path . 'src/Template/Cell/Admin/Example/display.ctp',
+        ];
+        $this->exec('bake cell --prefix Admin TestBake.Example');
+
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertFileContains('namespace TestBake\View\Cell\Admin;', $this->generatedFiles[0]);
+        $this->assertFileContains('class ExampleCell extends Cell', $this->generatedFiles[0]);
+    }
 }

--- a/tests/TestCase/Shell/Task/CellTaskTest.php
+++ b/tests/TestCase/Shell/Task/CellTaskTest.php
@@ -114,6 +114,7 @@ class CellTaskTest extends TestCase
 
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
+        $this->assertFileContains('namespace App\View\Cell\Admin;', $this->generatedFiles[0]);
         $this->assertFileContains('class ExampleCell extends Cell', $this->generatedFiles[0]);
     }
 


### PR DESCRIPTION
I like prefixes for code I don't want to decouple into plugin. I am missing this option in some bake tasks, currently in the cell so I have tried to add it there.

Maybe it would be good idea to implement prefix to ` src/Shell/Task/SimpleBakeTask.php` so all Tasks which extends this class can have this prefix option, but that's too much for me at the moment

Hope all OK

Reference #235 