### PR TITLE
Make the list of commands run by AllCommands a property

### DIFF
--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -93,7 +93,7 @@ class AllCommand extends BakeCommand
         }
 
         foreach ($this->commands as $commandName) {
-            /** @var \Cake\Comand\Command $command */
+            /** @var \Cake\Command\Command $command */
             $command = new $commandName();
             foreach ($tables as $table) {
                 $subArgs = new Arguments([$table], $args->getOptions(), ['name']);

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -16,14 +16,14 @@ declare(strict_types=1);
  */
 namespace Bake\Command;
 
+use Bake\Command\ControllerCommand;
+use Bake\Command\ModelCommand;
+use Bake\Command\TemplateCommand;
 use Bake\Utility\TableScanner;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
-use Bake\Command\ControllerCommand;
-use Bake\Command\ModelCommand;
-use Bake\Command\TemplateCommand;
 
 /**
  * Command for `bake all`

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -21,6 +21,9 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
+use Bake\Command\ModelCommand;
+use Bake\Command\ControllerCommand;
+use Bake\Command\TemplateCommand;
 
 /**
  * Command for `bake all`
@@ -33,9 +36,9 @@ class AllCommand extends BakeCommand
      * @var string[]
      */
     protected $commands = [
-        'Bake\Command\ModelCommand',
-        'Bake\Command\ControllerCommand',
-        'Bake\Command\TemplateCommand',
+        ModelCommand::class,
+        ControllerCommand::class,
+        TemplateCommand::class,
     ];
     /**
      * Gets the option parser instance and configures it.

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -21,9 +21,6 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
-use Bake\Command\ModelCommand;
-use Bake\Command\ControllerCommand;
-use Bake\Command\TemplateCommand;
 
 /**
  * Command for `bake all`
@@ -36,9 +33,9 @@ class AllCommand extends BakeCommand
      * @var string[]
      */
     protected $commands = [
-        ModelCommand::class,
-        ControllerCommand::class,
-        TemplateCommand::class,
+        'Bake\Command\ModelCommand',
+        'Bake\Command\ControllerCommand',
+        'Bake\Command\TemplateCommand',
     ];
     /**
      * Gets the option parser instance and configures it.

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -30,12 +30,12 @@ class AllCommand extends BakeCommand
     /**
      * All commands to call.
      *
-     * @var string[]
+     * @var array
      */
-    protected $commands = [
-        'Bake\Command\ModelCommand',
-        'Bake\Command\ControllerCommand',
-        'Bake\Command\TemplateCommand',
+    public $commands = [
+        'ModelCommand',
+        'ControllerCommand',
+        'TemplateCommand',
     ];
     /**
      * Gets the option parser instance and configures it.
@@ -93,7 +93,6 @@ class AllCommand extends BakeCommand
         }
 
         foreach ($this->commands as $commandName) {
-            /** @var \Cake\Comand\Command $command */
             $command = new $commandName();
             foreach ($tables as $table) {
                 $subArgs = new Arguments([$table], $args->getOptions(), ['name']);

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -37,6 +37,7 @@ class AllCommand extends BakeCommand
         ControllerCommand::class,
         TemplateCommand::class,
     ];
+
     /**
      * Gets the option parser instance and configures it.
      *

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -16,9 +16,6 @@ declare(strict_types=1);
  */
 namespace Bake\Command;
 
-use Bake\Command\ControllerCommand;
-use Bake\Command\ModelCommand;
-use Bake\Command\TemplateCommand;
 use Bake\Utility\TableScanner;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
@@ -36,9 +33,9 @@ class AllCommand extends BakeCommand
      * @var string[]
      */
     protected $commands = [
-        ModelCommand::class,
-        ControllerCommand::class,
-        TemplateCommand::class,
+        'Bake\Command\ControllerCommand',
+        'Bake\Command\ModelCommand',
+        'Bake\Command\TemplateCommand',
     ];
     /**
      * Gets the option parser instance and configures it.

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -16,9 +16,6 @@ declare(strict_types=1);
  */
 namespace Bake\Command;
 
-use Bake\Command\ControllerCommand;
-use Bake\Command\ModelCommand;
-use Bake\Command\TemplateCommand;
 use Bake\Utility\TableScanner;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
  */
 namespace Bake\Command;
 
+use Bake\Command\ControllerCommand;
+use Bake\Command\ModelCommand;
+use Bake\Command\TemplateCommand;
 use Bake\Utility\TableScanner;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
@@ -33,9 +36,9 @@ class AllCommand extends BakeCommand
      * @var string[]
      */
     protected $commands = [
-        'Bake\Command\ControllerCommand',
-        'Bake\Command\ModelCommand',
-        'Bake\Command\TemplateCommand',
+        ModelCommand::class,
+        ControllerCommand::class,
+        TemplateCommand::class,
     ];
     /**
      * Gets the option parser instance and configures it.

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -30,12 +30,12 @@ class AllCommand extends BakeCommand
     /**
      * All commands to call.
      *
-     * @var array
+     * @var string[]
      */
-    public $commands = [
-        'ModelCommand',
-        'ControllerCommand',
-        'TemplateCommand',
+    protected $commands = [
+        'Bake\Command\ModelCommand',
+        'Bake\Command\ControllerCommand',
+        'Bake\Command\TemplateCommand',
     ];
     /**
      * Gets the option parser instance and configures it.
@@ -93,6 +93,7 @@ class AllCommand extends BakeCommand
         }
 
         foreach ($this->commands as $commandName) {
+            /** @var \Cake\Comand\Command $command */
             $command = new $commandName();
             foreach ($tables as $table) {
                 $subArgs = new Arguments([$table], $args->getOptions(), ['name']);

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -21,12 +21,25 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
+use Bake\Command\ModelCommand;
+use Bake\Command\ControllerCommand;
+use Bake\Command\TemplateCommand;
 
 /**
  * Command for `bake all`
  */
 class AllCommand extends BakeCommand
 {
+    /**
+     * All commands to call.
+     *
+     * @var string[]
+     */
+    protected $commands = [
+        ModelCommand::class,
+        ControllerCommand::class,
+        TemplateCommand::class,
+    ];
     /**
      * Gets the option parser instance and configures it.
      *
@@ -82,13 +95,10 @@ class AllCommand extends BakeCommand
             $tables = [$name];
         }
 
-        $commands = [
-            new ModelCommand(),
-            new ControllerCommand(),
-            new TemplateCommand(),
-        ];
-        foreach ($tables as $table) {
-            foreach ($commands as $command) {
+        foreach ($this->commands as $commandName) {
+            /** @var \Cake\Comand\Command $command */
+            $command = new $commandName();
+            foreach ($tables as $table) {
                 $subArgs = new Arguments([$table], $args->getOptions(), ['name']);
                 $command->execute($subArgs, $io);
             }

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -21,8 +21,8 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
-use Bake\Command\ModelCommand;
 use Bake\Command\ControllerCommand;
+use Bake\Command\ModelCommand;
 use Bake\Command\TemplateCommand;
 
 /**

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -28,16 +28,6 @@ use Cake\Datasource\ConnectionManager;
 class AllCommand extends BakeCommand
 {
     /**
-     * All commands to call. 
-     *
-     * @var array
-     */
-    public $commands = [
-        'ModelCommand',
-        'ControllerCommand',
-        'TemplateCommand'
-    ];
-    /**
      * Gets the option parser instance and configures it.
      *
      * @param \Cake\Console\ConsoleOptionParser $parser Option parser to update.
@@ -92,9 +82,13 @@ class AllCommand extends BakeCommand
             $tables = [$name];
         }
 
-        foreach ($this->commands as $commandName) {
-            $command = new $commandName();
-            foreach ($tables as $table) {
+        $commands = [
+            new ModelCommand(),
+            new ControllerCommand(),
+            new TemplateCommand(),
+        ];
+        foreach ($tables as $table) {
+            foreach ($commands as $command) {
                 $subArgs = new Arguments([$table], $args->getOptions(), ['name']);
                 $command->execute($subArgs, $io);
             }

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -28,6 +28,16 @@ use Cake\Datasource\ConnectionManager;
 class AllCommand extends BakeCommand
 {
     /**
+     * All commands to call. 
+     *
+     * @var array
+     */
+    public $commands = [
+        'ModelCommand',
+        'ControllerCommand',
+        'TemplateCommand'
+    ];
+    /**
      * Gets the option parser instance and configures it.
      *
      * @param \Cake\Console\ConsoleOptionParser $parser Option parser to update.
@@ -82,13 +92,9 @@ class AllCommand extends BakeCommand
             $tables = [$name];
         }
 
-        $commands = [
-            new ModelCommand(),
-            new ControllerCommand(),
-            new TemplateCommand(),
-        ];
-        foreach ($tables as $table) {
-            foreach ($commands as $command) {
+        foreach ($this->commands as $commandName) {
+            $command = new $commandName();
+            foreach ($tables as $table) {
                 $subArgs = new Arguments([$table], $args->getOptions(), ['name']);
                 $command->execute($subArgs, $io);
             }

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -28,14 +28,14 @@ use Cake\Datasource\ConnectionManager;
 class AllCommand extends BakeCommand
 {
     /**
-     * All commands to call. 
+     * All commands to call.
      *
      * @var array
      */
     public $commands = [
         'ModelCommand',
         'ControllerCommand',
-        'TemplateCommand'
+        'TemplateCommand',
     ];
     /**
      * Gets the option parser instance and configures it.

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -28,14 +28,14 @@ use Cake\Datasource\ConnectionManager;
 class AllCommand extends BakeCommand
 {
     /**
-     * All commands to call.
+     * All commands to call. 
      *
      * @var array
      */
     public $commands = [
         'ModelCommand',
         'ControllerCommand',
-        'TemplateCommand',
+        'TemplateCommand'
     ];
     /**
      * Gets the option parser instance and configures it.


### PR DESCRIPTION
- Having the list of commands as a protected property allows it to be modified without needing to override the execute method.
- This allows one to change the scope of the Commands called also, e.g. for plugins.
- I've also flipped the foreach loop in the execute method for performance (i.e. to avoid an extra loop).