### PR TITLE
Fix docblock of controller actions to reflect aiid/uuid agnostic case.

### DIFF
--- a/src/Template/Bake/Element/Controller/delete.twig
+++ b/src/Template/Bake/Element/Controller/delete.twig
@@ -16,7 +16,7 @@
     /**
      * Delete method
      *
-     * @param string|null $id {{ singularHumanName }} id.
+     * @param int|string|null $id {{ singularHumanName }} id.
      * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */

--- a/src/Template/Bake/Element/Controller/edit.twig
+++ b/src/Template/Bake/Element/Controller/edit.twig
@@ -19,7 +19,7 @@
     /**
      * Edit method
      *
-     * @param string|null $id {{ singularHumanName }} id.
+     * @param int|string|null $id {{ singularHumanName }} id.
      * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */

--- a/src/Template/Bake/Element/Controller/view.twig
+++ b/src/Template/Bake/Element/Controller/view.twig
@@ -20,7 +20,7 @@
     /**
      * View method
      *
-     * @param string|null $id {{ singularHumanName }} id.
+     * @param int|string|null $id {{ singularHumanName }} id.
      * @return \Cake\Http\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */

--- a/tests/comparisons/Controller/testBakeActions.php
+++ b/tests/comparisons/Controller/testBakeActions.php
@@ -45,7 +45,7 @@ class BakeArticlesController extends AppController
     /**
      * View method
      *
-     * @param string|null $id Bake Article id.
+     * @param int|string|null $id Bake Article id.
      * @return \Cake\Http\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
@@ -83,7 +83,7 @@ class BakeArticlesController extends AppController
     /**
      * Edit method
      *
-     * @param string|null $id Bake Article id.
+     * @param int|string|null $id Bake Article id.
      * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
@@ -109,7 +109,7 @@ class BakeArticlesController extends AppController
     /**
      * Delete method
      *
-     * @param string|null $id Bake Article id.
+     * @param int|string|null $id Bake Article id.
      * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */

--- a/tests/comparisons/Controller/testBakeActionsContent.php
+++ b/tests/comparisons/Controller/testBakeActionsContent.php
@@ -29,7 +29,7 @@ class BakeArticlesController extends AppController
     /**
      * View method
      *
-     * @param string|null $id Bake Article id.
+     * @param int|string|null $id Bake Article id.
      * @return \Cake\Http\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
@@ -67,7 +67,7 @@ class BakeArticlesController extends AppController
     /**
      * Edit method
      *
-     * @param string|null $id Bake Article id.
+     * @param int|string|null $id Bake Article id.
      * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
@@ -93,7 +93,7 @@ class BakeArticlesController extends AppController
     /**
      * Delete method
      *
-     * @param string|null $id Bake Article id.
+     * @param int|string|null $id Bake Article id.
      * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */

--- a/tests/comparisons/Controller/testBakeWithPlugin.php
+++ b/tests/comparisons/Controller/testBakeWithPlugin.php
@@ -30,7 +30,7 @@ class BakeArticlesController extends AppController
     /**
      * View method
      *
-     * @param string|null $id Bake Article id.
+     * @param int|string|null $id Bake Article id.
      * @return \Cake\Http\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
@@ -68,7 +68,7 @@ class BakeArticlesController extends AppController
     /**
      * Edit method
      *
-     * @param string|null $id Bake Article id.
+     * @param int|string|null $id Bake Article id.
      * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
@@ -94,7 +94,7 @@ class BakeArticlesController extends AppController
     /**
      * Delete method
      *
-     * @param string|null $id Bake Article id.
+     * @param int|string|null $id Bake Article id.
      * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */


### PR DESCRIPTION
If you use the slevomatic strict cs checks, it will always wrongly annotate them as string (or int) based on the current primary key type in your app.
Keeping this agostic by saying int|string prevents this and also then reflects that this can only be typehinted once the specific type in schema is detected (which currently is not the case for baked actions).