### PR TITLE
Disable the twig view caching

### DIFF
--- a/src/View/BakeView.php
+++ b/src/View/BakeView.php
@@ -72,6 +72,10 @@ class BakeView extends TwigView
             mkdir($this->_tmpLocation);
         }
 
+        Configure::write(TwigView::ENV_CONFIG, [
+            'cache' => false,
+        ]);
+
         parent::initialize();
     }
 


### PR DESCRIPTION
You had to manually delete the `tmp/cache/twigView` folder every time you alter your bake templates to see the correct results. Fixes  #549 