### PR TITLE
Use the table class to read schema metadata

### DIFF
--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -171,11 +171,12 @@ class FixtureTask extends BakeTask
         }
 
         try {
-            $data = $this->readSchema($useTable);
+            $data = $this->readSchema($model, $useTable);
         } catch (Exception $e) {
+            TableRegistry::remove($model);
             $useTable = Inflector::underscore($model);
             $table = $useTable;
-            $data = $this->readSchema($model);
+            $data = $this->readSchema($model, $useTable);
         }
 
         if ($modelImport === null) {
@@ -199,17 +200,18 @@ class FixtureTask extends BakeTask
     /**
      * Get schema metadata for the current table mapping.
      *
+     * @param string $name The model alias to use
      * @param string $table The table name to get schema metadata for.
      * @return \Cake\Database\Schema\TableSchema
      */
-    public function readSchema($table)
+    public function readSchema($name, $table)
     {
         $connection = ConnectionManager::get($this->connection);
 
-        if (TableRegistry::exists($table)) {
-            $model = TableRegistry::get($table);
+        if (TableRegistry::exists($name)) {
+            $model = TableRegistry::get($name);
         } else {
-            $model = TableRegistry::get($table, [
+            $model = TableRegistry::get($name, [
                 'table' => $table,
                 'connection' => $connection
             ]);

--- a/tests/TestCase/Shell/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Shell/Task/FixtureTaskTest.php
@@ -329,7 +329,7 @@ class FixtureTaskTest extends TestCase
     }
 
     /**
-     * test record generation with float and binary types
+     * test record generation with various datatypes
      *
      * @return void
      */
@@ -367,17 +367,20 @@ class FixtureTaskTest extends TestCase
     }
 
     /**
-     * Test that file generation includes headers and correct path for plugins.
+     * Test that file generation works with remapped json types
      *
      * @return void
      */
-    public function testGenerateFixtureFile()
+    public function testGenerateFixtureFileRemappedJsonTypes()
     {
+        $table = TableRegistry::get('articles');
+        $table->getSchema()->addColumn('body', ['type' => 'json']);
         $this->generatedFile = ROOT . 'tests/Fixture/ArticlesFixture.php';
         $this->exec('bake fixture --connection test Articles');
 
         $this->assertFileContains('<?php', $this->generatedFile);
         $this->assertFileContains('namespace App\Test\Fixture;', $this->generatedFile);
+        $this->assertFileContains("'body' => ['type' => 'json'", $this->generatedFile);
     }
 
     /**

--- a/tests/TestCase/Shell/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Shell/Task/FixtureTaskTest.php
@@ -373,7 +373,7 @@ class FixtureTaskTest extends TestCase
      */
     public function testGenerateFixtureFileRemappedJsonTypes()
     {
-        $table = TableRegistry::get('articles');
+        $table = TableRegistry::get('Articles');
         $table->getSchema()->addColumn('body', ['type' => 'json']);
         $this->generatedFile = ROOT . 'tests/Fixture/ArticlesFixture.php';
         $this->exec('bake fixture --connection test Articles');


### PR DESCRIPTION
Using the table classes to read schema metadata instead of going directly to the schema information on the connection allows bake to leverage the changes made in a table class' `_initializeSchema` hook

Refs #419