### PR TITLE
Make sure the confirm JavaScript is escaped

### DIFF
--- a/src/Template/Bake/Element/form.twig
+++ b/src/Template/Bake/Element/form.twig
@@ -21,7 +21,7 @@
         <li><?= $this->Form->postLink(
                 __('Delete'),
                 ['action' => 'delete', ${{ singularVar }}->{{ primaryKey[0] }}],
-                ['confirm' => __('Are you sure you want to delete # {0}?', ${{ singularVar }}->{{ primaryKey[0] }})]
+                ['confirm' => __('Are you sure you want to delete # {0}?', ${{ singularVar }}->{{ primaryKey[0] }}), 'escape' => true]
             )
         ?></li>
 {% endif %}

--- a/src/Template/Bake/Template/index.twig
+++ b/src/Template/Bake/Template/index.twig
@@ -71,7 +71,7 @@
                 <td class="actions">
                     <?= $this->Html->link(__('View'), ['action' => 'view', {{ pk|raw }}]) ?>
                     <?= $this->Html->link(__('Edit'), ['action' => 'edit', {{ pk|raw }}]) ?>
-                    <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', {{ pk|raw }}], ['confirm' => __('Are you sure you want to delete # {0}?', {{ pk|raw }})]) ?>
+                    <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', {{ pk|raw }}], ['confirm' => __('Are you sure you want to delete # {0}?', {{ pk|raw }}), 'escape' => true]) ?>
                 </td>
             </tr>
             <?php endforeach; ?>


### PR DESCRIPTION
Without the escaping, it generates this:

`<a href="#" onclick="if (confirm("Are you sure you want to delete # x?")) { document.post_token.submit(); } event.returnValue = false; return false;">Delete</a>`

Which of course creates an issue with the double quotes... Adding the escaping produces this:

`<a href="#" onclick="if (confirm(&quot;Are you sure you want to delete # x?&quot;)) { document.post_token.submit(); } event.returnValue = false; return false;">Delete</a>`

Which allows the records to be deleted