### PR TITLE
Fix plugin bootstrap setup

### DIFF
--- a/src/Template/Bake/Plugin/tests/bootstrap.php.twig
+++ b/src/Template/Bake/Plugin/tests/bootstrap.php.twig
@@ -40,11 +40,16 @@ unset($findRoot);
 chdir($root);
 
 require_once $root . '/vendor/autoload.php';
-require_once $root . '/vendor/cakephp/cakephp/src/basics.php';
+
+/**
+ * Define fallback values for required constants and configuration.
+ * To customize constants and configuration remove this require
+ * and define the data required by your plugin here.
+ */
+require_once $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
 
 if (file_exists($root . '/config/bootstrap.php')) {
     require $root . '/config/bootstrap.php';
 
     return;
 }
-require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';

--- a/tests/comparisons/Plugin/Company/Example/tests/bootstrap.php
+++ b/tests/comparisons/Plugin/Company/Example/tests/bootstrap.php
@@ -23,11 +23,16 @@ unset($findRoot);
 chdir($root);
 
 require_once $root . '/vendor/autoload.php';
-require_once $root . '/vendor/cakephp/cakephp/src/basics.php';
+
+/**
+ * Define fallback values for required constants and configuration.
+ * To customize constants and configuration remove this require
+ * and define the data required by your plugin here.
+ */
+require_once $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
 
 if (file_exists($root . '/config/bootstrap.php')) {
     require $root . '/config/bootstrap.php';
 
     return;
 }
-require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';

--- a/tests/comparisons/Plugin/SimpleExample/tests/bootstrap.php
+++ b/tests/comparisons/Plugin/SimpleExample/tests/bootstrap.php
@@ -23,11 +23,16 @@ unset($findRoot);
 chdir($root);
 
 require_once $root . '/vendor/autoload.php';
-require_once $root . '/vendor/cakephp/cakephp/src/basics.php';
+
+/**
+ * Define fallback values for required constants and configuration.
+ * To customize constants and configuration remove this require
+ * and define the data required by your plugin here.
+ */
+require_once $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
 
 if (file_exists($root . '/config/bootstrap.php')) {
     require $root . '/config/bootstrap.php';
 
     return;
 }
-require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';


### PR DESCRIPTION
The fix done in #560 addressed issues for when a plugin didn't have a config/bootstrap.php but not when that file was missing. These changes work in both scenarios, and include a comment on how to customize configuration if necessary.