### PR TITLE
Remove empty line in class doc blocks

### DIFF
--- a/src/Shell/Task/BakeTask.php
+++ b/src/Shell/Task/BakeTask.php
@@ -23,7 +23,6 @@ use Cake\Filesystem\File;
 
 /**
  * Base class for Bake Tasks.
- *
  */
 class BakeTask extends Shell
 {

--- a/src/Template/Bake/tests/fixture.twig
+++ b/src/Template/Bake/tests/fixture.twig
@@ -24,7 +24,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * {{ name }}Fixture
- *
  */
 class {{ name }}Fixture extends TestFixture
 {

--- a/src/Utility/Model/AssociationFilter.php
+++ b/src/Utility/Model/AssociationFilter.php
@@ -20,7 +20,6 @@ use Exception;
 
 /**
  * Utility class to filter Model Table associations
- *
  */
 class AssociationFilter
 {

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -29,6 +29,9 @@ class DocBlockHelper extends Helper
         $lines = [];
         if ($className && $classType) {
             $lines[] = "{$className} {$classType}";
+        }
+
+        if ($annotations) {
             $lines[] = "";
         }
 

--- a/tests/Fixture/BakeArticlesBakeTagsFixture.php
+++ b/tests/Fixture/BakeArticlesBakeTagsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * Short description for class.
- *
  */
 class BakeArticlesBakeTagsFixture extends TestFixture
 {

--- a/tests/Fixture/BakeArticlesFixture.php
+++ b/tests/Fixture/BakeArticlesFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * BakeArticleFixture
- *
  */
 class BakeArticlesFixture extends TestFixture
 {

--- a/tests/Fixture/BakeCarFixture.php
+++ b/tests/Fixture/BakeCarFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * BakeCarFixture
- *
  */
 class BakeCarFixture extends TestFixture
 {

--- a/tests/Fixture/BakeCommentsFixture.php
+++ b/tests/Fixture/BakeCommentsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * BakeCommentFixture fixture for testing bake
- *
  */
 class BakeCommentsFixture extends TestFixture
 {

--- a/tests/Fixture/BakeTagsFixture.php
+++ b/tests/Fixture/BakeTagsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * Short description for class.
- *
  */
 class BakeTagsFixture extends TestFixture
 {

--- a/tests/Fixture/CategoriesFixture.php
+++ b/tests/Fixture/CategoriesFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * CategoriesFixture
- *
  */
 class CategoriesFixture extends TestFixture
 {

--- a/tests/Fixture/CategoriesProductsFixture.php
+++ b/tests/Fixture/CategoriesProductsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * CategoriesProductsFixture
- *
  */
 class CategoriesProductsFixture extends TestFixture
 {

--- a/tests/Fixture/InvitationsFixture.php
+++ b/tests/Fixture/InvitationsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * InvitationsFixture
- *
  */
 class InvitationsFixture extends TestFixture
 {

--- a/tests/Fixture/OldProductsFixture.php
+++ b/tests/Fixture/OldProductsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * OldProductsFixture
- *
  */
 class OldProductsFixture extends TestFixture
 {

--- a/tests/Fixture/ProductVersionsFixture.php
+++ b/tests/Fixture/ProductVersionsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * ProductVersionsFixture
- *
  */
 class ProductVersionsFixture extends TestFixture
 {

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * ProductsFixture
- *
  */
 class ProductsFixture extends TestFixture
 {

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
 
 /**
  * PluginTest class
- *
  */
 class PluginTest extends TestCase
 {

--- a/tests/TestCase/Shell/Task/ControllerTaskTest.php
+++ b/tests/TestCase/Shell/Task/ControllerTaskTest.php
@@ -23,7 +23,6 @@ use Cake\ORM\TableRegistry;
 
 /**
  * ControllerTaskTest class
- *
  */
 class ControllerTaskTest extends TestCase
 {

--- a/tests/TestCase/Shell/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Shell/Task/FixtureTaskTest.php
@@ -24,7 +24,6 @@ use Cake\ORM\TableRegistry;
 
 /**
  * FixtureTaskTest class
- *
  */
 class FixtureTaskTest extends TestCase
 {

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -27,7 +27,6 @@ use Cake\ORM\TableRegistry;
 
 /**
  * TestTaskTest class
- *
  */
 class TestTaskTest extends TestCase
 {

--- a/tests/TestCase/Utility/Model/AssociationFilterTest.php
+++ b/tests/TestCase/Utility/Model/AssociationFilterTest.php
@@ -20,7 +20,6 @@ use Cake\TestSuite\TestCase;
 
 /**
  * BakeViewTest class
- *
  */
 class AssociationFilterTest extends TestCase
 {

--- a/tests/TestCase/View/BakeViewTest.php
+++ b/tests/TestCase/View/BakeViewTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
 
 /**
  * BakeViewTest class
- *
  */
 class BakeViewTest extends TestCase
 {

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
 
 /**
  * BakeViewTest class
- *
  */
 class BakeHelperTest extends TestCase
 {

--- a/tests/comparisons/BakeTemplate/testGenerateWithTemplateFallbacks.ctp
+++ b/tests/comparisons/BakeTemplate/testGenerateWithTemplateFallbacks.ctp
@@ -5,7 +5,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * ArticlesFixture
- *
  */
 class ArticlesFixture extends TestFixture
 {

--- a/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
+++ b/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
@@ -5,7 +5,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * UsersFixture
- *
  */
 class UsersFixture extends TestFixture
 {

--- a/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
+++ b/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
@@ -5,7 +5,6 @@ use Cake\ORM\Entity;
 
 /**
  * BakeArticle Entity
- *
  */
 class BakeArticle extends Entity
 {


### PR DESCRIPTION
I know I'm a nitpicker but I always found the empty line in the class doc blocks superfluous.
Finally fixed that.

Before:
```` php
/**
 * Foo class
 *
 */
````
Now:
```` php
/**
 * Foo class
 */
````