### PR TITLE
Correcting Controller Docblocks

### DIFF
--- a/templates/bake/element/Controller/add.twig
+++ b/templates/bake/element/Controller/add.twig
@@ -17,7 +17,7 @@
     /**
      * Add method
      *
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|null|void Redirects on successful add, renders view otherwise.
      */
     public function add()
     {

--- a/templates/bake/element/Controller/delete.twig
+++ b/templates/bake/element/Controller/delete.twig
@@ -17,7 +17,7 @@
      * Delete method
      *
      * @param string|null $id {{ singularHumanName }} id.
-     * @return \Cake\Http\Response|null Redirects to index.
+     * @return \Cake\Http\Response|null|void Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function delete($id = null)

--- a/templates/bake/element/Controller/edit.twig
+++ b/templates/bake/element/Controller/edit.twig
@@ -20,7 +20,7 @@
      * Edit method
      *
      * @param string|null $id {{ singularHumanName }} id.
-     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function edit($id = null)

--- a/templates/bake/element/Controller/index.twig
+++ b/templates/bake/element/Controller/index.twig
@@ -16,7 +16,7 @@
     /**
      * Index method
      *
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void Renders view
      */
     public function index()
     {

--- a/templates/bake/element/Controller/login.twig
+++ b/templates/bake/element/Controller/login.twig
@@ -16,7 +16,7 @@
     /**
      * Login method
      *
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void Renders view
      */
     public function login()
     {

--- a/templates/bake/element/Controller/logout.twig
+++ b/templates/bake/element/Controller/logout.twig
@@ -16,7 +16,7 @@
     /**
      * Logout method
      *
-     * @return \Cake\Http\Response
+     * @return \Cake\Http\Response|null|void Redirects to logout URL
      */
     public function logout()
     {

--- a/templates/bake/element/Controller/view.twig
+++ b/templates/bake/element/Controller/view.twig
@@ -21,7 +21,7 @@
      * View method
      *
      * @param string|null $id {{ singularHumanName }} id.
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void Renders view
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function view($id = null)

--- a/tests/comparisons/Controller/testBakeActions.php
+++ b/tests/comparisons/Controller/testBakeActions.php
@@ -31,7 +31,7 @@ class BakeArticlesController extends AppController
     /**
      * Index method
      *
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void Renders view
      */
     public function index()
     {
@@ -47,7 +47,7 @@ class BakeArticlesController extends AppController
      * View method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void Renders view
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function view($id = null)
@@ -62,7 +62,7 @@ class BakeArticlesController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|null|void Redirects on successful add, renders view otherwise.
      */
     public function add()
     {
@@ -85,7 +85,7 @@ class BakeArticlesController extends AppController
      * Edit method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function edit($id = null)
@@ -111,7 +111,7 @@ class BakeArticlesController extends AppController
      * Delete method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null Redirects to index.
+     * @return \Cake\Http\Response|null|void Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function delete($id = null)

--- a/tests/comparisons/Controller/testBakeActionsContent.php
+++ b/tests/comparisons/Controller/testBakeActionsContent.php
@@ -15,7 +15,7 @@ class BakeArticlesController extends AppController
     /**
      * Index method
      *
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void Renders view
      */
     public function index()
     {
@@ -31,7 +31,7 @@ class BakeArticlesController extends AppController
      * View method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void Renders view
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function view($id = null)
@@ -46,7 +46,7 @@ class BakeArticlesController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|null|void Redirects on successful add, renders view otherwise.
      */
     public function add()
     {
@@ -69,7 +69,7 @@ class BakeArticlesController extends AppController
      * Edit method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function edit($id = null)
@@ -95,7 +95,7 @@ class BakeArticlesController extends AppController
      * Delete method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null Redirects to index.
+     * @return \Cake\Http\Response|null|void Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function delete($id = null)

--- a/tests/comparisons/Controller/testBakeActionsOption.php
+++ b/tests/comparisons/Controller/testBakeActionsOption.php
@@ -29,7 +29,7 @@ class BakeArticlesController extends AppController
     /**
      * Login method
      *
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void Renders view
      */
     public function login()
     {
@@ -47,7 +47,7 @@ class BakeArticlesController extends AppController
     /**
      * Logout method
      *
-     * @return \Cake\Http\Response
+     * @return \Cake\Http\Response|null|void Redirects to logout URL
      */
     public function logout()
     {

--- a/tests/comparisons/Controller/testBakeWithPlugin.php
+++ b/tests/comparisons/Controller/testBakeWithPlugin.php
@@ -15,7 +15,7 @@ class BakeArticlesController extends AppController
     /**
      * Index method
      *
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void Renders view
      */
     public function index()
     {
@@ -31,7 +31,7 @@ class BakeArticlesController extends AppController
      * View method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void Renders view
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function view($id = null)
@@ -46,7 +46,7 @@ class BakeArticlesController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|null|void Redirects on successful add, renders view otherwise.
      */
     public function add()
     {
@@ -69,7 +69,7 @@ class BakeArticlesController extends AppController
      * Edit method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function edit($id = null)
@@ -95,7 +95,7 @@ class BakeArticlesController extends AppController
      * Delete method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null Redirects to index.
+     * @return \Cake\Http\Response|null|void Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function delete($id = null)


### PR DESCRIPTION
We should be documenting return Response|null|void to avoid false positives with PHPStan. See https://github.com/phpstan/phpstan/issues/2643

When baking a new Controller on a table and then running PHPStan 0.12.14 the following errors are found.

```
 ------ ----------------------------------------------------------------- 
  Line   Controller/TestBakeController.php                                
 ------ ----------------------------------------------------------------- 
  27     Method App\Controller\TestBakeController::index() should return  
         Cake\Http\Response|null but return statement is missing.         
  43     Method App\Controller\TestBakeController::view() should return   
         Cake\Http\Response|null but return statement is missing.         
  67     Method App\Controller\TestBakeController::add() should return    
         Cake\Http\Response|null but return statement is missing.         
  95     Method App\Controller\TestBakeController::edit() should return   
         Cake\Http\Response|null but return statement is missing.         
 ------ ----------------------------------------------------------------- 
```