### PR TITLE
Remove blank line after class opening brackets

### DIFF
--- a/src/Template/Bake/Command/command.twig
+++ b/src/Template/Bake/Command/command.twig
@@ -26,7 +26,6 @@ use Cake\Console\ConsoleOptionParser;
  */
 class {{ name }}Command extends Command
 {
-
     /**
      * Hook method for defining this command's option parser.
      *

--- a/src/Template/Bake/Controller/component.twig
+++ b/src/Template/Bake/Controller/component.twig
@@ -24,7 +24,6 @@ use Cake\Controller\ComponentRegistry;
  */
 class {{ name }}Component extends Component
 {
-
     /**
      * Default configuration.
      *

--- a/src/Template/Bake/Controller/controller.twig
+++ b/src/Template/Bake/Controller/controller.twig
@@ -44,14 +44,21 @@ class {{ name }}Controller extends AppController
 {% set helpers = Bake.arrayProperty('helpers', helpers, {'indent': false})|raw %}
 {% if helpers|trim %}
     {{- helpers|raw }}
-{% endif %}
+{% if components %}
 
+{% endif %}
+{% endif %}
 {%- set components = Bake.arrayProperty('components', components, {'indent': false})|raw %}
 {% if components|trim %}
     {{- components|raw }}
-{% endif %}
+{% if actions %}
 
+{% endif %}
+{% endif %}
 {%- for action in actions %}
+{% if loop.index > 1 %}
+
+{% endif %}
     {%- element 'Controller/' ~ action %}
 {% endfor %}
 }

--- a/src/Template/Bake/Element/Controller/add.twig
+++ b/src/Template/Bake/Element/Controller/add.twig
@@ -14,7 +14,6 @@
  */
 #}
 {% set compact = ["'#{singularName}'"] %}
-
     /**
      * Add method
      *

--- a/src/Template/Bake/Element/Controller/delete.twig
+++ b/src/Template/Bake/Element/Controller/delete.twig
@@ -13,7 +13,6 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 #}
-
     /**
      * Delete method
      *

--- a/src/Template/Bake/Element/Controller/edit.twig
+++ b/src/Template/Bake/Element/Controller/edit.twig
@@ -16,7 +16,6 @@
 {% set belongsTo = Bake.aliasExtractor(modelObj, 'BelongsTo') %}
 {% set belongsToMany = Bake.aliasExtractor(modelObj, 'belongsToMany') %}
 {% set compact = ["'#{singularName}'"] %}
-
     /**
      * Edit method
      *

--- a/src/Template/Bake/Element/Controller/index.twig
+++ b/src/Template/Bake/Element/Controller/index.twig
@@ -13,7 +13,6 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 #}
-
     /**
      * Index method
      *

--- a/src/Template/Bake/Element/Controller/login.twig
+++ b/src/Template/Bake/Element/Controller/login.twig
@@ -13,7 +13,6 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 #}
-
     /**
      * Login method
      *

--- a/src/Template/Bake/Element/Controller/logout.twig
+++ b/src/Template/Bake/Element/Controller/logout.twig
@@ -13,7 +13,6 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 #}
-
     /**
      * Logout method
      *

--- a/src/Template/Bake/Element/Controller/view.twig
+++ b/src/Template/Bake/Element/Controller/view.twig
@@ -17,7 +17,6 @@
 {% set allAssociations = allAssociations|merge(Bake.aliasExtractor(modelObj, 'BelongsToMany')) %}
 {% set allAssociations = allAssociations|merge(Bake.aliasExtractor(modelObj, 'HasOne')) %}
 {% set allAssociations = allAssociations|merge(Bake.aliasExtractor(modelObj, 'HasMany')) %}
-
     /**
      * View method
      *

--- a/src/Template/Bake/Element/array_property.twig
+++ b/src/Template/Bake/Element/array_property.twig
@@ -1,4 +1,3 @@
-
     /**
      * {{ name|humanize }}
      *

--- a/src/Template/Bake/Mailer/mailer.twig
+++ b/src/Template/Bake/Mailer/mailer.twig
@@ -23,7 +23,6 @@ use Cake\Mailer\Mailer;
  */
 class {{ name }}Mailer extends Mailer
 {
-
     /**
      * Mailer's name.
      *

--- a/src/Template/Bake/Middleware/middleware.twig
+++ b/src/Template/Bake/Middleware/middleware.twig
@@ -24,7 +24,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class {{ name }}Middleware
 {
-
     /**
      * Invoke method.
      *

--- a/src/Template/Bake/Model/behavior.twig
+++ b/src/Template/Bake/Model/behavior.twig
@@ -24,7 +24,6 @@ use Cake\ORM\Table;
  */
 class {{ name }}Behavior extends Behavior
 {
-
     /**
      * Default configuration.
      *

--- a/src/Template/Bake/Model/entity.twig
+++ b/src/Template/Bake/Model/entity.twig
@@ -32,7 +32,6 @@ use Cake\ORM\Entity;
 class {{ name }} extends Entity
 {
 {% if accessible %}
-
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().
      *
@@ -44,18 +43,15 @@ class {{ name }} extends Entity
      */
     protected $_accessible = [{{ Bake.stringifyList(accessible, {'quotes': false})|raw }}];
 {% endif %}
+{% if accessible and hidden %}
 
+{% endif %}
 {%- if hidden %}
-
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
      * @var array
      */
     protected $_hidden = [{{ Bake.stringifyList(hidden)|raw }}];
-{% endif %}
-
-{%- if not accessible and not hidden %}
-
 {% endif %}
 }

--- a/src/Template/Bake/Model/table.twig
+++ b/src/Template/Bake/Model/table.twig
@@ -23,7 +23,6 @@ namespace {{ namespace }}\Model\Table;
 {{ DocBlock.classDescription(name, 'Model', annotations)|raw }}
 class {{ name }}Table extends Table
 {
-
     /**
      * Initialize method
      *

--- a/src/Template/Bake/Plugin/src/Controller/AppController.php.twig
+++ b/src/Template/Bake/Plugin/src/Controller/AppController.php.twig
@@ -21,5 +21,4 @@ use {{ baseNamespace }}\Controller\AppController as BaseController;
 
 class AppController extends BaseController
 {
-
 }

--- a/src/Template/Bake/Shell/helper.twig
+++ b/src/Template/Bake/Shell/helper.twig
@@ -23,7 +23,6 @@ use Cake\Console\Helper;
  */
 class {{ name }}Helper extends Helper
 {
-
     /**
      * Output method.
      *

--- a/src/Template/Bake/Shell/shell.twig
+++ b/src/Template/Bake/Shell/shell.twig
@@ -23,7 +23,6 @@ use Cake\Console\Shell;
  */
 class {{ name }}Shell extends Shell
 {
-
     /**
      * Manage the available sub-commands along with their arguments and help
      *

--- a/src/Template/Bake/Shell/task.twig
+++ b/src/Template/Bake/Shell/task.twig
@@ -22,7 +22,6 @@ use Cake\Console\Shell;
  */
 class {{ name }}Task extends Shell
 {
-
     /**
      * Manage the available sub-commands along with their arguments and help
      *

--- a/src/Template/Bake/View/cell.twig
+++ b/src/Template/Bake/View/cell.twig
@@ -23,7 +23,6 @@ use Cake\View\Cell;
  */
 class {{ name }}Cell extends Cell
 {
-
     /**
      * List of valid options that can be passed into this
      * cell's constructor.

--- a/src/Template/Bake/View/helper.twig
+++ b/src/Template/Bake/View/helper.twig
@@ -24,7 +24,6 @@ use Cake\View\View;
  */
 class {{ name }}Helper extends Helper
 {
-
     /**
      * Default configuration.
      *

--- a/src/Template/Bake/tests/fixture.twig
+++ b/src/Template/Bake/tests/fixture.twig
@@ -28,7 +28,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class {{ name }}Fixture extends TestFixture
 {
 {% if table %}
-
     /**
      * Table name
      *
@@ -38,17 +37,16 @@ class {{ name }}Fixture extends TestFixture
 {% endif %}
 
 {%- if import %}
-
     /**
      * Import
      *
      * @var array
      */
     public $import = {{ import|raw }};
+
 {% endif %}
 
 {%- if schema %}
-
     /**
      * Fields
      *
@@ -60,7 +58,6 @@ class {{ name }}Fixture extends TestFixture
 {% endif %}
 
 {%- if records %}
-
     /**
      * Init method
      *

--- a/src/Template/Bake/tests/test_case.twig
+++ b/src/Template/Bake/tests/test_case.twig
@@ -43,31 +43,40 @@ class {{ className }}Test extends TestCase
 {
 {% if traitName %}
     use {{ traitName }};
+{% if properties or fixtures or construction or methods %}
+
+{% endif %}
 {% endif %}
 {% if properties %}
 {% for propertyInfo in properties %}
+{% if loop.index > 1 %}
 
+{% endif %}
     /**
      * {{ propertyInfo.description }}
      *
      * @var {{ propertyInfo.type }}
      */
     public ${{ propertyInfo.name }}{% if propertyInfo.value is defined and propertyInfo.value %} = {{ propertyInfo.value }}{% endif %};
+{% if loop.last and (fixtures or construction or methods) %}
+
+{% endif %}
 {% endfor %}
 {% endif %}
 
 {%- if fixtures %}
-
     /**
      * Fixtures
      *
      * @var array
      */
     public $fixtures = [{{ Bake.stringifyList(fixtures|values)|raw }}];
+{% if construction or methods %}
+
+{% endif %}
 {% endif %}
 
 {%- if construction %}
-
     /**
      * setUp method
      *
@@ -101,11 +110,16 @@ class {{ className }}Test extends TestCase
 
         parent::tearDown();
     }
+{% if methods %}
+
+{% endif %}
 {% endif %}
 {% endif %}
 
 {%- for method in methods %}
+{% if loop.index > 1 %}
 
+{% endif %}
     /**
      * Test {{ method }} method
      *
@@ -118,7 +132,9 @@ class {{ className }}Test extends TestCase
 {% endfor %}
 
 {%- if not methods %}
+{%- if traitName or properties or fixtures or construction or methods %}
 
+{% endif %}
     /**
      * Test initial setup
      *

--- a/src/Utility/CommonOptionsTrait.php
+++ b/src/Utility/CommonOptionsTrait.php
@@ -19,7 +19,6 @@ use Cake\Core\Plugin;
 
 trait CommonOptionsTrait
 {
-
     /**
      * Set common options used by all bake tasks.
      *

--- a/src/Utility/Model/AssociationFilter.php
+++ b/src/Utility/Model/AssociationFilter.php
@@ -23,7 +23,6 @@ use Exception;
  */
 class AssociationFilter
 {
-
     /**
      * Detect existing belongsToMany associations and cleanup the hasMany aliases based on existing
      * belongsToMany associations provided

--- a/tests/Fixture/BakeCarFixture.php
+++ b/tests/Fixture/BakeCarFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class BakeCarFixture extends TestFixture
 {
-
     /**
      * @var string
      */

--- a/tests/Fixture/BakeTemplateAuthorsFixture.php
+++ b/tests/Fixture/BakeTemplateAuthorsFixture.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class BakeTemplateAuthorsFixture extends TestFixture
 {
-
     /**
      * Avoid overriding core.authors
      * @var string

--- a/tests/Fixture/BakeTemplateProfilesFixture.php
+++ b/tests/Fixture/BakeTemplateProfilesFixture.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class BakeTemplateProfilesFixture extends TestFixture
 {
-
     /**
      * @var string
      */

--- a/tests/Fixture/BinaryTestsFixture.php
+++ b/tests/Fixture/BinaryTestsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class BinaryTestsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/CategoriesFixture.php
+++ b/tests/Fixture/CategoriesFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CategoriesFixture extends TestFixture
 {
-
     /**
      * Fields
      *

--- a/tests/Fixture/CategoriesProductsFixture.php
+++ b/tests/Fixture/CategoriesProductsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CategoriesProductsFixture extends TestFixture
 {
-
     /**
      * Fields
      *

--- a/tests/Fixture/CategoryThreadsFixture.php
+++ b/tests/Fixture/CategoryThreadsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CategoryThreadsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/DatatypesFixture.php
+++ b/tests/Fixture/DatatypesFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class DatatypesFixture extends TestFixture
 {
-
     /**
      * Fields property
      *

--- a/tests/Fixture/NumberTreesFixture.php
+++ b/tests/Fixture/NumberTreesFixture.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class NumberTreesFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/OldProductsFixture.php
+++ b/tests/Fixture/OldProductsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class OldProductsFixture extends TestFixture
 {
-
     /**
      * Fields
      *

--- a/tests/Fixture/ProductVersionsFixture.php
+++ b/tests/Fixture/ProductVersionsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class ProductVersionsFixture extends TestFixture
 {
-
     /**
      * Fields
      *

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class ProductsFixture extends TestFixture
 {
-
     /**
      * Fields
      *

--- a/tests/TestCase/Shell/Task/ModelTaskAssociationDetectionTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskAssociationDetectionTest.php
@@ -30,7 +30,6 @@ use Cake\ORM\TableRegistry;
  */
 class ModelTaskAssociationDetectionTest extends TestCase
 {
-
     /**
      * fixtures
      *

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -31,7 +31,6 @@ use Cake\ORM\TableRegistry;
  */
 class ModelTaskTest extends TestCase
 {
-
     /**
      * Fixtures should be dropped after each tests
      *

--- a/tests/TestCase/Utility/Model/AssociationFilterTest.php
+++ b/tests/TestCase/Utility/Model/AssociationFilterTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class AssociationFilterTest extends TestCase
 {
-
     /**
      * fixtures
      *

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
  */
 class BakeHelperTest extends TestCase
 {
-
     /**
      * fixtures
      *

--- a/tests/comparisons/BakeTemplate/testGenerateWithTemplateFallbacks.ctp
+++ b/tests/comparisons/BakeTemplate/testGenerateWithTemplateFallbacks.ctp
@@ -8,7 +8,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class ArticlesFixture extends TestFixture
 {
-
     /**
      * Table name
      *

--- a/tests/comparisons/Cell/testBakePlugin.php
+++ b/tests/comparisons/Cell/testBakePlugin.php
@@ -8,7 +8,6 @@ use Cake\View\Cell;
  */
 class ExampleCell extends Cell
 {
-
     /**
      * List of valid options that can be passed into this
      * cell's constructor.

--- a/tests/comparisons/Command/testBake.php
+++ b/tests/comparisons/Command/testBake.php
@@ -11,7 +11,6 @@ use Cake\Console\ConsoleOptionParser;
  */
 class ExampleCommand extends Command
 {
-
     /**
      * Hook method for defining this command's option parser.
      *

--- a/tests/comparisons/Command/testBakePlugin.php
+++ b/tests/comparisons/Command/testBakePlugin.php
@@ -11,7 +11,6 @@ use Cake\Console\ConsoleOptionParser;
  */
 class ExampleCommand extends Command
 {
-
     /**
      * Hook method for defining this command's option parser.
      *

--- a/tests/comparisons/Controller/testBakeActions.php
+++ b/tests/comparisons/Controller/testBakeActions.php
@@ -13,7 +13,6 @@ use App\Controller\AppController;
  */
 class BakeArticlesController extends AppController
 {
-
     /**
      * Helpers
      *

--- a/tests/comparisons/Controller/testBakeActionsContent.php
+++ b/tests/comparisons/Controller/testBakeActionsContent.php
@@ -11,7 +11,6 @@ use App\Controller\AppController;
  */
 class BakeArticlesController extends AppController
 {
-
     /**
      * Index method
      *

--- a/tests/comparisons/Controller/testBakeActionsOption.php
+++ b/tests/comparisons/Controller/testBakeActionsOption.php
@@ -11,7 +11,6 @@ use App\Controller\AppController;
  */
 class BakeArticlesController extends AppController
 {
-
     /**
      * Helpers
      *

--- a/tests/comparisons/Controller/testBakeComponents.php
+++ b/tests/comparisons/Controller/testBakeComponents.php
@@ -15,7 +15,6 @@ use App\Controller\AppController;
  */
 class BakeArticlesController extends AppController
 {
-
     /**
      * Components
      *

--- a/tests/comparisons/Controller/testBakeNoActions.php
+++ b/tests/comparisons/Controller/testBakeNoActions.php
@@ -11,7 +11,6 @@ use App\Controller\AppController;
  */
 class BakeArticlesController extends AppController
 {
-
     /**
      * Helpers
      *

--- a/tests/comparisons/Controller/testBakeWithPlugin.php
+++ b/tests/comparisons/Controller/testBakeWithPlugin.php
@@ -12,7 +12,6 @@ use BakeTest\Controller\AppController;
  */
 class BakeArticlesController extends AppController
 {
-
     /**
      * Index method
      *

--- a/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
+++ b/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
@@ -8,7 +8,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class UsersFixture extends TestFixture
 {
-
     /**
      * Import
      *

--- a/tests/comparisons/Mailer/testBakePlugin.php
+++ b/tests/comparisons/Mailer/testBakePlugin.php
@@ -8,7 +8,6 @@ use Cake\Mailer\Mailer;
  */
 class ExampleMailer extends Mailer
 {
-
     /**
      * Mailer's name.
      *

--- a/tests/comparisons/Middleware/testBakePlugin.php
+++ b/tests/comparisons/Middleware/testBakePlugin.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class ExampleMiddleware
 {
-
     /**
      * Invoke method.
      *

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
@@ -23,7 +23,6 @@ use Cake\Validation\Validator;
  */
 class CategoriesProductsTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
@@ -24,7 +24,6 @@ use Cake\Validation\Validator;
  */
 class CategoriesTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
@@ -24,7 +24,6 @@ use Cake\Validation\Validator;
  */
 class CategoriesTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
@@ -22,7 +22,6 @@ use Cake\Validation\Validator;
  */
 class OldProductsTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTableSigned.php
@@ -22,7 +22,6 @@ use Cake\Validation\Validator;
  */
 class OldProductsTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
@@ -22,7 +22,6 @@ use Cake\Validation\Validator;
  */
 class ProductVersionsTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
@@ -22,7 +22,6 @@ use Cake\Validation\Validator;
  */
 class ProductVersionsTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductsTable.php
@@ -25,7 +25,6 @@ use Cake\Validation\Validator;
  */
 class ProductsTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductsTableSigned.php
@@ -25,7 +25,6 @@ use Cake\Validation\Validator;
  */
 class ProductsTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeEntityCustomHidden.php
+++ b/tests/comparisons/Model/testBakeEntityCustomHidden.php
@@ -17,7 +17,6 @@ use Cake\ORM\Entity;
  */
 class User extends Entity
 {
-
     /**
      * Fields that are excluded from JSON versions of the entity.
      *

--- a/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
+++ b/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
@@ -8,7 +8,6 @@ use Cake\ORM\Entity;
  */
 class BakeArticle extends Entity
 {
-
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().
      *

--- a/tests/comparisons/Model/testBakeEntityFieldsWhiteList.php
+++ b/tests/comparisons/Model/testBakeEntityFieldsWhiteList.php
@@ -22,7 +22,6 @@ use Cake\ORM\Entity;
  */
 class BakeArticle extends Entity
 {
-
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().
      *

--- a/tests/comparisons/Model/testBakeEntityFullContext.php
+++ b/tests/comparisons/Model/testBakeEntityFullContext.php
@@ -17,7 +17,6 @@ use Cake\ORM\Entity;
  */
 class User extends Entity
 {
-
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().
      *

--- a/tests/comparisons/Model/testBakeEntityHidden.php
+++ b/tests/comparisons/Model/testBakeEntityHidden.php
@@ -17,7 +17,6 @@ use Cake\ORM\Entity;
  */
 class User extends Entity
 {
-
     /**
      * Fields that are excluded from JSON versions of the entity.
      *

--- a/tests/comparisons/Model/testBakeEntityNoFields.php
+++ b/tests/comparisons/Model/testBakeEntityNoFields.php
@@ -22,5 +22,4 @@ use Cake\ORM\Entity;
  */
 class BakeArticle extends Entity
 {
-
 }

--- a/tests/comparisons/Model/testBakeEntitySimple.php
+++ b/tests/comparisons/Model/testBakeEntitySimple.php
@@ -17,5 +17,4 @@ use Cake\ORM\Entity;
  */
 class User extends Entity
 {
-
 }

--- a/tests/comparisons/Model/testBakeEntityWithPlugin.php
+++ b/tests/comparisons/Model/testBakeEntityWithPlugin.php
@@ -25,7 +25,6 @@ use Cake\Validation\Validator;
  */
 class UsersTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeEntityWithPropertyTypeHints.php
+++ b/tests/comparisons/Model/testBakeEntityWithPropertyTypeHints.php
@@ -26,5 +26,4 @@ use Cake\ORM\Entity;
  */
 class BakeArticle extends Entity
 {
-
 }

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -22,7 +22,6 @@ use Cake\Validation\Validator;
  */
 class BakeArticlesTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeTableRelations.php
+++ b/tests/comparisons/Model/testBakeTableRelations.php
@@ -25,7 +25,6 @@ use Cake\Validation\Validator;
  */
 class BakeArticlesTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeTableValidation.php
+++ b/tests/comparisons/Model/testBakeTableValidation.php
@@ -20,7 +20,6 @@ use Cake\Validation\Validator;
  */
 class BakeArticlesTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeTableWithPlugin.php
+++ b/tests/comparisons/Model/testBakeTableWithPlugin.php
@@ -25,7 +25,6 @@ use Cake\Validation\Validator;
  */
 class UsersTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testBakeWithRules.php
+++ b/tests/comparisons/Model/testBakeWithRules.php
@@ -20,7 +20,6 @@ use Cake\Validation\Validator;
  */
 class UsersTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Model/testGetBehaviors.php
+++ b/tests/comparisons/Model/testGetBehaviors.php
@@ -23,7 +23,6 @@ use Cake\Validation\Validator;
  */
 class PostsTable extends Table
 {
-
     /**
      * Initialize method
      *

--- a/tests/comparisons/Plugin/Company/Example/src/Controller/AppController.php
+++ b/tests/comparisons/Plugin/Company/Example/src/Controller/AppController.php
@@ -6,5 +6,4 @@ use App\Controller\AppController as BaseController;
 
 class AppController extends BaseController
 {
-
 }

--- a/tests/comparisons/Plugin/SimpleExample/src/Controller/AppController.php
+++ b/tests/comparisons/Plugin/SimpleExample/src/Controller/AppController.php
@@ -6,5 +6,4 @@ use App\Controller\AppController as BaseController;
 
 class AppController extends BaseController
 {
-
 }

--- a/tests/comparisons/Shell/Task/testBake.php
+++ b/tests/comparisons/Shell/Task/testBake.php
@@ -8,7 +8,6 @@ use Cake\Console\Shell;
  */
 class ExampleTask extends Shell
 {
-
     /**
      * Manage the available sub-commands along with their arguments and help
      *

--- a/tests/comparisons/Shell/Task/testBakePlugin.php
+++ b/tests/comparisons/Shell/Task/testBakePlugin.php
@@ -8,7 +8,6 @@ use Cake\Console\Shell;
  */
 class ExampleTask extends Shell
 {
-
     /**
      * Manage the available sub-commands along with their arguments and help
      *

--- a/tests/comparisons/Simple/testBake.php
+++ b/tests/comparisons/Simple/testBake.php
@@ -9,7 +9,6 @@ use Cake\ORM\Table;
  */
 class ExampleBehavior extends Behavior
 {
-
     /**
      * Default configuration.
      *

--- a/tests/comparisons/Simple/testBakePlugin.php
+++ b/tests/comparisons/Simple/testBakePlugin.php
@@ -9,7 +9,6 @@ use Cake\ORM\Table;
  */
 class ExampleBehavior extends Behavior
 {
-
     /**
      * Default configuration.
      *

--- a/tests/comparisons/Test/testBakeBehaviorTest.php
+++ b/tests/comparisons/Test/testBakeBehaviorTest.php
@@ -9,7 +9,6 @@ use Cake\TestSuite\TestCase;
  */
 class ExampleBehaviorTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/comparisons/Test/testBakeCellTest.php
+++ b/tests/comparisons/Test/testBakeCellTest.php
@@ -9,7 +9,6 @@ use Cake\TestSuite\TestCase;
  */
 class ArticlesCellTest extends TestCase
 {
-
     /**
      * Request mock
      *

--- a/tests/comparisons/Test/testBakeComponentTest.php
+++ b/tests/comparisons/Test/testBakeComponentTest.php
@@ -10,7 +10,6 @@ use Cake\TestSuite\TestCase;
  */
 class AppleComponentTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/comparisons/Test/testBakeFixturesParam.php
+++ b/tests/comparisons/Test/testBakeFixturesParam.php
@@ -10,7 +10,6 @@ use Cake\TestSuite\TestCase;
  */
 class ArticlesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/comparisons/Test/testBakeHelperTest.php
+++ b/tests/comparisons/Test/testBakeHelperTest.php
@@ -10,7 +10,6 @@ use Cake\View\View;
  */
 class ExampleHelperTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/comparisons/Test/testBakeModelTest.php
+++ b/tests/comparisons/Test/testBakeModelTest.php
@@ -10,7 +10,6 @@ use Cake\TestSuite\TestCase;
  */
 class ArticlesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/comparisons/Test/testBakeNoFixtureParam.php
+++ b/tests/comparisons/Test/testBakeNoFixtureParam.php
@@ -10,7 +10,6 @@ use Cake\TestSuite\TestCase;
  */
 class ArticlesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/comparisons/Test/testBakeShellHelperTest.php
+++ b/tests/comparisons/Test/testBakeShellHelperTest.php
@@ -11,7 +11,6 @@ use Cake\TestSuite\TestCase;
  */
 class ExampleHelperTest extends TestCase
 {
-
     /**
      * ConsoleOutput stub
      *

--- a/tests/comparisons/Test/testBakeShellTaskTest.php
+++ b/tests/comparisons/Test/testBakeShellTaskTest.php
@@ -9,7 +9,6 @@ use Cake\TestSuite\TestCase;
  */
 class ArticlesTaskTest extends TestCase
 {
-
     /**
      * ConsoleIo mock
      *

--- a/tests/test_app/App/Controller/AuthorsController.php
+++ b/tests/test_app/App/Controller/AuthorsController.php
@@ -20,7 +20,6 @@ use Cake\Controller\Controller;
  */
 class AuthorsController extends Controller
 {
-
     /**
      * Testing public controller action
      *

--- a/tests/test_app/App/Model/Table/AuthorsTable.php
+++ b/tests/test_app/App/Model/Table/AuthorsTable.php
@@ -20,7 +20,6 @@ use Cake\ORM\Table;
  */
 class AuthorsTable extends Table
 {
-
     /**
      * @param array $config
      * @return void


### PR DESCRIPTION
Again, I know I nitpick, but I also never liked the blank line after the class opening brackets.

Neither our [code style](https://book.cakephp.org/3.0/en/contributing/cakephp-coding-conventions.html) nor [PSR-2](https://www.php-fig.org/psr/psr-2/) demand such a blank line.

Our code style actually shows [an example where there  is no blank line:](https://book.cakephp.org/3.0/en/contributing/cakephp-coding-conventions.html#careful-when-using-empty-isset)

```` php
class Thing
{
    private $property; // Defined

    public function readProperty()
    {
        // Not recommended as the property is defined in the class
        if (!isset($this->property)) {
            // ...
        }
        // Recommended
        if ($this->property === null) {

        }
    }
}
````

My change inserts only blank lines where and when necessary instead of always prepending one.