### PR TITLE
Update command.twig

### DIFF
--- a/templates/bake/Command/command.twig
+++ b/templates/bake/Command/command.twig
@@ -19,7 +19,7 @@ declare(strict_types=1);
 namespace {{ namespace }}\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 


### PR DESCRIPTION
this causes little problems, like IDE not found autocomplete, some functions not work like initialize, because contract of command changed.
And for surprise, have a deprecate warning about Cake\Console\Command.