### PR TITLE
Create FixtureCommands

### DIFF
--- a/src/Command/FixtureAllCommand.php
+++ b/src/Command/FixtureAllCommand.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Command;
+
+use Bake\Utility\CommonOptionsTrait;
+use Bake\Utility\TableScanner;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Datasource\ConnectionManager;
+
+/**
+ * Task class for creating all fixtures in an application
+ */
+class FixtureAllCommand extends BakeCommand
+{
+    use CommonOptionsTrait;
+
+    /**
+     * Gets the option parser instance and configures it.
+     *
+     * @param \Cake\Console\ConsoleOptionParser $parser The parser to update
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        $parser = $this->_setCommonOptions($parser);
+
+        $parser = $parser->setDescription(
+            'Generate all fixtures for use with the test suite.'
+        )->addOption('count', [
+            'help' => 'When using generated data, the number of records to include in the fixture(s).',
+            'short' => 'n',
+            'default' => 1,
+        ])->addOption('schema', [
+            'help' => 'Create a fixture that imports schema, instead of dumping a schema snapshot into the fixture.',
+            'short' => 's',
+            'boolean' => true,
+        ])->addOption('records', [
+            'help' => 'Generate a fixture with records from the non-test database.' .
+            ' Used with --count and --conditions to limit which records are added to the fixture.',
+            'short' => 'r',
+            'boolean' => true,
+        ])->addOption('conditions', [
+            'help' => 'The SQL snippet to use when importing records.',
+            'default' => '1=1',
+        ]);
+
+        return $parser;
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return void
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $this->extractCommonProperties($args);
+
+        $connection = ConnectionManager::get($args->getOption('connection') ?? 'default');
+        $scanner = new TableScanner($connection);
+        $fixture = new FixtureCommand();
+        foreach ($scanner->listUnskipped() as $table) {
+            $fixtureArgs = new Arguments([$table], $args->getOptions(), ['name']);
+            $fixture->execute($fixtureArgs, $io);
+        }
+    }
+}

--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -1,0 +1,454 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Command;
+
+use Bake\Utility\TableScanner;
+use Bake\Utility\TemplateRenderer;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Configure;
+use Cake\Database\Exception;
+use Cake\Database\Schema\TableSchema;
+use Cake\Datasource\ConnectionManager;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
+use Cake\Utility\Text;
+use DateTimeInterface;
+
+/**
+ * Task class for creating and updating fixtures files.
+ */
+class FixtureCommand extends BakeCommand
+{
+    /**
+     * Get the file path.
+     *
+     * @param \Cake\Console\Arguments $args Arguments instance to read the prefix option from.
+     * @return string Path to output.
+     */
+    public function getPath(Arguments $args)
+    {
+        $dir = 'Fixture/';
+        $path = defined('TESTS') ? TESTS . $dir : ROOT . DS . 'tests' . DS . $dir;
+        if ($this->plugin) {
+            $path = $this->_pluginPath($this->plugin) . 'tests/' . $dir;
+        }
+
+        return str_replace('/', DS, $path);
+    }
+
+    /**
+     * Gets the option parser instance and configures it.
+     *
+     * @param \Cake\Console\ConsoleOptionParser $parser Option parser to update.
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        $parser = $this->_setCommonOptions($parser);
+
+        $parser = $parser->setDescription(
+            'Generate fixtures for use with the test suite. You can use `bake fixture all` to bake all fixtures.'
+        )->addArgument('name', [
+            'help' => 'Name of the fixture to bake (without the `Fixture` suffix). ' .
+                'You can use Plugin.name to bake plugin fixtures.',
+        ])->addOption('table', [
+            'help' => 'The table name if it does not follow conventions.',
+        ])->addOption('count', [
+            'help' => 'When using generated data, the number of records to include in the fixture(s).',
+            'short' => 'n',
+            'default' => 1,
+        ])->addOption('schema', [
+            'help' => 'Create a fixture that imports schema, instead of dumping a schema snapshot into the fixture.',
+            'short' => 's',
+            'boolean' => true,
+        ])->addOption('records', [
+            'help' => 'Generate a fixture with records from the non-test database.' .
+            ' Used with --count and --conditions to limit which records are added to the fixture.',
+            'short' => 'r',
+            'boolean' => true,
+        ])->addOption('conditions', [
+            'help' => 'The SQL snippet to use when importing records.',
+            'default' => '1=1',
+        ])->addSubcommand('all', [
+            'help' => 'Bake all fixture files for tables in the chosen connection.',
+        ]);
+
+        return $parser;
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return null|int The exit code or null for success
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $this->extractCommonProperties($args);
+        $name = $args->getArgument('name') ?? '';
+        $name = $this->_getName($name);
+
+        $connection = ConnectionManager::get($this->connection);
+        $scanner = new TableScanner($connection);
+        if (empty($name)) {
+            $io->out('Choose a fixture to bake from the following:');
+            foreach ($scanner->listUnskipped() as $table) {
+                $io->out('- ' . $this->_camelize($table));
+            }
+
+            return static::CODE_SUCCESS;
+        }
+
+        $table = $args->getOption('table');
+        $model = $this->_camelize($name);
+        $this->bake($model, $table, $args, $io);
+    }
+
+    /**
+     * Assembles and writes a Fixture file
+     *
+     * @param string $model Name of model to bake.
+     * @param string $useTable Name of table to use.
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return void
+     * @throws \RuntimeException
+     */
+    protected function bake($model, $useTable, $args, $io)
+    {
+        $table = $schema = $records = $import = $modelImport = null;
+
+        if (!$useTable) {
+            $useTable = Inflector::tableize($model);
+        } elseif ($useTable !== Inflector::tableize($model)) {
+            $table = $useTable;
+        }
+
+        $importBits = [];
+        if ($args->getOption('schema')) {
+            $modelImport = true;
+            $importBits[] = "'table' => '{$useTable}'";
+        }
+        if (!empty($importBits) && $this->connection !== 'default') {
+            $importBits[] = "'connection' => '{$this->connection}'";
+        }
+        if (!empty($importBits)) {
+            $import = sprintf("[%s]", implode(', ', $importBits));
+        }
+
+        try {
+            $data = $this->readSchema($model, $useTable);
+        } catch (Exception $e) {
+            TableRegistry::getTableLocator()->remove($model);
+            $useTable = Inflector::underscore($model);
+            $table = $useTable;
+            $data = $this->readSchema($model, $useTable);
+        }
+
+        if ($modelImport === null) {
+            $schema = $this->_generateSchema($data);
+        }
+
+        if ($args->getOption('records')) {
+            $records = $this->_makeRecordString($this->_getRecordsFromTable($model, $useTable));
+        } else {
+            $recordCount = 1;
+            if (isset($this->params['count'])) {
+                $recordCount = $this->params['count'];
+            }
+            $records = $this->_makeRecordString($this->_generateRecords($data, $recordCount));
+        }
+
+        $this->generateFixtureFile($args, $io, $model, compact('records', 'table', 'schema', 'import'));
+    }
+
+    /**
+     * Get schema metadata for the current table mapping.
+     *
+     * @param string $name The model alias to use
+     * @param string $table The table name to get schema metadata for.
+     * @return \Cake\Database\Schema\TableSchema
+     */
+    public function readSchema($name, $table)
+    {
+        $connection = ConnectionManager::get($this->connection);
+
+        if (TableRegistry::getTableLocator()->exists($name)) {
+            $model = TableRegistry::getTableLocator()->get($name);
+        } else {
+            $model = TableRegistry::getTableLocator()->get($name, [
+                'table' => $table,
+                'connection' => $connection,
+            ]);
+        }
+
+        return $model->getSchema();
+    }
+
+    /**
+     * Generate the fixture file, and write to disk
+     *
+     * @param \Cake\Console\Arguments $args The CLI arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io instance.
+     * @param string $model name of the model being generated
+     * @param array $otherVars Contents of the fixture file.
+     * @return void
+     */
+    public function generateFixtureFile($args, $io, $model, array $otherVars)
+    {
+        $defaults = [
+            'name' => $model,
+            'table' => null,
+            'schema' => null,
+            'records' => null,
+            'import' => null,
+            'fields' => null,
+            'namespace' => Configure::read('App.namespace'),
+        ];
+        if ($this->plugin) {
+            $defaults['namespace'] = $this->_pluginNamespace($this->plugin);
+        }
+        $vars = $otherVars + $defaults;
+
+        $path = $this->getPath($args);
+        $filename = $vars['name'] . 'Fixture.php';
+
+        $renderer = new TemplateRenderer($args->getOption('theme'));
+        $renderer->set('model', $model);
+        $renderer->set($vars);
+        $content = $renderer->generate('tests/fixture');
+
+        $io->out("\n" . sprintf('Baking test fixture for %s...', $model), 1, ConsoleIo::QUIET);
+        $io->createFile($path . $filename, $content);
+        $emptyFile = $path . 'empty';
+        $this->deleteEmptyFile($emptyFile, $io);
+    }
+
+    /**
+     * Generates a string representation of a schema.
+     *
+     * @param \Cake\Database\Schema\TableSchema $table Table schema
+     * @return string fields definitions
+     */
+    protected function _generateSchema(TableSchema $table)
+    {
+        $cols = $indexes = $constraints = [];
+        foreach ($table->columns() as $field) {
+            $fieldData = $table->getColumn($field);
+            $properties = implode(', ', $this->_values($fieldData));
+            $cols[] = "        '$field' => [$properties],";
+        }
+        foreach ($table->indexes() as $index) {
+            $fieldData = $table->getIndex($index);
+            $properties = implode(', ', $this->_values($fieldData));
+            $indexes[] = "            '$index' => [$properties],";
+        }
+        foreach ($table->constraints() as $index) {
+            $fieldData = $table->getConstraint($index);
+            $properties = implode(', ', $this->_values($fieldData));
+            $constraints[] = "            '$index' => [$properties],";
+        }
+        $options = $this->_values($table->getOptions());
+
+        $content = implode("\n", $cols) . "\n";
+        if (!empty($indexes)) {
+            $content .= "        '_indexes' => [\n" . implode("\n", $indexes) . "\n        ],\n";
+        }
+        if (!empty($constraints)) {
+            $content .= "        '_constraints' => [\n" . implode("\n", $constraints) . "\n        ],\n";
+        }
+        if (!empty($options)) {
+            foreach ($options as &$option) {
+                $option = '            ' . $option;
+            }
+            $content .= "        '_options' => [\n" . implode(",\n", $options) . "\n        ],\n";
+        }
+
+        return "[\n$content    ]";
+    }
+
+    /**
+     * Formats Schema columns from Model Object
+     *
+     * @param array $values options keys(type, null, default, key, length, extra)
+     * @return array Formatted values
+     */
+    protected function _values($values)
+    {
+        $vals = [];
+        if (!is_array($values)) {
+            return $vals;
+        }
+        foreach ($values as $key => $val) {
+            if (is_array($val)) {
+                $vals[] = "'{$key}' => [" . implode(", ", $this->_values($val)) . "]";
+            } else {
+                $val = var_export($val, true);
+                if ($val === 'NULL') {
+                    $val = 'null';
+                }
+                if (!is_numeric($key)) {
+                    $vals[] = "'{$key}' => {$val}";
+                } else {
+                    $vals[] = "{$val}";
+                }
+            }
+        }
+
+        return $vals;
+    }
+
+    /**
+     * Generate String representation of Records
+     *
+     * @param \Cake\Database\Schema\TableSchema $table Table schema array
+     * @param int $recordCount The number of records to generate.
+     * @return array Array of records to use in the fixture.
+     */
+    protected function _generateRecords(TableSchema $table, $recordCount = 1)
+    {
+        $records = [];
+        for ($i = 0; $i < $recordCount; $i++) {
+            $record = [];
+            foreach ($table->columns() as $field) {
+                $fieldInfo = $table->getColumn($field);
+                $insert = '';
+                switch ($fieldInfo['type']) {
+                    case 'decimal':
+                        $insert = $i + 1.5;
+                        break;
+                    case 'biginteger':
+                    case 'integer':
+                    case 'float':
+                    case 'smallinteger':
+                    case 'tinyinteger':
+                        $insert = $i + 1;
+                        break;
+                    case 'string':
+                    case 'binary':
+                        $isPrimary = in_array($field, $table->primaryKey());
+                        if ($isPrimary) {
+                            $insert = Text::uuid();
+                        } else {
+                            $insert = "Lorem ipsum dolor sit amet";
+                            if (!empty($fieldInfo['length'])) {
+                                $insert = substr(
+                                    $insert,
+                                    0,
+                                    (int)$fieldInfo['length'] > 2
+                                        ? (int)$fieldInfo['length'] - 2
+                                        : (int)$fieldInfo['length']
+                                );
+                            }
+                        }
+                        break;
+                    case 'timestamp':
+                        $insert = time();
+                        break;
+                    case 'datetime':
+                        $insert = date('Y-m-d H:i:s');
+                        break;
+                    case 'date':
+                        $insert = date('Y-m-d');
+                        break;
+                    case 'time':
+                        $insert = date('H:i:s');
+                        break;
+                    case 'boolean':
+                        $insert = 1;
+                        break;
+                    case 'text':
+                        $insert = "Lorem ipsum dolor sit amet, aliquet feugiat.";
+                        $insert .= " Convallis morbi fringilla gravida,";
+                        $insert .= " phasellus feugiat dapibus velit nunc, pulvinar eget sollicitudin";
+                        $insert .= " venenatis cum nullam, vivamus ut a sed, mollitia lectus. Nulla";
+                        $insert .= " vestibulum massa neque ut et, id hendrerit sit,";
+                        $insert .= " feugiat in taciti enim proin nibh, tempor dignissim, rhoncus";
+                        $insert .= " duis vestibulum nunc mattis convallis.";
+                        break;
+                    case 'uuid':
+                        $insert = Text::uuid();
+                        break;
+                }
+                $record[$field] = $insert;
+            }
+            $records[] = $record;
+        }
+
+        return $records;
+    }
+
+    /**
+     * Convert a $records array into a string.
+     *
+     * @param array $records Array of records to be converted to string
+     * @return string A string value of the $records array.
+     */
+    protected function _makeRecordString($records)
+    {
+        $out = "[\n";
+        foreach ($records as $record) {
+            $values = [];
+            foreach ($record as $field => $value) {
+                if ($value instanceof DateTimeInterface) {
+                    $value = $value->format('Y-m-d H:i:s');
+                }
+                $val = var_export($value, true);
+                if ($val === 'NULL') {
+                    $val = 'null';
+                }
+                $values[] = "                '$field' => $val";
+            }
+            $out .= "            [\n";
+            $out .= implode(",\n", $values);
+            $out .= "\n            ],\n";
+        }
+        $out .= "        ]";
+
+        return $out;
+    }
+
+    /**
+     * Interact with the user to get a custom SQL condition and use that to extract data
+     * to build a fixture.
+     *
+     * @param string $modelName name of the model to take records from.
+     * @param string|null $useTable Name of table to use.
+     * @return array Array of records.
+     */
+    protected function _getRecordsFromTable($modelName, $useTable = null)
+    {
+        $recordCount = ($this->params['count'] ?? 10);
+        $conditions = ($this->params['conditions'] ?? '1=1');
+        if (TableRegistry::getTableLocator()->exists($modelName)) {
+            $model = TableRegistry::getTableLocator()->get($modelName);
+        } else {
+            $model = TableRegistry::getTableLocator()->get($modelName, [
+                'table' => $useTable,
+                'connection' => ConnectionManager::get($this->connection),
+            ]);
+        }
+        $records = $model->find('all')
+            ->where($conditions)
+            ->limit($recordCount)
+            ->enableHydration(false);
+
+        return $records->toArray();
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -19,6 +19,8 @@ use Bake\Command\BehaviorCommand;
 use Bake\Command\CellCommand;
 use Bake\Command\CommandCommand;
 use Bake\Command\ComponentCommand;
+use Bake\Command\FixtureAllCommand;
+use Bake\Command\FixtureCommand;
 use Bake\Command\FormCommand;
 use Bake\Command\HelperCommand;
 use Bake\Command\MailerCommand;
@@ -78,6 +80,8 @@ class Plugin extends BasePlugin
         $commands->add('bake cell', CellCommand::class);
         $commands->add('bake command', CommandCommand::class);
         $commands->add('bake component', ComponentCommand::class);
+        $commands->add('bake fixture', FixtureCommand::class);
+        $commands->add('bake fixture all', FixtureAllCommand::class);
         $commands->add('bake form', FormCommand::class);
         $commands->add('bake helper', HelperCommand::class);
         $commands->add('bake mailer', MailerCommand::class);

--- a/src/Utility/TableScanner.php
+++ b/src/Utility/TableScanner.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Utility;
+
+use Cake\Database\Connection;
+use RuntimeException;
+
+/**
+ * Fetch table listings from ConnectionManager
+ *
+ * Allows common infrastructure tables to be ignored based
+ * parameters.
+ *
+ * @internal
+ */
+class TableScanner
+{
+    /**
+     * @var \Cake\Datasource\Connection
+     */
+    protected $connection;
+
+    /**
+     * @var array
+     */
+    protected $ignore;
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\Database\Connection $connection The connection name in ConnectionManager
+     * @param array|null $ignore List of tables to ignore. If null, the default ignore
+     *   list will be used.
+     */
+    public function __construct(Connection $connection, ?array $ignore = null)
+    {
+        $this->connection = $connection;
+        if ($ignore === null) {
+            $ignore = ['i18n', 'cake_sessions', 'phinxlog', 'users_phinxlog'];
+        }
+        $this->ignore = $ignore;
+    }
+
+    /**
+     * Get all tables in the connection without applying ignores.
+     *
+     * @return array
+     */
+    public function listAll()
+    {
+        $schema = $this->connection->getSchemaCollection();
+        $tables = $schema->listTables();
+        if (empty($tables)) {
+            throw new RuntimeException('Your database does not have any tables.');
+        }
+        sort($tables);
+
+        return $tables;
+    }
+
+    /**
+     * Get all tables in the connection that aren't ignored.
+     *
+     * @return array
+     */
+    public function listUnskipped()
+    {
+        $tables = $this->listAll();
+
+        return array_diff($tables, $this->ignore);
+    }
+}

--- a/tests/TestCase/Command/FixtureAllCommandTest.php
+++ b/tests/TestCase/Command/FixtureAllCommandTest.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\TestCase\Command;
+
+use Bake\Test\TestCase\TestCase;
+use Cake\Console\Command;
+use Cake\Core\Plugin;
+
+/**
+ * FixtureAllCommand Test
+ *
+ */
+class FixtureAllCommandTest extends TestCase
+{
+    /**
+     * fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'core.Articles',
+        'core.Comments',
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->_compareBasePath = Plugin::path('Bake') . 'tests' . DS . 'comparisons' . DS . 'Fixture' . DS;
+        $this->setAppNamespace('Bake\Test\App');
+        $this->useCommandRunner();
+    }
+
+    /**
+     * test that execute runs all() when args[0] = all
+     *
+     * @return void
+     */
+    public function testMainIntoAll()
+    {
+        $this->generatedFiles = [
+             ROOT . 'tests/Fixture/ArticlesFixture.php',
+             ROOT . 'tests/Fixture/CommentsFixture.php',
+        ];
+        $this->exec('bake fixture all --connection test');
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFilesExist($this->generatedFiles);
+        $this->assertFileContains('class ArticlesFixture', $this->generatedFiles[0]);
+        $this->assertFileContains('class CommentsFixture', $this->generatedFiles[1]);
+    }
+
+    /**
+     * test using all() with -count and -records
+     *
+     * @return void
+     */
+    public function testAllWithCountAndRecordsFlags()
+    {
+        $this->generatedFiles = [
+             ROOT . 'tests/Fixture/ArticlesFixture.php',
+             ROOT . 'tests/Fixture/CommentsFixture.php',
+        ];
+        $this->exec('bake fixture all --connection test --count 10 --records');
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFilesExist($this->generatedFiles);
+        $this->assertFileContains("'title' => 'Third Article'", $this->generatedFiles[0]);
+        $this->assertFileContains(
+            "'comment' => 'First Comment for First Article'",
+            $this->generatedFiles[1]
+        );
+    }
+
+    /**
+     * test using all() with -schema
+     *
+     * @return void
+     */
+    public function testAllWithSchemaImport()
+    {
+        $this->generatedFiles = [
+             ROOT . 'tests/Fixture/ArticlesFixture.php',
+             ROOT . 'tests/Fixture/CommentsFixture.php',
+        ];
+        $this->exec('bake fixture all --connection test --schema');
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFilesExist($this->generatedFiles);
+        $this->assertFileContains(
+            "public \$import = ['table' => 'articles'",
+            $this->generatedFiles[0]
+        );
+        $this->assertFileContains(
+            "public \$import = ['table' => 'comments'",
+            $this->generatedFiles[1]
+        );
+    }
+}

--- a/tests/TestCase/Command/FixtureCommandTest.php
+++ b/tests/TestCase/Command/FixtureCommandTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Bake\Test\TestCase\Shell\Task;
+namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
 use Cake\Console\Shell;
@@ -23,10 +23,10 @@ use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 
 /**
- * FixtureTaskTest class
+ * FixtureCommand Test
  *
  */
-class FixtureTaskTest extends TestCase
+class FixtureCommandTest extends TestCase
 {
     /**
      * fixtures
@@ -43,11 +43,6 @@ class FixtureTaskTest extends TestCase
     ];
 
     /**
-     * @var \Bake\Shell\Task\ModelTask|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $Task;
-
-    /**
      * setUp method
      *
      * @return void
@@ -55,55 +50,10 @@ class FixtureTaskTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->Task = $this->getMockBuilder('Bake\Shell\Task\FixtureTask')
-            ->setMethods(['in', 'err', 'createFile', '_stop', 'clear'])
-            ->setConstructorArgs([$io])
-            ->getMock();
-        $this->Task->Model = $this->getMockBuilder('Bake\Shell\Task\ModelTask')
-            ->setMethods(['in', 'out', 'err', 'createFile', 'getName', 'getTable', 'listUnskipped'])
-            ->setConstructorArgs([$io])
-            ->getMock();
 
         $this->_compareBasePath = Plugin::path('Bake') . 'tests' . DS . 'comparisons' . DS . 'Fixture' . DS;
-    }
-
-    /**
-     * tearDown method
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        unset($this->Task);
-    }
-
-    /**
-     * Test that initialize() copies the connection property over.
-     *
-     * @return void
-     */
-    public function testInitializeCopyConnection()
-    {
-        $this->assertEquals('', $this->Task->connection);
-        $this->Task->params = ['connection' => 'test'];
-
-        $this->Task->initialize();
-        $this->assertEquals('test', $this->Task->connection);
-    }
-
-    /**
-     * test that initialize sets the path
-     *
-     * @return void
-     */
-    public function testGetPath()
-    {
-        $this->assertPathEquals(ROOT . DS . 'tests' . DS . 'Fixture/', $this->Task->getPath());
+        $this->setAppNamespace('Bake\Test\App');
+        $this->useCommandRunner();
     }
 
     /**
@@ -209,6 +159,7 @@ class FixtureTaskTest extends TestCase
      */
     public function testMainIntoAll()
     {
+        $this->markTestIncomplete('Move to fixture all test');
         $this->Task->connection = 'test';
         $this->Task->Model->expects($this->any())
             ->method('listUnskipped')
@@ -234,6 +185,7 @@ class FixtureTaskTest extends TestCase
      */
     public function testAllWithCountAndRecordsFlags()
     {
+        $this->markTestIncomplete('Move to fixture all test');
         $this->Task->connection = 'test';
         $this->Task->params = ['count' => 10, 'records' => true];
 
@@ -262,6 +214,7 @@ class FixtureTaskTest extends TestCase
      */
     public function testAllWithSchemaImport()
     {
+        $this->markTestIncomplete('Move to fixture all test');
         $this->Task->connection = 'test';
         $this->Task->params = ['schema' => true];
 
@@ -399,7 +352,7 @@ class FixtureTaskTest extends TestCase
         $this->exec('bake fixture --connection test Articles');
 
         $this->assertFileContains('<?php', $this->generatedFile);
-        $this->assertFileContains('namespace App\Test\Fixture;', $this->generatedFile);
+        $this->assertFileContains('namespace Bake\Test\App\Test\Fixture;', $this->generatedFile);
         $this->assertFileContains("'body' => ['type' => 'json'", $this->generatedFile);
     }
 

--- a/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
+++ b/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
@@ -1,5 +1,5 @@
 <?php
-namespace App\Test\Fixture;
+namespace Bake\Test\App\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 


### PR DESCRIPTION
Because of how commands work the `all` subcommand found in the fixture task requires another command. I've not removed the old fixture command as doing so would break the ModelTask. Once ModelTask has been converted I can remove the old FixtureTask as well.

The new `TableScanner` utility class replicates behavior from ModelTask but allows that logic to be decoupled from tasks/commands allowing it to be more easily reused across bake.