### PR TITLE
Fixed dummy text generation for short text fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "cakephp/cakephp": "^3.6.0",
+        "cakephp/cakephp": "^3.6.12",
         "cakephp/plugin-installer": "^1.0",
         "wyrihaximus/twig-view": "^4.3.4"
     },

--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -366,7 +366,7 @@ class FixtureTask extends BakeTask
                         } else {
                             $insert = "Lorem ipsum dolor sit amet";
                             if (!empty($fieldInfo['length'])) {
-                                $insert = substr($insert, 0, (int)$fieldInfo['length'] - 2);
+                                $insert = substr($insert, 0, (int)$fieldInfo['length'] > 2 ? (int)$fieldInfo['length'] - 2 : (int)$fieldInfo['length']);
                             }
                         }
                         break;

--- a/tests/Fixture/BinaryTestsFixture.php
+++ b/tests/Fixture/BinaryTestsFixture.php
@@ -29,6 +29,7 @@ class BinaryTestsFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'integer'],
+        'byte' => ['type' => 'binary', 'length' => 1],
         'data' => ['type' => 'binary', 'length' => 300],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
     ];

--- a/tests/TestCase/Shell/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Shell/Task/FixtureTaskTest.php
@@ -18,6 +18,8 @@ use Bake\Shell\Task\BakeTemplateTask;
 use Bake\Test\TestCase\TestCase;
 use Cake\Console\Shell;
 use Cake\Core\Plugin;
+use Cake\Database\Driver\Postgres;
+use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -360,10 +362,31 @@ class FixtureTaskTest extends TestCase
      */
     public function testRecordGenerationForBinaryType()
     {
+        $driver = ConnectionManager::get('test')->getDriver();
+        $this->skipIf($driver instanceof Postgres, 'Incompatible with postgres');
+
         $this->generatedFile = ROOT . 'tests/Fixture/BinaryTestsFixture.php';
         $this->exec('bake fixture --connection test BinaryTests');
 
         $this->assertFileContains("'data' => 'Lorem ipsum dolor sit amet'", $this->generatedFile);
+        $this->assertFileContains("'byte' => 'L'", $this->generatedFile);
+    }
+
+    /**
+     * test record generation with float and binary types
+     *
+     * @return void
+     */
+    public function testRecordGenerationForBinaryTypePostgres()
+    {
+        $driver = ConnectionManager::get('test')->getDriver();
+        $this->skipIf(($driver instanceof Postgres) === false, 'Only compatible with postgres');
+
+        $this->generatedFile = ROOT . 'tests/Fixture/BinaryTestsFixture.php';
+        $this->exec('bake fixture --connection test BinaryTests');
+
+        $this->assertFileContains("'data' => 'Lorem ipsum dolor sit amet'", $this->generatedFile);
+        $this->assertFileContains("'byte' => 'Lorem ipsum dolor sit amet'", $this->generatedFile);
     }
 
     /**


### PR DESCRIPTION
Depends on cakephp/cakephp/pull/12518, https://github.com/cakephp/cakephp/pull/12552 & https://github.com/cakephp/cakephp/pull/12622

When text field is 1 charcter long generated dummy text in a fixture does not fit into a database resulting in the following error:
```
Exception: Unable to insert fixture "App\Test\Fixture\ExampleFixture" in "App\Test\TestCase\Controller\ExampleControllerTest" test
 case:
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'value' at row 1 in [.../vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureManager.php, line 345]
```