### PR TITLE
Checking for defined variables before using them

### DIFF
--- a/src/Template/Bake/Model/table.twig
+++ b/src/Template/Bake/Model/table.twig
@@ -116,7 +116,7 @@ class {{ name }}Table extends Table
     public function buildRules(RulesChecker $rules)
     {
 {% for field, rule in rulesChecker %}
-        $rules->add($rules->{{ rule.name }}(['{{ field }}']{{ (rule.extra ? (", '#{rule.extra}'") : '')|raw }}));
+        $rules->add($rules->{{ rule.name }}(['{{ field }}']{{ (rule.extra is defined and rule.extra ? (", '#{rule.extra}'") : '')|raw }}));
 {% endfor %}
 
         return $rules;

--- a/src/Template/Bake/tests/test_case.twig
+++ b/src/Template/Bake/tests/test_case.twig
@@ -49,7 +49,7 @@ class {{ className }}Test extends TestCase
      *
      * @var {{ propertyInfo.type }}
      */
-     public ${{ propertyInfo.name }}{% if propertyInfo.value is defined and propertyInfo.value %} = {{ propertyInfo.value }}{% endif %};
+    public ${{ propertyInfo.name }}{% if propertyInfo.value is defined and propertyInfo.value %} = {{ propertyInfo.value }}{% endif %};
 {% endfor %}
 {% endif %}
 

--- a/src/Template/Bake/tests/test_case.twig
+++ b/src/Template/Bake/tests/test_case.twig
@@ -49,7 +49,7 @@ class {{ className }}Test extends TestCase
      *
      * @var {{ propertyInfo.type }}
      */
-    public ${{ propertyInfo.name }}{% if propertyInfo.value %} = {{ propertyInfo.value }}{% endif %};
+     public ${{ propertyInfo.name }}{% if propertyInfo.value is defined and propertyInfo.value %} = {{ propertyInfo.value }}{% endif %};
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Applications using wyrihaximus/twig-view with twig set to fail on undefined variables are unable to use these templates (table.twig, test_case.twig) without error. table.twig and test_case.twig updated to check for variables to be defined first.

Errors Produced:

> Exception: Key "value" for array with keys "description, type, name" does not exist in "/var/www/vendor/cakephp/bake/src/Template/Bake/tests/test_case.twig" at line 52. in [/var/www/vendor/twig/twig/lib/Twig/Template.php, line 556]
2018-02-09 14:54:45 Error: [Twig_Error_Runtime] Key "value" for array with keys "description, type, name" does not exist in "/var/www/vendor/cakephp/bake/src/Template/Bake/tests/test_case.twig" at line 52. in /var/www/vendor/twig/twig/lib/Twig/Template.php on line 556


> Exception: Key "extra" for array with keys "name" does not exist in "/var/www/vendor/cakephp/bake/src/Template/Bake/Model/table.twig" at line 119. in [/var/www/vendor/twig/twig/lib/Twig/Template.php, line 556]
2018-02-09 14:54:14 Error: [Twig_Error_Runtime] Key "extra" for array with keys "name" does not exist in "/var/www/vendor/cakephp/bake/src/Template/Bake/Model/table.twig" at line 119. in /var/www/vendor/twig/twig/lib/Twig/Template.php on line 556

