### PR TITLE
TableSchema::index() is deprecated. Use TableSchema::getIndex() instead.

### DIFF
--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -273,7 +273,7 @@ class FixtureTask extends BakeTask
             $cols[] = "        '$field' => [$properties],";
         }
         foreach ($table->indexes() as $index) {
-            $fieldData = $table->index($index);
+            $fieldData = $table->getIndex($index);
             $properties = implode(', ', $this->_values($fieldData));
             $indexes[] = "            '$index' => [$properties],";
         }


### PR DESCRIPTION
Error Location:  Shell/Task/FixtureTask.php, line: 276

bake version 1.7.0