### PR TITLE
use `getArgumentAt()` instead of `getArgument()`

### DIFF
--- a/src/Command/SimpleBakeCommand.php
+++ b/src/Command/SimpleBakeCommand.php
@@ -76,7 +76,7 @@ abstract class SimpleBakeCommand extends BakeCommand
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $this->extractCommonProperties($args);
-        $name = $args->getArgument('name');
+        $name = $args->getArgumentAt(0);
         if (empty($name)) {
             $io->err('You must provide a name to bake a ' . $this->name());
             $this->abort();


### PR DESCRIPTION
some bake classes could have not `name` in their argument list
this prevents from error when first argument passes anonymously

Refs : https://github.com/cakephp/migrations/pull/425#discussion_r369862861