### PR TITLE
Stop baking requirePresence validation when db default set

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -768,10 +768,12 @@ class ModelTask extends BakeTask
                 'args' => [],
             ];
         } else {
-            $validation['requirePresence'] = [
-                'rule' => 'requirePresence',
-                'args' => ["'create'"],
-            ];
+            if ($metaData['default'] === null || $metaData['default'] === false) {
+                $validation['requirePresence'] = [
+                    'rule' => 'requirePresence',
+                    'args' => ["'create'"],
+                ];
+            }
             $validation['allowEmpty'] = [
                 'rule' => $this->getAllowEmptyMethod($fieldName, $metaData),
                 'args' => ['false'],

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -976,18 +976,15 @@ class ModelTaskTest extends TestCase
             ],
             'rating' => [
                 'numeric' => ['rule' => 'numeric', 'args' => []],
-                'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
                 'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => ['false']],
             ],
             'score' => [
                 'decimal' => ['rule' => 'decimal', 'args' => []],
-                'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
                 'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => ['false']]
             ],
             'published' => [
                 'boolean' => ['rule' => 'boolean', 'args' => []],
                 'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => ['false']],
-                'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
             ],
             'id' => [
                 'integer' => ['rule' => 'integer', 'args' => []],
@@ -1047,9 +1044,9 @@ class ModelTaskTest extends TestCase
             'dateTime' => ['rule' => 'dateTime', 'args' => []],
             'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
             'allowEmpty' => [
-                    'rule' => 'allowEmptyDateTime',
-                    'args' => ['false'],
-                ],
+                'rule' => 'allowEmptyDateTime',
+                'args' => ['false'],
+            ],
         ];
         $this->assertEquals($expected, $result['release_date']);
     }
@@ -1237,7 +1234,6 @@ class ModelTaskTest extends TestCase
             'published' => [
                 'boolean' => ['rule' => 'boolean', 'args' => []],
                 'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => ['false']],
-                'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
             ],
             'id' => [
                 'integer' => ['rule' => 'integer', 'args' => []],
@@ -1246,12 +1242,10 @@ class ModelTaskTest extends TestCase
             'rating' => [
                 'numeric' => ['rule' => 'numeric', 'args' => []],
                 'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => ['false']],
-                'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
             ],
             'score' => [
                 'decimal' => ['rule' => 'decimal', 'args' => []],
                 'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => ['false']],
-                'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
             ]
         ];
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -852,7 +852,7 @@ class ModelTaskTest extends TestCase
                 'integer' => ['rule' => 'integer', 'args' => []],
                 'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => ["'create'"]]
             ],
-           'bake_user_id' => [
+            'bake_user_id' => [
                 'integer' => ['rule' => 'integer', 'args' => []],
                 'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
                 'allowEmpty' => [

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -848,7 +848,11 @@ class ModelTaskTest extends TestCase
         $model = TableRegistry::getTableLocator()->get('BakeArticles');
         $result = $this->Task->getValidation($model);
         $expected = [
-            'bake_user_id' => [
+            'id' => [
+                'integer' => ['rule' => 'integer', 'args' => []],
+                'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => ["'create'"]]
+            ],
+           'bake_user_id' => [
                 'integer' => ['rule' => 'integer', 'args' => []],
                 'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
                 'allowEmpty' => [
@@ -871,7 +875,6 @@ class ModelTaskTest extends TestCase
             ],
             'rating' => [
                 'numeric' => ['rule' => 'numeric', 'args' => []],
-                'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
                 'greaterThanOrEqual' => [
                     'rule' => 'greaterThanOrEqual',
                     'args' => [
@@ -885,7 +888,6 @@ class ModelTaskTest extends TestCase
             ],
             'score' => [
                 'decimal' => ['rule' => 'decimal', 'args' => []],
-                'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
                 'greaterThanOrEqual' => [
                     'rule' => 'greaterThanOrEqual',
                     'args' => [
@@ -899,18 +901,10 @@ class ModelTaskTest extends TestCase
             ],
             'published' => [
                 'boolean' => ['rule' => 'boolean', 'args' => []],
-                'requirePresence' => [
-                    'rule' => 'requirePresence',
-                    'args' => ["'create'" ],
-                ],
                 'allowEmpty' => [
                     'rule' => 'allowEmptyString',
                     'args' => ['false'],
                 ],
-            ],
-            'id' => [
-                'integer' => ['rule' => 'integer', 'args' => []],
-                'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => ["'create'"]]
             ]
         ];
         $this->assertEquals($expected, $result);
@@ -1182,8 +1176,7 @@ class ModelTaskTest extends TestCase
                 'allowEmpty' => [
                     'rule' => 'allowEmptyString',
                     'args' => ['false'],
-                ],
-                'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
+                ]
             ],
             'score' => [
                 'decimal' => ['rule' => 'decimal', 'args' => []],
@@ -1193,7 +1186,6 @@ class ModelTaskTest extends TestCase
                         0,
                     ],
                 ],
-                'requirePresence' => ['rule' => 'requirePresence', 'args' => ["'create'"]],
                 'allowEmpty' => [
                     'rule' => 'allowEmptyString',
                     'args' => ['false'],
@@ -1203,10 +1195,6 @@ class ModelTaskTest extends TestCase
                 'boolean' => [
                     'rule' => 'boolean',
                     'args' => [],
-                ],
-                'requirePresence' => [
-                    'rule' => 'requirePresence',
-                    'args' => ["'create'" ],
                 ],
                 'allowEmpty' => [
                     'rule' => 'allowEmptyString',

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
@@ -62,7 +62,6 @@ class CategoriesTable extends Table
         $validator
             ->scalar('name')
             ->maxLength('name', 100)
-            ->requirePresence('name', 'create')
             ->allowEmptyString('name', false);
 
         return $validator;

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
@@ -62,7 +62,6 @@ class CategoriesTable extends Table
         $validator
             ->scalar('name')
             ->maxLength('name', 100)
-            ->requirePresence('name', 'create')
             ->allowEmptyString('name', false);
 
         return $validator;

--- a/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
@@ -54,7 +54,6 @@ class OldProductsTable extends Table
         $validator
             ->scalar('name')
             ->maxLength('name', 100)
-            ->requirePresence('name', 'create')
             ->allowEmptyString('name', false);
 
         return $validator;

--- a/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTableSigned.php
@@ -54,7 +54,6 @@ class OldProductsTable extends Table
         $validator
             ->scalar('name')
             ->maxLength('name', 100)
-            ->requirePresence('name', 'create')
             ->allowEmptyString('name', false);
 
         return $validator;

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductsTable.php
@@ -66,7 +66,6 @@ class ProductsTable extends Table
         $validator
             ->scalar('name')
             ->maxLength('name', 100)
-            ->requirePresence('name', 'create')
             ->allowEmptyString('name', false);
 
         return $validator;

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductsTableSigned.php
@@ -66,7 +66,6 @@ class ProductsTable extends Table
         $validator
             ->scalar('name')
             ->maxLength('name', 100)
-            ->requirePresence('name', 'create')
             ->allowEmptyString('name', false);
 
         return $validator;


### PR DESCRIPTION
#531 
Added `$metaData['default'] === false` too in case other drivers use this and for future-proofing to what I hope would be future behaviour. Would make more sense for TableSchema to be setting `['default']` to `false` rather than `null` (and use `null` when the column default is actually `NULL`).