### PR TITLE
Fix CommandTest setup

### DIFF
--- a/src/Template/Bake/tests/test_case.twig
+++ b/src/Template/Bake/tests/test_case.twig
@@ -76,7 +76,7 @@ class {{ className }}Test extends {{ superClassName }}
         {{ preConstruct|raw }}
 {% endif %}
 {% if isCommand %}
-        $this->{{ construction|raw }}
+        {{ construction|raw }}
 {% else %}
         $this->{{ (subject ~ ' = ' ~ construction)|raw }}
 {% endif %}

--- a/tests/comparisons/Test/testBakeCommandTest.php
+++ b/tests/comparisons/Test/testBakeCommandTest.php
@@ -18,7 +18,7 @@ class ExampleCommandTest extends ConsoleIntegrationTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->$this->useCommandRunner();
+        $this->useCommandRunner();
     }
 
     /**


### PR DESCRIPTION
Now that bake task generate below code:

```php
    public function setUp()
    {
        parent::setUp();
        $this->$this->useCommandRunner();
    }
```

As `TestTake` provide _construct_ value with **$this**:

```
$construct = "\$this->useCommandRunner();";
```

Theres no reason to repeat **$this** here.