### PR TITLE
4.x remove subcommand

### DIFF
--- a/src/Command/ControllerAllCommand.php
+++ b/src/Command/ControllerAllCommand.php
@@ -78,7 +78,6 @@ class ControllerAllCommand extends BakeCommand
         $parser = $this->controllerCommand->buildOptionParser($parser);
         $parser
             ->setDescription('Bake all controller files with tests.')
-            ->removeSubcommand('all')
             ->setEpilog('');
 
         return $parser;

--- a/src/Command/ControllerCommand.php
+++ b/src/Command/ControllerCommand.php
@@ -263,8 +263,6 @@ class ControllerCommand extends BakeCommand
         ])->addOption('no-actions', [
             'boolean' => true,
             'help' => 'Do not generate basic CRUD action methods.',
-        ])->addSubcommand('all', [
-            'help' => 'Bake all controllers with CRUD methods.',
         ]);
 
         return $parser;

--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -84,8 +84,6 @@ class FixtureCommand extends BakeCommand
         ])->addOption('conditions', [
             'help' => 'The SQL snippet to use when importing records.',
             'default' => '1=1',
-        ])->addSubcommand('all', [
-            'help' => 'Bake all fixture files for tables in the chosen connection.',
         ]);
 
         return $parser;

--- a/src/Command/ModelAllCommand.php
+++ b/src/Command/ModelAllCommand.php
@@ -56,7 +56,6 @@ class ModelAllCommand extends BakeCommand
         $parser = $this->modelCommand->buildOptionParser($parser);
         $parser
             ->setDescription('Bake all model files with associations and validation.')
-            ->removeSubcommand('all')
             ->setEpilog('');
 
         return $parser;

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -1087,8 +1087,6 @@ class ModelCommand extends BakeCommand
         )->addArgument('name', [
             'help' => 'Name of the model to bake (without the Table suffix). ' .
                 'You can use Plugin.name to bake plugin models.',
-        ])->addSubcommand('all', [
-            'help' => 'Bake all model files with associations and validation.',
         ])->addOption('table', [
             'help' => 'The table name to use if you have non-conventional table names.',
         ])->addOption('no-entity', [

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -403,9 +403,6 @@ class TemplateCommand extends BakeCommand
         ])->addOption('index-columns', [
             'help' => 'Limit for the number of index columns',
             'default' => 0,
-        ])->addSubcommand('all', [
-            'help' => 'Bake all CRUD action views for all controllers.' .
-                'Requires models and controllers to exist.',
         ]);
 
         return $parser;

--- a/templates/bake/Command/command.twig
+++ b/templates/bake/Command/command.twig
@@ -49,7 +49,7 @@ class {{ name }}Command extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return null|int The exit code or null for success
      */
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): ?int
     {
     }
 }

--- a/tests/TestCase/Command/EntryCommandTest.php
+++ b/tests/TestCase/Command/EntryCommandTest.php
@@ -57,12 +57,11 @@ class EntryCommandTest extends TestCase
         $this->exec('bake --help');
 
         $this->assertExitCode(Command::CODE_SUCCESS);
-        $this->assertOutputContains('Bake generates code');
-        $this->assertOutputContains('Subcommands:');
-        $this->assertOutputContains('controller');
-        $this->assertOutputContains('Generate controller files.');
+        $this->assertOutputContains('Available Commands');
+        $this->assertOutputContains('bake controller');
+        $this->assertOutputContains('bake controller all');
+        $this->assertOutputContains('bake command');
         $this->assertOutputContains('shell_helper');
-        $this->assertOutputContains('Generate shell helper files.');
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,6 +45,9 @@ define('CONFIG', APP);
 define('TMP', sys_get_temp_dir() . DS);
 define('CACHE', TMP . 'cache' . DS);
 
+//used by Cake\Command\HelpCommand
+define('CORE_PATH', $root . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS);
+
 Configure::write('debug', true);
 Configure::write('App', [
     'debug' => true,

--- a/tests/comparisons/Command/testBakePlugin.php
+++ b/tests/comparisons/Command/testBakePlugin.php
@@ -34,7 +34,7 @@ class ExampleCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return null|int The exit code or null for success
      */
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): ?int
     {
     }
 }


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/pull/13194

output:
```
# bin/cake bake --help
Current Paths:

* app:  src
* root: ...bake
* core: ...bake/vendor/cakephp/cakephp

Available Commands:

App:
 - bake command
 - bake shell
 - bake shell_helper

Bake:
 - bake all
 - bake behavior
 - bake cell
 - bake component
 - bake controller
 - bake controller all
 - bake fixture
 - bake fixture all
 - bake form
 - bake helper
 - bake mailer
 - bake middleware
 - bake model
 - bake model all
 - bake plugin
 - bake task
 - bake template
 - bake template all
 - bake test

To run a command, type `cake command_name [args|options]`
To get help on a specific command, type `cake command_name --help`
```

@markstory how we can move bellow lists to `bake` section?
```
App:
 - bake command
 - bake shell
 - bake shell_helper
```

also description does not show now 
