### PR TITLE
Resolve #554 Do not output a full stack trace for a missing table

### DIFF
--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -365,7 +365,7 @@ class TemplateCommand extends BakeCommand
     public function getContent(Arguments $args, ConsoleIo $io, string $action, ?array $vars = null)
     {
         if (!$vars) {
-            $vars = $this->_loadController();
+            $vars = $this->_loadController($io);
         }
 
         if (empty($vars['primaryKey'])) {

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -256,7 +256,7 @@ class TemplateCommand extends BakeCommand
      * - 'keyFields'
      * - 'schema'
      *
-     * @param \Cake\Console\ConsoleIo Instance of the ConsoleIO
+     * @param \Cake\Console\ConsoleIo $io Instance of the ConsoleIO
      * @return array Returns variables to be made available to a view template
      */
     protected function _loadController(ConsoleIo $io): array

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -270,13 +270,18 @@ class TemplateCommand extends BakeCommand
 
         $namespace = Configure::read('App.namespace');
 
-        $primaryKey = (array)$modelObject->getPrimaryKey();
-        $displayField = $modelObject->getDisplayField();
-        $singularVar = $this->_singularName($this->controllerName);
-        $singularHumanName = $this->_singularHumanName($this->controllerName);
-        $schema = $modelObject->getSchema();
-        $fields = $schema->columns();
-        $modelClass = $this->modelName;
+        try {
+            $primaryKey = (array)$modelObject->getPrimaryKey();
+            $displayField = $modelObject->getDisplayField();
+            $singularVar = $this->_singularName($this->controllerName);
+            $singularHumanName = $this->_singularHumanName($this->controllerName);
+            $schema = $modelObject->getSchema();
+            $fields = $schema->columns();
+            $modelClass = $this->modelName;
+        } catch (\Exception $exception) {
+            echo $exception->getMessage() . "\n";
+            exit;
+        }
 
         [, $entityClass] = namespaceSplit($this->_entityName($this->modelName));
         $entityClass = sprintf('%s\Model\Entity\%s', $namespace, $entityClass);

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -133,7 +133,7 @@ class TemplateCommand extends BakeCommand
             return static::CODE_SUCCESS;
         }
 
-        $vars = $this->_loadController();
+        $vars = $this->_loadController($io);
         $methods = $this->_methodsToBake();
 
         foreach ($methods as $method) {
@@ -256,9 +256,10 @@ class TemplateCommand extends BakeCommand
      * - 'keyFields'
      * - 'schema'
      *
+     * @param \Cake\Console\ConsoleIo Instance of the ConsoleIO
      * @return array Returns variables to be made available to a view template
      */
-    protected function _loadController(): array
+    protected function _loadController(ConsoleIo $io): array
     {
         if (TableRegistry::getTableLocator()->exists($this->modelName)) {
             $modelObject = TableRegistry::getTableLocator()->get($this->modelName);
@@ -279,8 +280,8 @@ class TemplateCommand extends BakeCommand
             $fields = $schema->columns();
             $modelClass = $this->modelName;
         } catch (\Exception $exception) {
-            echo $exception->getMessage() . "\n";
-            exit;
+            $io->error($exception->getMessage());
+            $this->abort();
         }
 
         [, $entityClass] = namespaceSplit($this->_entityName($this->modelName));

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -732,4 +732,16 @@ class TemplateCommandTest extends TestCase
         $this->assertFileExists($this->generatedFile);
         $this->assertFileContains('Template Task Comments', $this->generatedFile);
     }
+
+    /**
+     * test `cake bake template MissingTableClass`
+     *
+     * @return void
+     */
+    public function testMainWithMissingTable()
+    {
+        $this->exec('bake template MissingTableClass');
+
+        $this->assertExitCode(Command::CODE_ERROR);
+    }
 }


### PR DESCRIPTION
I have made a start on trying to [reduce the amount of noise](https://i.imgur.com/qtpM2ar.png) generated by an error when baking templates.

It seems that when the `getPrimaryKey()` method is called, this causes a chain reaction, because the schema doesn't exist etc.

I'm open to suggestions to improve the Exception handling, as I can see some instances where a stack trace might be helpful. Perhaps the error could be logged instead?

Thoughts welcome and I can update the pull request. 

Thanks!