### PR TITLE
4.x Add trailing commas to generated code

### DIFF
--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -69,7 +69,7 @@ class BakeHelper extends Helper
         $options += [
             'indent' => 2,
             'tab' => '    ',
-            'trailingComma' => false,
+            'trailingComma' => true,
             'quotes' => true,
         ];
 
@@ -116,7 +116,7 @@ class BakeHelper extends Helper
             $end = "\n" . str_repeat($options['tab'], $options['indent'] - 1);
         }
 
-        if ($options['trailingComma']) {
+        if ($options['trailingComma'] && $options['indent'] > 0) {
             $end = "," . $end;
         }
 

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -155,7 +155,7 @@ class BakeHelperTest extends TestCase
         $expected = "\n" .
             $spaces . $spaces . "'one' => 'foo',\n" .
             $spaces . $spaces . "'two' => 'bar',\n" .
-            $spaces . $spaces . "'three'\n" .
+            $spaces . $spaces . "'three',\n" .
             $spaces;
         $this->assertSame($expected, $result);
     }
@@ -186,7 +186,7 @@ class BakeHelperTest extends TestCase
         $expected = "\n" .
             $spaces . $spaces . $spaces . "'one' => 'foo',\n" .
             $spaces . $spaces . $spaces . "'two' => 'bar',\n" .
-            $spaces . $spaces . $spaces . "'three'\n" .
+            $spaces . $spaces . $spaces . "'three',\n" .
             $spaces . $spaces;
         $this->assertSame($expected, $result);
     }
@@ -204,7 +204,7 @@ class BakeHelperTest extends TestCase
         $expected = "\n" .
             $spaces . $spaces . $spaces . "'one' => 'foo',\n" .
             $spaces . $spaces . $spaces . "'two' => 'bar',\n" .
-            $spaces . $spaces . $spaces . "'three'\n" .
+            $spaces . $spaces . $spaces . "'three',\n" .
             $spaces . $spaces;
         $this->assertSame($expected, $result);
     }
@@ -214,19 +214,19 @@ class BakeHelperTest extends TestCase
      *
      * @return void
      */
-    public function testStringifyListWithCommaAtEnd()
+    public function testStringifyListWithNoCommaAtEnd()
     {
         $list = ['one' => 'foo', 'two' => 'bar', 'three'];
         $result = $this->BakeHelper->stringifyList($list, [
             'indent' => 3,
             'tab' => "\t",
-            'trailingComma' => true,
+            'trailingComma' => false,
         ]);
         $spaces = "\t";
         $expected = "\n" .
             $spaces . $spaces . $spaces . "'one' => 'foo',\n" .
             $spaces . $spaces . $spaces . "'two' => 'bar',\n" .
-            $spaces . $spaces . $spaces . "'three',\n" .
+            $spaces . $spaces . $spaces . "'three'\n" .
             $spaces . $spaces;
         $this->assertSame($expected, $result);
     }

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
@@ -40,11 +40,11 @@ class CategoriesProductsTable extends Table
 
         $this->belongsTo('Categories', [
             'foreignKey' => 'category_id',
-            'joinType' => 'INNER'
+            'joinType' => 'INNER',
         ]);
         $this->belongsTo('Products', [
             'foreignKey' => 'product_id',
-            'joinType' => 'INNER'
+            'joinType' => 'INNER',
         ]);
     }
 

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
@@ -44,7 +44,7 @@ class CategoriesTable extends Table
         $this->belongsToMany('Products', [
             'foreignKey' => 'category_id',
             'targetForeignKey' => 'product_id',
-            'joinTable' => 'categories_products'
+            'joinTable' => 'categories_products',
         ]);
     }
 

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
@@ -44,7 +44,7 @@ class CategoriesTable extends Table
         $this->belongsToMany('Products', [
             'foreignKey' => 'category_id',
             'targetForeignKey' => 'product_id',
-            'joinTable' => 'categories_products'
+            'joinTable' => 'categories_products',
         ]);
     }
 

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
@@ -39,7 +39,7 @@ class ProductVersionsTable extends Table
 
         $this->belongsTo('Products', [
             'foreignKey' => 'product_id',
-            'joinType' => 'INNER'
+            'joinType' => 'INNER',
         ]);
     }
 

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
@@ -39,7 +39,7 @@ class ProductVersionsTable extends Table
 
         $this->belongsTo('Products', [
             'foreignKey' => 'product_id',
-            'joinType' => 'INNER'
+            'joinType' => 'INNER',
         ]);
     }
 

--- a/tests/comparisons/Model/testBakeEntityCustomHidden.php
+++ b/tests/comparisons/Model/testBakeEntityCustomHidden.php
@@ -25,6 +25,6 @@ class User extends Entity
      */
     protected $_hidden = [
         'foo',
-        'bar'
+        'bar',
     ];
 }

--- a/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
+++ b/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
@@ -43,6 +43,6 @@ class TodoItem extends Entity
         'updated' => true,
         'user' => true,
         'todo_tasks' => true,
-        'todo_labels' => true
+        'todo_labels' => true,
     ];
 }

--- a/tests/comparisons/Model/testBakeEntityFieldsWhiteList.php
+++ b/tests/comparisons/Model/testBakeEntityFieldsWhiteList.php
@@ -36,6 +36,6 @@ class TodoItem extends Entity
         'id' => true,
         'title' => true,
         'body' => true,
-        'completed' => true
+        'completed' => true,
     ];
 }

--- a/tests/comparisons/Model/testBakeEntityFullContext.php
+++ b/tests/comparisons/Model/testBakeEntityFullContext.php
@@ -33,7 +33,7 @@ class User extends Entity
         'created' => true,
         'updated' => true,
         'comments' => true,
-        'todo_items' => true
+        'todo_items' => true,
     ];
 
     /**
@@ -42,6 +42,6 @@ class User extends Entity
      * @var array
      */
     protected $_hidden = [
-        'password'
+        'password',
     ];
 }

--- a/tests/comparisons/Model/testBakeEntityHidden.php
+++ b/tests/comparisons/Model/testBakeEntityHidden.php
@@ -24,6 +24,6 @@ class User extends Entity
      * @var array
      */
     protected $_hidden = [
-        'password'
+        'password',
     ];
 }

--- a/tests/comparisons/Model/testBakeEntityWithPlugin.php
+++ b/tests/comparisons/Model/testBakeEntityWithPlugin.php
@@ -44,11 +44,11 @@ class UsersTable extends Table
 
         $this->hasMany('Comments', [
             'foreignKey' => 'user_id',
-            'className' => 'BakeTest.Comments'
+            'className' => 'BakeTest.Comments',
         ]);
         $this->hasMany('TodoItems', [
             'foreignKey' => 'user_id',
-            'className' => 'BakeTest.TodoItems'
+            'className' => 'BakeTest.TodoItems',
         ]);
     }
 

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -45,15 +45,15 @@ class ItemsTable extends Table
 
         $this->belongsTo('Users', [
             'foreignKey' => 'user_id',
-            'joinType' => 'INNER'
+            'joinType' => 'INNER',
         ]);
         $this->hasMany('TodoTasks', [
-            'foreignKey' => 'todo_item_id'
+            'foreignKey' => 'todo_item_id',
         ]);
         $this->belongsToMany('TodoLabels', [
             'foreignKey' => 'todo_item_id',
             'targetForeignKey' => 'todo_label_id',
-            'joinTable' => 'todo_items_todo_labels'
+            'joinTable' => 'todo_items_todo_labels',
         ]);
     }
 

--- a/tests/comparisons/Model/testBakeTableWithCounterCache.php
+++ b/tests/comparisons/Model/testBakeTableWithCounterCache.php
@@ -42,12 +42,12 @@ class TodoTasksTable extends Table
 
         $this->addBehavior('Timestamp');
         $this->addBehavior('CounterCache', [
-            'TodoItems' => ['todo_task_count']
+            'TodoItems' => ['todo_task_count'],
         ]);
 
         $this->belongsTo('TodoItems', [
             'foreignKey' => 'todo_item_id',
-            'joinType' => 'INNER'
+            'joinType' => 'INNER',
         ]);
     }
 

--- a/tests/comparisons/Model/testBakeTableWithPlugin.php
+++ b/tests/comparisons/Model/testBakeTableWithPlugin.php
@@ -44,11 +44,11 @@ class UsersTable extends Table
 
         $this->hasMany('Comments', [
             'foreignKey' => 'user_id',
-            'className' => 'BakeTest.Comments'
+            'className' => 'BakeTest.Comments',
         ]);
         $this->hasMany('TodoItems', [
             'foreignKey' => 'user_id',
-            'className' => 'BakeTest.TodoItems'
+            'className' => 'BakeTest.TodoItems',
         ]);
     }
 

--- a/tests/comparisons/Model/testBakeWithRulesUnique.php
+++ b/tests/comparisons/Model/testBakeWithRulesUnique.php
@@ -43,10 +43,10 @@ class UsersTable extends Table
         $this->addBehavior('Timestamp');
 
         $this->hasMany('Comments', [
-            'foreignKey' => 'user_id'
+            'foreignKey' => 'user_id',
         ]);
         $this->hasMany('TodoItems', [
-            'foreignKey' => 'user_id'
+            'foreignKey' => 'user_id',
         ]);
     }
 

--- a/tests/comparisons/Test/testBakeControllerTest.php
+++ b/tests/comparisons/Test/testBakeControllerTest.php
@@ -18,7 +18,7 @@ class PostsControllerTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'app.Posts'
+        'app.Posts',
     ];
 
     /**

--- a/tests/comparisons/Test/testBakeFixturesParam.php
+++ b/tests/comparisons/Test/testBakeFixturesParam.php
@@ -26,7 +26,7 @@ class AuthorsTableTest extends TestCase
     public $fixtures = [
         'app.Posts',
         'app.Comments',
-        'app.Users'
+        'app.Users',
     ];
 
     /**

--- a/tests/comparisons/Test/testBakeModelTest.php
+++ b/tests/comparisons/Test/testBakeModelTest.php
@@ -27,7 +27,7 @@ class ArticlesTableTest extends TestCase
         'app.Articles',
         'app.Authors',
         'app.Tags',
-        'app.ArticlesTags'
+        'app.ArticlesTags',
     ];
 
     /**

--- a/tests/comparisons/Test/testBakePrefixControllerTest.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTest.php
@@ -18,7 +18,7 @@ class PostsControllerTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'app.Posts'
+        'app.Posts',
     ];
 
     /**

--- a/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
@@ -18,7 +18,7 @@ class PostsControllerTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'app.Posts'
+        'app.Posts',
     ];
 
     /**


### PR DESCRIPTION
Right now the code generated by bake does not pass codesniffer:dev-next which is what will be the 4.x version of our codesniffer rules.