### PR TITLE
Switch to using the interface instead of extend

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,3 @@
 parameters:
     autoload_files:
         - tests/bootstrap.php
-    ignoreErrors:
-        - '#Bake\\Utility\\SubsetSchemaCollection::__construct\(\) does not call parent#'

--- a/src/Utility/SubsetSchemaCollection.php
+++ b/src/Utility/SubsetSchemaCollection.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  */
 namespace Bake\Utility;
 
-use Cake\Database\Schema\Collection;
+use Cake\Database\Schema\CollectionInterface;
 use Cake\Database\Schema\TableSchemaInterface;
 
 /**
@@ -24,7 +24,7 @@ use Cake\Database\Schema\TableSchemaInterface;
  * Useful to create determinsitic subsets of fixtures when
  * testing.
  */
-class SubsetSchemaCollection extends Collection
+class SubsetSchemaCollection implements CollectionInterface
 {
     /**
      * @var \Cake\Database\Schema\Collection
@@ -38,10 +38,10 @@ class SubsetSchemaCollection extends Collection
 
     /**
      *
-     * @param \Cake\Database\Schema\Collection $collection The wrapped collection
+     * @param \Cake\Database\Schema\CollectionInterface $collection The wrapped collection
      * @param array $tables The subset of tables.
      */
-    public function __construct(Collection $collection, array $tables)
+    public function __construct(CollectionInterface $collection, array $tables)
     {
         $this->collection = $collection;
         $this->tables = $tables;
@@ -50,9 +50,9 @@ class SubsetSchemaCollection extends Collection
     /**
      * Get the wrapped collection
      *
-     * @return \Cake\Database\Schema\Collection
+     * @return \Cake\Database\Schema\CollectionInterface
      */
-    public function getInnerCollection(): Collection
+    public function getInnerCollection(): CollectionInterface
     {
         return $this->collection;
     }

--- a/src/Utility/SubsetSchemaCollection.php
+++ b/src/Utility/SubsetSchemaCollection.php
@@ -27,7 +27,7 @@ use Cake\Database\Schema\TableSchemaInterface;
 class SubsetSchemaCollection implements CollectionInterface
 {
     /**
-     * @var \Cake\Database\Schema\Collection
+     * @var \Cake\Database\Schema\CollectionInterface
      */
     protected $collection;
 


### PR DESCRIPTION
The new interface was partly added to make this scenario easier. Use the interface instead of the base class.