### PR TITLE
4.x Convert CellTask to a Command

### DIFF
--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -18,6 +18,7 @@ namespace Bake\Command;
 use Bake\Utility\CommonOptionsTrait;
 use Cake\Console\Arguments;
 use Cake\Console\Command;
+use Cake\Console\ConsoleIo;
 use Cake\Core\ConventionsTrait;
 
 /**
@@ -30,6 +31,13 @@ abstract class BakeCommand extends Command
 {
     use CommonOptionsTrait;
     use ConventionsTrait;
+
+    /**
+     * The pathFragment appended to the plugin/app path.
+     *
+     * @var string
+     */
+    protected $pathFragment;
 
     /**
      * Handles splitting up the plugin prefix and classname.
@@ -100,7 +108,7 @@ abstract class BakeCommand extends Command
     {
         if (file_exists($path)) {
             unlink($path);
-            $io->out(sprintf('<success>Deleted</success> `%s`', $path), 1, Shell::QUIET);
+            $io->out(sprintf('<success>Deleted</success> `%s`', $path), 1, ConsoleIo::QUIET);
         }
     }
 }

--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -69,6 +69,27 @@ abstract class BakeCommand extends Command
     }
 
     /**
+     * Gets the path for output. Checks the plugin property
+     * and returns the correct path.
+     *
+     * @param \Cake\Console\Arguments $args Arguments instance to read the prefix option from.
+     * @return string Path to output.
+     */
+    public function getPath(Arguments $args)
+    {
+        $path = APP . $this->pathFragment;
+        if ($this->plugin) {
+            $path = $this->_pluginPath($this->plugin) . 'src/' . $this->pathFragment;
+        }
+        $prefix = $this->getPrefix($args);
+        if ($prefix) {
+            $path .= $prefix . DS;
+        }
+
+        return str_replace('/', DS, $path);
+    }
+
+    /**
      * Delete empty file in a given path
      *
      * @param string $path Path to folder which contains 'empty' file.

--- a/src/Command/CellCommand.php
+++ b/src/Command/CellCommand.php
@@ -123,7 +123,7 @@ class CellCommand extends SimpleBakeCommand
     {
         $parser = parent::buildOptionParser($parser);
         $parser->addOption('prefix', [
-            'help' => 'The namespace prefix to use.'
+            'help' => 'The namespace prefix to use.',
         ]);
 
         return $parser;

--- a/src/Command/CellCommand.php
+++ b/src/Command/CellCommand.php
@@ -13,18 +13,17 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Bake\Shell\Task;
+namespace Bake\Command;
 
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
-use Cake\View\Cell;
 
 /**
  * Task for creating cells.
- *
- * @property \Bake\Shell\Task\TestTask $Test
  */
-class CellTask extends SimpleBakeTask
+class CellCommand extends SimpleBakeCommand
 {
     /**
      * Task name used in path generation.
@@ -60,11 +59,12 @@ class CellTask extends SimpleBakeTask
     /**
      * Get template data.
      *
+     * @param \Cake\Console\Arguments $arguments Arguments object.
      * @return array
      */
-    public function templateData()
+    public function templateData(Arguments $arguments): array
     {
-        $prefix = $this->_getPrefix();
+        $prefix = $this->getPrefix($arguments);
         if ($prefix) {
             $prefix = '\\' . str_replace('/', '\\', $prefix);
         }
@@ -81,45 +81,49 @@ class CellTask extends SimpleBakeTask
      * Bake the Cell class and template file.
      *
      * @param string $name The name of the cell to make.
-     * @return string
+     * @param \Cake\Console\Arguments $args The console arguments
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return void
      */
-    public function bake($name)
+    public function bake(string $name, Arguments $args, ConsoleIo $io)
     {
-        $this->bakeTemplate($name);
+        $this->bakeTemplate($name, $args, $io);
 
-        return parent::bake($name);
+        parent::bake($name, $args, $io);
     }
 
     /**
      * Bake an empty file for a cell.
      *
      * @param string $name The name of the cell a template is needed for.
+     * @param \Cake\Console\Arguments $args The console arguments
+     * @param \Cake\Console\ConsoleIo $io The console io
      * @return void
      */
-    public function bakeTemplate($name)
+    protected function bakeTemplate($name, $args, $io)
     {
         $restore = $this->pathFragment;
 
-        $this->pathFragment = '../templates/' . Cell::TEMPLATE_FOLDER . '/';
-        $path = $this->getPath();
-        $path .= implode(DS, [$name, 'display.php']);
+        $this->pathFragment = 'Template/Cell/';
+        $path = $this->getPath($args);
+        $path .= implode(DS, [$name, 'display.ctp']);
 
         $this->pathFragment = $restore;
 
-        $this->createFile($path, '');
+        $io->createFile($path, '');
     }
 
     /**
      * Gets the option parser instance and configures it.
      *
+     * @param \Cake\Console\ConsoleOptionParser $parser Parser instance
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser(): ConsoleOptionParser
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser();
-        $parser
-        ->addOption('prefix', [
-            'help' => 'The namespace prefix to use.',
+        $parser = parent::buildOptionParser($parser);
+        $parser->addOption('prefix', [
+            'help' => 'The namespace prefix to use.'
         ]);
 
         return $parser;

--- a/src/Command/SimpleBakeCommand.php
+++ b/src/Command/SimpleBakeCommand.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
  */
 namespace Bake\Command;
 
-use Bake\Command\TestCommand;
 use Bake\Utility\TemplateRenderer;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -231,7 +231,7 @@ class TestCommand extends BakeCommand
         $fullClassName = $this->getRealClassName($type, $className, $prefix);
 
         if (!$args->getOption('no-fixture')) {
-            if (strlen($args->getOption('fixtures'))) {
+            if ($args->getOption('fixtures')) {
                 $fixtures = array_map('trim', explode(',', $args->getOption('fixtures')));
                 $this->_fixtures = array_filter($fixtures);
             } elseif ($this->typeCanDetectFixtures($type) && class_exists($fullClassName)) {
@@ -285,7 +285,7 @@ class TestCommand extends BakeCommand
         $out = $renderer->generate('tests/test_case');
 
         $filename = $this->testCaseFileName($type, $fullClassName);
-        $emptyFile = $this->getPath() . $this->getSubspacePath($type) . DS . 'empty';
+        $emptyFile = dirname($filename) . DS . 'empty';
         $this->deleteEmptyFile($emptyFile, $io);
         if ($io->createFile($filename, $out)) {
             return $out;
@@ -523,7 +523,7 @@ class TestCommand extends BakeCommand
         $pre = $construct = $post = '';
         if ($type === 'Table') {
             $tableName = str_replace('Table', '', $className);
-            $pre = "\$config = TableRegistry::getTableLocator()->exists('{$tableName}')" .
+            $pre = "\$config = TableRegistry::getTableLocator()->exists('{$tableName}') " .
                 "? [] : ['className' => {$className}::class];";
             $construct = "TableRegistry::getTableLocator()->get('{$tableName}', \$config);";
         }
@@ -658,11 +658,11 @@ class TestCommand extends BakeCommand
     }
 
     /**
-     * Get the file path.
+     * Get the base path to the plugin/app tests.
      *
      * @return string
      */
-    public function getPath()
+    public function getBasePath()
     {
         $dir = 'TestCase/';
         $path = defined('TESTS') ? TESTS . $dir : ROOT . DS . 'tests' . DS . $dir;
@@ -683,7 +683,7 @@ class TestCommand extends BakeCommand
      */
     public function testCaseFileName($type, $className)
     {
-        $path = $this->getPath();
+        $path = $this->getBasePath();
         $namespace = Configure::read('App.namespace');
         if ($this->plugin) {
             $namespace = $this->plugin;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Bake;
 
+use Bake\Command\CellCommand;
 use Bake\Command\TestCommand;
 use Bake\Shell\BakeShell;
 use Cake\Console\CommandCollection;
@@ -65,6 +66,7 @@ class Plugin extends BasePlugin
     {
         // Temporary until cakephp/cakephp#12824 is merged
         $commands->add('bake:test', TestCommand::class);
+        $commands->add('bake:cell', CellCommand::class);
 
         // Add shell for incomplete tasks and backwards compatibility discover.
         $commands->add('bake', BakeShell::class);

--- a/src/Utility/CommonOptionsTrait.php
+++ b/src/Utility/CommonOptionsTrait.php
@@ -51,6 +51,8 @@ trait CommonOptionsTrait
      */
     protected function extractCommonProperties(Arguments $args): void
     {
+        // These properties should ideally not exist, but until ConsoleOptionParser
+        // gets validation and transform logic they will have to stay.
         if ($args->hasOption('plugin')) {
             $plugin = $args->getOption('plugin');
             $parts = explode('/', $plugin);

--- a/src/Utility/TemplateRenderer.php
+++ b/src/Utility/TemplateRenderer.php
@@ -34,7 +34,7 @@ class TemplateRenderer
     /**
      * BakeView instance
      *
-     * @var \Bake\View\BakeView
+     * @var \Bake\View\BakeView|null
      */
     protected $view;
 

--- a/templates/bake/View/cell.twig
+++ b/templates/bake/View/cell.twig
@@ -37,7 +37,7 @@ class {{ name }}Cell extends Cell
      *
      * @return void
      */
-    public function initialize()
+    public function initialize(): void
     {
     }
 

--- a/tests/TestCase/Command/CellCommandTest.php
+++ b/tests/TestCase/Command/CellCommandTest.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
@@ -13,10 +12,11 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Bake\Test\TestCase\Shell\Task;
+namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
 use Cake\Console\Shell;
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 
 /**
@@ -33,6 +33,9 @@ class CellTaskTest extends TestCase
     {
         parent::setUp();
         $this->_compareBasePath = Plugin::path('Bake') . 'tests' . DS . 'comparisons' . DS . 'Cell' . DS;
+
+        $this->useCommandRunner();
+        $this->setAppNamespace('Bake\Test\App');
     }
 
     /**
@@ -45,9 +48,9 @@ class CellTaskTest extends TestCase
         $this->generatedFiles = [
             APP . 'View/Cell/ExampleCell.php',
             ROOT . 'tests/TestCase/View/Cell/ExampleCellTest.php',
-            ROOT . 'templates/cell/Example/display.php',
+            APP . 'Template/Cell/Example/display.ctp',
         ];
-        $this->exec('bake cell Example');
+        $this->exec('bake:cell Example');
 
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
@@ -63,14 +66,13 @@ class CellTaskTest extends TestCase
     {
         $this->_loadTestPlugin('TestBake');
         $path = Plugin::path('TestBake');
-        $templatePath = Plugin::templatePath('TestBake');
 
         $this->generatedFiles = [
             $path . 'src/View/Cell/ExampleCell.php',
             $path . 'tests/TestCase/View/Cell/ExampleCellTest.php',
-            $templatePath . 'cell/Example/display.php',
+            $path . 'src/Template/Cell/Example/display.ctp',
         ];
-        $this->exec('bake cell TestBake.Example');
+        $this->exec('bake:cell TestBake.Example');
 
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertFileContains('namespace TestBake\View\Cell;', $this->generatedFiles[0]);
@@ -86,14 +88,13 @@ class CellTaskTest extends TestCase
     {
         $this->_loadTestPlugin('TestBake');
         $path = Plugin::path('TestBake');
-        $templatePath = Plugin::templatePath('TestBake');
 
         $this->generatedFiles = [
             $path . 'src/View/Cell/ExampleCell.php',
             $path . 'tests/TestCase/View/Cell/ExampleCellTest.php',
-            $templatePath . 'cell/Example/display.php',
+            $path . 'src/Template/Cell/Example/display.ctp',
         ];
-        $this->exec('bake cell TestBake.Example');
+        $this->exec('bake:cell --plugin TestBake Example');
 
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
@@ -109,13 +110,13 @@ class CellTaskTest extends TestCase
         $this->generatedFiles = [
             APP . 'View/Cell/Admin/ExampleCell.php',
             ROOT . 'tests/TestCase/View/Cell/Admin/ExampleCellTest.php',
-            ROOT . 'templates/cell/Admin/Example/display.php',
+            APP . 'Template/Cell/Admin/Example/display.ctp',
         ];
-        $this->exec('bake cell --prefix Admin Example');
+        $this->exec('bake:cell --prefix Admin Example');
 
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
-        $this->assertFileContains('namespace App\View\Cell\Admin;', $this->generatedFiles[0]);
+        $this->assertFileContains('namespace Bake\Test\App\View\Cell\Admin;', $this->generatedFiles[0]);
         $this->assertFileContains('class ExampleCell extends Cell', $this->generatedFiles[0]);
     }
 
@@ -128,14 +129,13 @@ class CellTaskTest extends TestCase
     {
         $this->_loadTestPlugin('TestBake');
         $path = Plugin::path('TestBake');
-        $templatePath = Plugin::templatePath('TestBake');
 
         $this->generatedFiles = [
             $path . 'src/View/Cell/Admin/ExampleCell.php',
             $path . 'tests/TestCase/View/Cell/Admin/ExampleCellTest.php',
-            $templatePath . 'cell/Admin/Example/display.php',
+            $path . 'src/Template/Cell/Admin/Example/display.ctp',
         ];
-        $this->exec('bake cell --prefix Admin TestBake.Example');
+        $this->exec('bake:cell --prefix Admin TestBake.Example');
 
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertFileContains('namespace TestBake\View\Cell\Admin;', $this->generatedFiles[0]);

--- a/tests/TestCase/Command/CellCommandTest.php
+++ b/tests/TestCase/Command/CellCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
@@ -16,7 +17,6 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
 use Cake\Console\Shell;
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 
 /**

--- a/tests/TestCase/Shell/BakeShellTest.php
+++ b/tests/TestCase/Shell/BakeShellTest.php
@@ -206,7 +206,6 @@ class BakeShellTest extends TestCase
             '',
             '- all',
             '- behavior',
-            '- cell',
             '- command',
             '- component',
             '- controller',
@@ -264,7 +263,6 @@ class BakeShellTest extends TestCase
         $this->Shell->loadTasks();
         $expected = [
             'Bake.Behavior',
-            'Bake.Cell',
             'Bake.Command',
             'Bake.Component',
             'Bake.Fixture',

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -48,13 +48,13 @@ abstract class TestCase extends BaseTestCase
         parent::tearDown();
 
         if ($this->generatedFile) {
-            unlink($this->generatedFile);
+            @unlink($this->generatedFile);
             $this->generatedFile = '';
         }
 
         if (count($this->generatedFiles)) {
             foreach ($this->generatedFiles as $file) {
-                unlink($file);
+                @unlink($file);
             }
             $this->generatedFiles = [];
         }

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -47,14 +47,16 @@ abstract class TestCase extends BaseTestCase
     {
         parent::tearDown();
 
-        if ($this->generatedFile) {
-            @unlink($this->generatedFile);
+        if ($this->generatedFile && file_exists($this->generatedFile)) {
+            unlink($this->generatedFile);
             $this->generatedFile = '';
         }
 
         if (count($this->generatedFiles)) {
             foreach ($this->generatedFiles as $file) {
-                @unlink($file);
+                if (file_exists($file)) {
+                    unlink($file);
+                }
             }
             $this->generatedFiles = [];
         }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,6 +45,7 @@ define('CACHE', TMP . 'cache' . DS);
 
 Configure::write('debug', true);
 Configure::write('App', [
+    'debug' => true,
     'namespace' => 'App',
     'paths' => [
         'plugins' => [ROOT . 'Plugin' . DS],

--- a/tests/comparisons/Cell/testBakePlugin.php
+++ b/tests/comparisons/Cell/testBakePlugin.php
@@ -5,7 +5,6 @@ use Cake\View\Cell;
 
 /**
  * Example cell
- *
  */
 class ExampleCell extends Cell
 {

--- a/tests/comparisons/Cell/testBakePlugin.php
+++ b/tests/comparisons/Cell/testBakePlugin.php
@@ -5,6 +5,7 @@ use Cake\View\Cell;
 
 /**
  * Example cell
+ *
  */
 class ExampleCell extends Cell
 {
@@ -22,7 +23,7 @@ class ExampleCell extends Cell
      *
      * @return void
      */
-    public function initialize()
+    public function initialize(): void
     {
     }
 


### PR DESCRIPTION
Move the first of the `SimpleBakeTask` subclasses over to a command. This should make converting the other subclasses easier as they are mostly the same.