### PR TITLE
Don't use the old class name.

### DIFF
--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace Bake\Command;
 
 use Bake\Utility\CommonOptionsTrait;
+use Cake\Command\Command;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Core\ConventionsTrait;


### PR DESCRIPTION
Using this classname causes analysis fails in other packages.