### PR TITLE
Fixed return type issue

### DIFF
--- a/src/Shell/Task/BakeTask.php
+++ b/src/Shell/Task/BakeTask.php
@@ -133,6 +133,8 @@ class BakeTask extends Shell
         if (isset($this->params['connection'])) {
             $this->connection = $this->params['connection'];
         }
+
+        return static::CODE_SUCCESS;
     }
 
     /**

--- a/src/Shell/Task/SimpleBakeTask.php
+++ b/src/Shell/Task/SimpleBakeTask.php
@@ -80,7 +80,7 @@ abstract class SimpleBakeTask extends BakeTask
         $name = $this->_getName($name);
         $name = Inflector::camelize($name);
         $this->bake($name);
-        
+
         return null;
     }
 

--- a/src/Shell/Task/SimpleBakeTask.php
+++ b/src/Shell/Task/SimpleBakeTask.php
@@ -81,7 +81,7 @@ abstract class SimpleBakeTask extends BakeTask
         $name = Inflector::camelize($name);
         $this->bake($name);
 
-        return null;
+        return static::CODE_SUCCESS;
     }
 
     /**

--- a/src/Shell/Task/SimpleBakeTask.php
+++ b/src/Shell/Task/SimpleBakeTask.php
@@ -80,6 +80,8 @@ abstract class SimpleBakeTask extends BakeTask
         $name = $this->_getName($name);
         $name = Inflector::camelize($name);
         $this->bake($name);
+        
+        return null;
     }
 
     /**


### PR DESCRIPTION
Tested on linux - PHP 7.2.13

Error: Return value of Bake\Shell\Task\SimpleBakeTask::main() must be of the type integer or null, none returned