### PR TITLE
Add forwards compatible plugin loading.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,5 @@ parameters:
     level: 4
     autoload_files:
         - tests/bootstrap.php
+    ignoreErrors:
+        - '#Class Cake\\Command\\PluginCommand not found#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,4 +3,4 @@ parameters:
     autoload_files:
         - tests/bootstrap.php
     ignoreErrors:
-        - '#Class Cake\\Command\\PluginCommand not found#'
+        - '#Class Cake\\Command\\PluginLoadCommand not found#'

--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -19,6 +19,7 @@ namespace Bake\Command;
 use Bake\Utility\Process;
 use Bake\Utility\TemplateRenderer;
 use Bake\View\BakeView;
+use Cake\Command\PluginLoadCommand;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
@@ -31,7 +32,6 @@ use Cake\Utility\Inflector;
 
 /**
  * The Plugin Command handles creating an empty plugin, ready to be used
- *
  */
 class PluginCommand extends BakeCommand
 {
@@ -136,9 +136,13 @@ class PluginCommand extends BakeCommand
      */
     protected function _modifyApplication(string $plugin, ConsoleIo $io): void
     {
-        $pluginShell = new PluginShell($io);
-        $pluginShell->initialize();
-        $pluginShell->runCommand(['load', $plugin], true);
+        if (class_exists(PluginShell::class)) {
+            $pluginShell = new PluginShell($io);
+            $pluginShell->initialize();
+            $pluginShell->runCommand(['load', $plugin], true);
+        } elseif (class_exists(PluginLoadCommand::class)) {
+            $this->executeCommand(PluginLoadCommand::class, [$plugin], $io);
+        }
     }
 
     /**

--- a/tests/TestCase/Command/PluginCommandTest.php
+++ b/tests/TestCase/Command/PluginCommandTest.php
@@ -83,7 +83,7 @@ class PluginCommandTest extends TestCase
      */
     public function testMainBakePluginContents()
     {
-        $this->exec('bake plugin SimpleExample', ['y']);
+        $this->exec('bake plugin SimpleExample', ['y', 'n']);
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertPluginContents('SimpleExample');
     }
@@ -95,7 +95,7 @@ class PluginCommandTest extends TestCase
      */
     public function testMainCustomAppNamespace()
     {
-        $this->exec('bake plugin Simple', ['y']);
+        $this->exec('bake plugin Simple', ['y', 'n']);
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertPluginContents('Simple');
 
@@ -111,7 +111,7 @@ class PluginCommandTest extends TestCase
      */
     public function testMainVendorName()
     {
-        $this->exec('bake plugin Company/Example', ['y']);
+        $this->exec('bake plugin Company/Example', ['y', 'n']);
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertPluginContents('Company/Example');
     }
@@ -123,7 +123,7 @@ class PluginCommandTest extends TestCase
      */
     public function testMainVendorNameCasingFix()
     {
-        $this->exec('bake plugin company/example', ['y']);
+        $this->exec('bake plugin company/example', ['y', 'n']);
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertPluginContents('Company/Example');
     }

--- a/tests/TestCase/Utility/TemplateRendererTest.php
+++ b/tests/TestCase/Utility/TemplateRendererTest.php
@@ -80,6 +80,7 @@ class TemplateRendererTest extends TestCase
         $result = $renderer->generate('config/routes');
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }
+
     /**
      * test generate with a missing template in the chosen template.
      * ensure fallback to default works.


### PR DESCRIPTION
CakePHP will soon be getting a new PluginLoadCommand. This allows forwards/backwards compatibility during the beta release cycles.