### PR TITLE
Make controllers final by default

### DIFF
--- a/src/Template/Bake/Controller/controller.twig
+++ b/src/Template/Bake/Controller/controller.twig
@@ -39,7 +39,7 @@ use {{ namespace }}\Controller\AppController;
  * @method \{{ namespace }}\Model\Entity\{{ entityClassName }}[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
 {% endif %}
  */
-class {{ name }}Controller extends AppController
+final class {{ name }}Controller extends AppController
 {
 {% set helpers = Bake.arrayProperty('helpers', helpers, {'indent': false})|raw %}
 {% if helpers|trim %}

--- a/tests/comparisons/Controller/testBakeActions.php
+++ b/tests/comparisons/Controller/testBakeActions.php
@@ -11,7 +11,7 @@ use App\Controller\AppController;
  *
  * @method \App\Model\Entity\BakeArticle[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
  */
-class BakeArticlesController extends AppController
+final class BakeArticlesController extends AppController
 {
     /**
      * Helpers

--- a/tests/comparisons/Controller/testBakeActionsContent.php
+++ b/tests/comparisons/Controller/testBakeActionsContent.php
@@ -9,7 +9,7 @@ use App\Controller\AppController;
  *
  * @method \App\Model\Entity\BakeArticle[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
  */
-class BakeArticlesController extends AppController
+final class BakeArticlesController extends AppController
 {
     /**
      * Index method

--- a/tests/comparisons/Controller/testBakeActionsOption.php
+++ b/tests/comparisons/Controller/testBakeActionsOption.php
@@ -9,7 +9,7 @@ use App\Controller\AppController;
  * @property \Cake\Controller\Component\CsrfComponent $Csrf
  * @property \Cake\Controller\Component\AuthComponent $Auth
  */
-class BakeArticlesController extends AppController
+final class BakeArticlesController extends AppController
 {
     /**
      * Helpers

--- a/tests/comparisons/Controller/testBakeComponents.php
+++ b/tests/comparisons/Controller/testBakeComponents.php
@@ -13,7 +13,7 @@ use App\Controller\AppController;
  * @property \App\Controller\Component\AppleComponent $Apple
  * @property \App\Controller\Component\NonExistentComponent $NonExistent
  */
-class BakeArticlesController extends AppController
+final class BakeArticlesController extends AppController
 {
     /**
      * Components

--- a/tests/comparisons/Controller/testBakeNoActions.php
+++ b/tests/comparisons/Controller/testBakeNoActions.php
@@ -9,7 +9,7 @@ use App\Controller\AppController;
  * @property \Cake\Controller\Component\CsrfComponent $Csrf
  * @property \Cake\Controller\Component\AuthComponent $Auth
  */
-class BakeArticlesController extends AppController
+final class BakeArticlesController extends AppController
 {
     /**
      * Helpers

--- a/tests/comparisons/Controller/testBakeWithPlugin.php
+++ b/tests/comparisons/Controller/testBakeWithPlugin.php
@@ -10,7 +10,7 @@ use BakeTest\Controller\AppController;
  *
  * @method \BakeTest\Model\Entity\BakeArticle[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
  */
-class BakeArticlesController extends AppController
+final class BakeArticlesController extends AppController
 {
     /**
      * Index method


### PR DESCRIPTION
If you are extending controllers, maybe the initial thing shouldn't be a controller, and instead just a set of traits that can be composed into a class.