### PR TITLE
Publish 2x docs

### DIFF
--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -5,9 +5,9 @@ COPY docs /data/docs
 
 RUN cd /data/docs-builder && \
   # Build 1.x docs
-  make website LANGS="en es fr ja pt ru" SOURCE=/data/docs DEST=/data/website/1.x
+  make website LANGS="en es fr ja pt ru" SOURCE=/data/docs DEST=/data/website/1.x && \
   # Build 2.x docs
-  git checkout 4.x
+  git checkout 4.x && \
   make website LANGS="en es fr ja pt ru" SOURCE=/data/docs DEST=/data/website/2.x
 
 # Build a small nginx container with just the static site in it.

--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -4,8 +4,11 @@ FROM markstory/cakephp-docs-builder as builder
 COPY docs /data/docs
 
 RUN cd /data/docs-builder && \
-  # In the future repeat website for each version
+  # Build 1.x docs
   make website LANGS="en es fr ja pt ru" SOURCE=/data/docs DEST=/data/website/1.x
+  # Build 2.x docs
+  git checkout 4.x
+  make website LANGS="en es fr ja pt ru" SOURCE=/data/docs DEST=/data/website/2.x
 
 # Build a small nginx container with just the static site in it.
 FROM nginx:1.15-alpine
@@ -14,4 +17,5 @@ COPY --from=builder /data/website /data/website
 COPY --from=builder /data/docs-builder/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Move each version into place
-RUN mv /data/website/1.x/html/ /usr/share/nginx/html/1.x
+RUN mv /data/website/1.x/html/ /usr/share/nginx/html/1.x && \
+  mv /data/website/2.x/html/ /usr/share/nginx/html/2.x

--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -1,14 +1,16 @@
 # Generate the HTML output.
 FROM markstory/cakephp-docs-builder as builder
 
-COPY docs /data/docs
+# Copy entire repo in with .git so we can build all versions in one image.
+COPY . /data/src
 
-RUN cd /data/docs-builder && \
+RUN cd /data/docs-builder \
   # Build 1.x docs
-  make website LANGS="en es fr ja pt ru" SOURCE=/data/docs DEST=/data/website/1.x && \
+  && make website LANGS="en es fr ja pt ru" SOURCE=/data/src/docs DEST=/data/website/1.x \
   # Build 2.x docs
-  git checkout 4.x && \
-  make website LANGS="en es fr ja pt ru" SOURCE=/data/docs DEST=/data/website/2.x
+  && cd /data/src && git checkout 4.x \
+  && cd /data/docs-builder \
+  && make website LANGS="en es fr ja pt ru" SOURCE=/data/src/docs DEST=/data/website/2.x
 
 # Build a small nginx container with just the static site in it.
 FROM nginx:1.15-alpine

--- a/docs/config/all.py
+++ b/docs/config/all.py
@@ -24,6 +24,7 @@ project = 'CakePHP Bake'
 # Other versions that display in the version picker menu.
 version_list = [
     {'name': '1.x', 'number': '/bake/1.x', 'title': '1.x', 'current': True},
+    {'name': '2.x', 'number': '/bake/2.x', 'title': '2.x'},
 ]
 
 # Languages available.


### PR DESCRIPTION
Add the bake 2.x docs to the generate docs image for bake. Both versions will only update when master is updated right now. I think this is OK as once 2.x becomes master I don't foresee us needing many quick docs fixes to the 1.x version of bake.