### PR TITLE
Assign fixture records at run time rather than compile time

### DIFF
--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -425,13 +425,13 @@ class FixtureTask extends BakeTask
                 if ($val === 'NULL') {
                     $val = 'null';
                 }
-                $values[] = "            '$field' => $val";
+                $values[] = "                '$field' => $val";
             }
-            $out .= "        [\n";
+            $out .= "            [\n";
             $out .= implode(",\n", $values);
-            $out .= "\n        ],\n";
+            $out .= "\n            ],\n";
         }
-        $out .= "    ]";
+        $out .= "        ]";
 
         return $out;
     }

--- a/src/Template/Bake/tests/fixture.twig
+++ b/src/Template/Bake/tests/fixture.twig
@@ -63,10 +63,14 @@ class {{ name }}Fixture extends TestFixture
 {%- if records %}
 
     /**
-     * Records
+     * Init method
      *
-     * @var array
+     * @return void
      */
-    public $records = {{ records|raw }};
+    public function init()
+    {
+        $this->records = {{ records|raw }};
+        parent::init();
+    }
 {% endif %}
 }

--- a/tests/TestCase/Shell/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Shell/Task/FixtureTaskTest.php
@@ -308,7 +308,7 @@ class FixtureTaskTest extends TestCase
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertFileContains('class ArticlesFixture extends TestFixture', $this->generatedFile);
         $this->assertFileContains('public $fields', $this->generatedFile);
-        $this->assertFileContains('public $records', $this->generatedFile);
+        $this->assertFileContains('$this->records =', $this->generatedFile);
         $this->assertFileNotContains('public $import', $this->generatedFile);
     }
 
@@ -324,7 +324,7 @@ class FixtureTaskTest extends TestCase
 
         $importString = "public \$import = ['table' => 'comments', 'connection' => 'test'];";
         $this->assertFileContains($importString, $this->generatedFile);
-        $this->assertFileContains('public $records', $this->generatedFile);
+        $this->assertFileContains('$this->records =', $this->generatedFile);
         $this->assertFileNotContains('public $fields', $this->generatedFile);
     }
 

--- a/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
+++ b/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
@@ -18,11 +18,13 @@ class UsersFixture extends TestFixture
     public $import = ['table' => 'users', 'connection' => 'test'];
 
     /**
-     * Records
+     * Init method
      *
-     * @var array
+     * @return void
      */
-    public $records = [
+    public function init()
+    {
+        $this->records = [
         [
             'id' => 1,
             'username' => 'mariano',
@@ -52,4 +54,6 @@ class UsersFixture extends TestFixture
             'updated' => '2012-06-12 01:24:31'
         ],
     ];
+        parent::init();
+    }
 }

--- a/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
+++ b/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
@@ -25,35 +25,35 @@ class UsersFixture extends TestFixture
     public function init()
     {
         $this->records = [
-        [
-            'id' => 1,
-            'username' => 'mariano',
-            'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
-            'created' => '2007-03-17 01:16:23',
-            'updated' => '2007-03-17 01:18:31'
-        ],
-        [
-            'id' => 2,
-            'username' => 'nate',
-            'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
-            'created' => '2008-03-17 01:18:23',
-            'updated' => '2008-03-17 01:20:31'
-        ],
-        [
-            'id' => 3,
-            'username' => 'larry',
-            'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
-            'created' => '2010-05-10 01:20:23',
-            'updated' => '2010-05-10 01:22:31'
-        ],
-        [
-            'id' => 4,
-            'username' => 'garrett',
-            'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
-            'created' => '2012-06-10 01:22:23',
-            'updated' => '2012-06-12 01:24:31'
-        ],
-    ];
+            [
+                'id' => 1,
+                'username' => 'mariano',
+                'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
+                'created' => '2007-03-17 01:16:23',
+                'updated' => '2007-03-17 01:18:31'
+            ],
+            [
+                'id' => 2,
+                'username' => 'nate',
+                'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
+                'created' => '2008-03-17 01:18:23',
+                'updated' => '2008-03-17 01:20:31'
+            ],
+            [
+                'id' => 3,
+                'username' => 'larry',
+                'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
+                'created' => '2010-05-10 01:20:23',
+                'updated' => '2010-05-10 01:22:31'
+            ],
+            [
+                'id' => 4,
+                'username' => 'garrett',
+                'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
+                'created' => '2012-06-10 01:22:23',
+                'updated' => '2012-06-12 01:24:31'
+            ],
+        ];
         parent::init();
     }
 }


### PR DESCRIPTION
This PR changes Bake fixture templates so that assignment of a fixture's records happens at run time via an `init()` method, rather than at compile time via a property declaration. The limitations imposed by the current implementation can cause problems for complex data types. See https://github.com/cakephp/bake/issues/425