### PR TITLE
Add plugin class creation when baking a plugin.

### DIFF
--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -210,7 +210,7 @@ class PluginTask extends BakeTask
 
         sort($templates);
         foreach ($templates as $template) {
-            $template = substr($template, strrpos($template, 'Plugin') + 7, -4);
+            $template = substr($template, strrpos($template, 'Plugin' . DIRECTORY_SEPARATOR) + 7, -4);
             $template = rtrim($template, '.');
             $this->_generateFile($template, $root);
         }

--- a/src/Template/Bake/Plugin/src/Plugin.php.twig
+++ b/src/Template/Bake/Plugin/src/Plugin.php.twig
@@ -1,0 +1,28 @@
+{#
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         1.7.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+#}
+<?php
+
+namespace {{ namespace }};
+
+use Cake\Core\BasePlugin;
+
+/**
+ * Plugin for {{ namespace }}
+ */
+class Plugin extends BasePlugin
+{
+
+}

--- a/src/Template/Bake/Plugin/src/Plugin.php.twig
+++ b/src/Template/Bake/Plugin/src/Plugin.php.twig
@@ -24,5 +24,4 @@ use Cake\Core\BasePlugin;
  */
 class Plugin extends BasePlugin
 {
-
 }

--- a/tests/comparisons/Plugin/Company/Example/src/Plugin.php
+++ b/tests/comparisons/Plugin/Company/Example/src/Plugin.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Company\Example;
+
+use Cake\Core\BasePlugin;
+
+/**
+ * Plugin for Company\Example
+ */
+class Plugin extends BasePlugin
+{
+
+}

--- a/tests/comparisons/Plugin/Company/Example/src/Plugin.php
+++ b/tests/comparisons/Plugin/Company/Example/src/Plugin.php
@@ -9,5 +9,4 @@ use Cake\Core\BasePlugin;
  */
 class Plugin extends BasePlugin
 {
-
 }

--- a/tests/comparisons/Plugin/SimpleExample/src/Plugin.php
+++ b/tests/comparisons/Plugin/SimpleExample/src/Plugin.php
@@ -9,5 +9,4 @@ use Cake\Core\BasePlugin;
  */
 class Plugin extends BasePlugin
 {
-
 }

--- a/tests/comparisons/Plugin/SimpleExample/src/Plugin.php
+++ b/tests/comparisons/Plugin/SimpleExample/src/Plugin.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SimpleExample;
+
+use Cake\Core\BasePlugin;
+
+/**
+ * Plugin for SimpleExample
+ */
+class Plugin extends BasePlugin
+{
+
+}


### PR DESCRIPTION
Create the stub plugin class when creating a new plugin. I needed to fix the template name mangling to ensure that Plugin.php is generated correctly.