### PR TITLE
Remove PluginShell reference

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,3 @@ parameters:
     level: 4
     autoload_files:
         - tests/bootstrap.php
-    ignoreErrors:
-        - '#Class Cake\\Command\\PluginLoadCommand not found#'

--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -27,7 +27,6 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Filesystem\Folder;
-use Cake\Shell\PluginShell;
 use Cake\Utility\Inflector;
 
 /**
@@ -136,13 +135,7 @@ class PluginCommand extends BakeCommand
      */
     protected function _modifyApplication(string $plugin, ConsoleIo $io): void
     {
-        if (class_exists(PluginShell::class)) {
-            $pluginShell = new PluginShell($io);
-            $pluginShell->initialize();
-            $pluginShell->runCommand(['load', $plugin], true);
-        } elseif (class_exists(PluginLoadCommand::class)) {
-            $this->executeCommand(PluginLoadCommand::class, [$plugin], $io);
-        }
+        $this->executeCommand(PluginLoadCommand::class, [$plugin], $io);
     }
 
     /**


### PR DESCRIPTION
It has been removed from cakephp/core and we've done a beta since it was removed. This shim should no longer be necessary.