### PR TITLE
Include parent call in generated plugin class methods

### DIFF
--- a/templates/bake/Plugin/src/Plugin.php.twig
+++ b/templates/bake/Plugin/src/Plugin.php.twig
@@ -61,6 +61,7 @@ class Plugin extends BasePlugin
                 $builder->fallbacks();
             }
         );
+        parent::routes($routes);
     }
 
     /**

--- a/tests/comparisons/Plugin/Company/Example/src/Plugin.php
+++ b/tests/comparisons/Plugin/Company/Example/src/Plugin.php
@@ -46,6 +46,7 @@ class Plugin extends BasePlugin
                 $builder->fallbacks();
             }
         );
+        parent::routes($routes);
     }
 
     /**

--- a/tests/comparisons/Plugin/SimpleExample/src/Plugin.php
+++ b/tests/comparisons/Plugin/SimpleExample/src/Plugin.php
@@ -46,6 +46,7 @@ class Plugin extends BasePlugin
                 $builder->fallbacks();
             }
         );
+        parent::routes($routes);
     }
 
     /**


### PR DESCRIPTION
Including the parent calls can lead to less surprising outcomes when users follow tutorials or examples.

Fixes cakephp/cakephp#14052