### PR TITLE
Replace deleting directory placeholder file from 'empty' to '.gitkeep' when baking templates

### DIFF
--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -237,7 +237,7 @@ class FixtureCommand extends BakeCommand
 
         $io->out("\n" . sprintf('Baking test fixture for %s...', $model), 1, ConsoleIo::QUIET);
         $io->createFile($path . $filename, $content);
-        $emptyFile = $path . 'empty';
+        $emptyFile = $path . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);
     }
 

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -965,7 +965,7 @@ class ModelCommand extends BakeCommand
         $io->out("\n" . sprintf('Baking entity class for %s...', $name), 1, ConsoleIo::QUIET);
         $io->createFile($filename, $out);
 
-        $emptyFile = $path . 'Entity' . DS . 'empty';
+        $emptyFile = $path . 'Entity' . DS . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);
     }
 

--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -120,7 +120,7 @@ class PluginCommand extends BakeCommand
         $io->hr();
         $io->out(sprintf('<success>Created:</success> %s in %s', $plugin, $this->path . $plugin), 2);
 
-        $emptyFile = $this->path . 'empty';
+        $emptyFile = $this->path . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);
 
         return true;

--- a/src/Command/SimpleBakeCommand.php
+++ b/src/Command/SimpleBakeCommand.php
@@ -109,7 +109,7 @@ abstract class SimpleBakeCommand extends BakeCommand
         $filename = $this->getPath($args) . $this->fileName($name);
         $io->createFile($filename, $contents);
 
-        $emptyFile = $this->getPath($args) . 'empty';
+        $emptyFile = $this->getPath($args) . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);
     }
 

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -288,7 +288,7 @@ class TestCommand extends BakeCommand
         $out = $renderer->generate('tests/test_case');
 
         $filename = $this->testCaseFileName($type, $fullClassName);
-        $emptyFile = dirname($filename) . DS . 'empty';
+        $emptyFile = dirname($filename) . DS . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);
         if ($io->createFile($filename, $out)) {
             return $out;

--- a/src/Shell/Task/SimpleBakeTask.php
+++ b/src/Shell/Task/SimpleBakeTask.php
@@ -99,7 +99,7 @@ abstract class SimpleBakeTask extends BakeTask
 
         $filename = $this->getPath() . $this->fileName($name);
         $this->createFile($filename, $contents);
-        $emptyFile = $this->getPath() . 'empty';
+        $emptyFile = $this->getPath() . '.gitkeep';
         $this->_deleteEmptyFile($emptyFile);
 
         return $contents;


### PR DESCRIPTION
After baking certain templates, a directory file placeholder is removed as it is replaced by the baked files. In `cakephp/app:4.x`, this file has changed from `empty` to `.gitkeep`.

This PR reflects that change.

https://github.com/cakephp/app/commit/024b74e343fe81ee4f7a0e404ce4df63d1168dc3