### PR TITLE
Don't output to stderr when templates are missing

### DIFF
--- a/src/Shell/Task/TemplateTask.php
+++ b/src/Shell/Task/TemplateTask.php
@@ -27,6 +27,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
+use Cake\View\Exception\MissingTemplateException;
 use RuntimeException;
 
 /**
@@ -138,6 +139,8 @@ class TemplateTask extends BakeTask
             try {
                 $content = $this->getContent($method, $vars);
                 $this->bake($method, $content);
+            } catch (MissingTemplateException $e) {
+                $this->_io->verbose($e->getMessage());
             } catch (RuntimeException $e) {
                 $this->_io->err($e->getMessage());
             }

--- a/src/Utility/TemplateRenderer.php
+++ b/src/Utility/TemplateRenderer.php
@@ -22,7 +22,6 @@ use Cake\Event\EventManager;
 use Cake\View\Exception\MissingTemplateException;
 use Cake\View\View;
 use Cake\View\ViewVarsTrait;
-use RuntimeException;
 
 /**
  * Used by other tasks to generate templated output, Acts as an interface to BakeView
@@ -100,7 +99,8 @@ class TemplateRenderer
         try {
             return $view->render($template);
         } catch (MissingTemplateException $e) {
-            throw new RuntimeException(sprintf('No bake template found for "%s"', $template));
+            $message = sprintf('No bake template found for "%s" skipping file generation.', $template);
+            throw new MissingTemplateException($message);
         }
     }
 }

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -24,7 +24,7 @@ use Cake\Console\Exception\StopException;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\ORM\TableRegistry;
-use RuntimeException;
+use Cake\View\Exception\MissingTemplateException;
 
 /**
  * TemplateCommand test
@@ -580,7 +580,7 @@ class TemplateCommandTest extends TestCase
      */
     public function testBakeWithNoTemplate()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(MissingTemplateException::class);
         $this->expectExceptionMessage('No bake template found for "Template/delete"');
         $this->exec('bake template template_task_comments delete');
     }
@@ -696,6 +696,8 @@ class TemplateCommandTest extends TestCase
 
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
+        $this->assertOutputNotContains('No bake template found');
+        $this->assertErrorEmpty();
     }
 
     /**


### PR DESCRIPTION
The default template sets do not include a template for delete. We shouldn't emit errors when that template is absent. This restores behavior consistency with 3.x which also used verbose output.