### PR TITLE
PHP7.3 removed warning about undefined variable admin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: php
 php:
   - 5.6
   - 7.0
-  - 7.1
   - 7.2
+  - 7.3
 
 cache:
   directories:
@@ -23,17 +23,17 @@ matrix:
   fast_finish: true
 
   include:
+    - php: 5.6
+      env: PREFER_LOWEST=1
+
     - php: 7.1
       env: RUN_CS=1 RUN_TESTS=0
 
     - php: 7.1
       env: PHPSTAN=1 RUN_TESTS=0
 
-    - php: 5.6
-      env: PREFER_LOWEST=1
-
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != 7.1 ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != 7.3 ]]; then phpenv config-rm xdebug.ini; fi
   - if [[ -n "$GH_TOKEN" ]]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
   - if [[ $DB = 'mysql' ]]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi
   - if [[ $DB = 'pgsql' ]]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi
@@ -43,15 +43,15 @@ before_script:
   - if [[ $PREFER_LOWEST = 1 ]]; then composer update --no-interaction --prefer-lowest --prefer-stable; fi
 
 script:
-  - if [[ $RUN_TESTS = 1 && $TRAVIS_PHP_VERSION != 7.1 ]]; then vendor/bin/phpunit; fi
-  - if [[ $RUN_TESTS = 1 && $TRAVIS_PHP_VERSION = 7.1 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - if [[ $RUN_TESTS = 1 && $TRAVIS_PHP_VERSION != 7.2 ]]; then vendor/bin/phpunit; fi
+  - if [[ $RUN_TESTS = 1 && $TRAVIS_PHP_VERSION = 7.2 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml; fi
 
   - if [[ $RUN_CS = 1 ]]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi
 
   - if [[ $PHPSTAN = 1 ]]; then composer require --dev phpstan/phpstan:^0.9 && vendor/bin/phpstan analyse -c phpstan.neon -l 4 src; fi
 
 after_success:
-  - if [[ $RUN_TESTS = 1 && $TRAVIS_PHP_VERSION = 7.1 ]]; then bash <(curl -s https://codecov.io/bash); fi
+  - if [[ $RUN_TESTS = 1 && $TRAVIS_PHP_VERSION = 7.2 ]]; then bash <(curl -s https://codecov.io/bash); fi
 
 notifications:
   email: false

--- a/src/Shell/Task/ControllerTask.php
+++ b/src/Shell/Task/ControllerTask.php
@@ -142,7 +142,6 @@ class ControllerTask extends BakeTask
 
         $data = compact(
             'actions',
-            'admin',
             'components',
             'currentModelName',
             'defaultModel',


### PR DESCRIPTION
Closes #471

I've looked into history, and the variable was used last back in 2014, when admin views, and admin routing were features baked. Currently the mentioned variable is not used anywhere in the cakephp/bake codebase, which means, it's safe to remove

patch tested in environment mentioned in #471