### PR TITLE
Remove creation of empty email layouts by mailer command.

### DIFF
--- a/src/Command/MailerCommand.php
+++ b/src/Command/MailerCommand.php
@@ -18,7 +18,6 @@ namespace Bake\Command;
 
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
-use Cake\Utility\Inflector;
 
 /**
  * Mailer code generator.
@@ -66,25 +65,6 @@ class MailerCommand extends SimpleBakeCommand
      */
     public function bake(string $name, Arguments $args, ConsoleIo $io): void
     {
-        $this->bakeLayouts($name, $args, $io);
-
         parent::bake($name, $args, $io);
-    }
-
-    /**
-     * Bake empty layout files for html/text emails.
-     *
-     * @param string $name The name of the mailer layouts are needed for.
-     * @param \Cake\Console\Arguments $args The console arguments
-     * @param \Cake\Console\ConsoleIo $io The console io
-     * @return void
-     */
-    protected function bakeLayouts(string $name, Arguments $args, ConsoleIo $io): void
-    {
-        foreach (['html', 'text'] as $type) {
-            $pathFragment = implode(DS, ['layout', 'email', $type, Inflector::underscore($name) . '.php']);
-            $path = $this->getTemplatePath($args) . $pathFragment;
-            $io->createFile($path, '');
-        }
     }
 }

--- a/tests/TestCase/Command/MailerCommandTest.php
+++ b/tests/TestCase/Command/MailerCommandTest.php
@@ -48,8 +48,6 @@ class MailerCommandTest extends TestCase
         $this->generatedFiles = [
             APP . 'Mailer/ExampleMailer.php',
             ROOT . 'tests/TestCase/Mailer/ExampleMailerTest.php',
-            ROOT . 'templates/layout/email/html/example.php',
-            ROOT . 'templates/layout/email/text/example.php',
         ];
         $this->exec('bake mailer Example');
 
@@ -72,8 +70,6 @@ class MailerCommandTest extends TestCase
         $this->generatedFiles = [
             $path . 'src/Mailer/ExampleMailer.php',
             $path . 'tests/TestCase/Mailer/ExampleMailerTest.php',
-            $templatePath . 'layout/email/html/example.php',
-            $templatePath . 'layout/email/text/example.php',
         ];
         $this->exec('bake mailer TestBake.Example');
 


### PR DESCRIPTION
They serve no purpose. Closes #625.