### PR TITLE
Pass the force option into createFile() calls.

### DIFF
--- a/src/Command/CellCommand.php
+++ b/src/Command/CellCommand.php
@@ -106,7 +106,7 @@ class CellCommand extends SimpleBakeCommand
         $path = $this->getTemplatePath($args, 'cell');
         $path .= implode(DS, [$name, 'display.php']);
 
-        $io->createFile($path, '');
+        $io->createFile($path, '', $args->getOption('force'));
     }
 
     /**

--- a/src/Command/ControllerCommand.php
+++ b/src/Command/ControllerCommand.php
@@ -176,7 +176,7 @@ class ControllerCommand extends BakeCommand
 
         $path = $this->getPath($args);
         $filename = $path . $controllerName . 'Controller.php';
-        $io->createFile($filename, $contents);
+        $io->createFile($filename, $contents, $args->getOption('force'));
     }
 
     /**

--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -236,7 +236,7 @@ class FixtureCommand extends BakeCommand
         $content = $renderer->generate('tests/fixture');
 
         $io->out("\n" . sprintf('Baking test fixture for %s...', $model), 1, ConsoleIo::QUIET);
-        $io->createFile($path . $filename, $content);
+        $io->createFile($path . $filename, $content, $args->getOption('force'));
         $emptyFile = $path . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);
     }

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -980,7 +980,7 @@ class ModelCommand extends BakeCommand
         $path = $this->getPath($args);
         $filename = $path . 'Entity' . DS . $name . '.php';
         $io->out("\n" . sprintf('Baking entity class for %s...', $name), 1, ConsoleIo::QUIET);
-        $io->createFile($filename, $out);
+        $io->createFile($filename, $out, $args->getOption('force'));
 
         $emptyFile = $path . 'Entity' . DS . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);
@@ -1032,7 +1032,7 @@ class ModelCommand extends BakeCommand
         $path = $this->getPath($args);
         $filename = $path . 'Table' . DS . $name . 'Table.php';
         $io->out("\n" . sprintf('Baking table class for %s...', $name), 1, ConsoleIo::QUIET);
-        $io->createFile($filename, $out);
+        $io->createFile($filename, $out, $args->getOption('force'));
 
         // Work around composer caching that classes/files do not exist.
         // Check for the file as it might not exist in tests.

--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -269,7 +269,7 @@ class PluginCommand extends BakeCommand
         $io->out('<info>Modifying composer autoloader</info>');
 
         $out = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n";
-        $io->createFile($file, $out);
+        $io->createFile($file, $out, (bool)$args->getOption('force'));
 
         $composer = $this->findComposer($args, $io);
 

--- a/src/Command/SimpleBakeCommand.php
+++ b/src/Command/SimpleBakeCommand.php
@@ -107,7 +107,7 @@ abstract class SimpleBakeCommand extends BakeCommand
         $contents = $renderer->generate($this->template());
 
         $filename = $this->getPath($args) . $this->fileName($name);
-        $io->createFile($filename, $contents);
+        $io->createFile($filename, $contents, (bool)$args->getOption('force'));
 
         $emptyFile = $this->getPath($args) . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -349,7 +349,7 @@ class TemplateCommand extends BakeCommand
         $filename = $path . Inflector::underscore($outputFile) . '.php';
 
         $io->out("\n" . sprintf('Baking `%s` view template file...', $outputFile), 1, ConsoleIo::QUIET);
-        $io->createFile($filename, $content);
+        $io->createFile($filename, $content, $args->getOption('force'));
     }
 
     /**

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -293,7 +293,7 @@ class TestCommand extends BakeCommand
         $filename = $this->testCaseFileName($type, $fullClassName);
         $emptyFile = dirname($filename) . DS . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);
-        if ($io->createFile($filename, $out)) {
+        if ($io->createFile($filename, $out, $args->getOption('force'))) {
             return $out;
         }
 

--- a/tests/TestCase/Command/AllCommandTest.php
+++ b/tests/TestCase/Command/AllCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
 use Bake\Utility\SubsetSchemaCollection;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Datasource\ConnectionManager;
 
 /**
@@ -93,7 +93,7 @@ class AllCommandTest extends TestCase
             $testsPath . 'TestCase/Model/Table/ProductsTableTest.php',
             $testsPath . 'TestCase/Controller/ProductsControllerTest.php',
         ];
-        $this->exec('bake all --connection test Products');
+        $this->exec('bake all --connection test Products', ['y']);
 
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
@@ -134,7 +134,7 @@ class AllCommandTest extends TestCase
             $testsPath . 'TestCase/Model/Table/ProductVersionsTableTest.php',
             $testsPath . 'TestCase/Controller/ProductVersionsControllerTest.php',
         ];
-        $this->exec('bake all --connection test --everything');
+        $this->exec('bake all --connection test --everything', ['y']);
 
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);

--- a/tests/TestCase/Command/CellCommandTest.php
+++ b/tests/TestCase/Command/CellCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 
 /**

--- a/tests/TestCase/Command/CommandCommandTest.php
+++ b/tests/TestCase/Command/CommandCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 
 /**

--- a/tests/TestCase/Command/ControllerAllCommandTest.php
+++ b/tests/TestCase/Command/ControllerAllCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\App\Model\Table\BakeArticlesTable;
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;

--- a/tests/TestCase/Command/ControllerCommandTest.php
+++ b/tests/TestCase/Command/ControllerCommandTest.php
@@ -19,8 +19,8 @@ namespace Bake\Test\TestCase\Command;
 use Bake\Command\ControllerCommand;
 use Bake\Test\App\Model\Table\BakeArticlesTable;
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Arguments;
 use Cake\Command\Command;
+use Cake\Console\Arguments;
 use Cake\Core\Plugin;
 use Cake\ORM\TableRegistry;
 

--- a/tests/TestCase/Command/ControllerCommandTest.php
+++ b/tests/TestCase/Command/ControllerCommandTest.php
@@ -20,7 +20,7 @@ use Bake\Command\ControllerCommand;
 use Bake\Test\App\Model\Table\BakeArticlesTable;
 use Bake\Test\TestCase\TestCase;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 use Cake\ORM\TableRegistry;
 

--- a/tests/TestCase/Command/EntryCommandTest.php
+++ b/tests/TestCase/Command/EntryCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Command;
+use Cake\Command\Command;
 
 /**
  * EntryCommand Test

--- a/tests/TestCase/Command/FixtureAllCommandTest.php
+++ b/tests/TestCase/Command/FixtureAllCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
 use Bake\Utility\SubsetSchemaCollection;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 

--- a/tests/TestCase/Command/MailerCommandTest.php
+++ b/tests/TestCase/Command/MailerCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 
 /**

--- a/tests/TestCase/Command/MiddlewareCommandTest.php
+++ b/tests/TestCase/Command/MiddlewareCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 
 /**

--- a/tests/TestCase/Command/ModelAllCommandTest.php
+++ b/tests/TestCase/Command/ModelAllCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
 use Bake\Utility\SubsetSchemaCollection;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;

--- a/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
+++ b/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Postgres;

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -19,7 +19,7 @@ namespace Bake\Test\TestCase\Command;
 use Bake\Command\ModelCommand;
 use Bake\Test\TestCase\TestCase;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -18,8 +18,8 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Command\ModelCommand;
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Arguments;
 use Cake\Command\Command;
+use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;

--- a/tests/TestCase/Command/PluginCommandTest.php
+++ b/tests/TestCase/Command/PluginCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Command\PluginCommand;
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\StopException;
 use Cake\Core\App;

--- a/tests/TestCase/Command/SimpleBakeCommandTest.php
+++ b/tests/TestCase/Command/SimpleBakeCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 
 /**

--- a/tests/TestCase/Command/TaskCommandTest.php
+++ b/tests/TestCase/Command/TaskCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 
 /**

--- a/tests/TestCase/Command/TemplateAllCommandTest.php
+++ b/tests/TestCase/Command/TemplateAllCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
 use Bake\Utility\SubsetSchemaCollection;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -19,7 +19,7 @@ namespace Bake\Test\TestCase\Command;
 use Bake\Command\TemplateCommand;
 use Bake\Test\TestCase\TestCase;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\StopException;
 use Cake\Core\Configure;

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -18,8 +18,8 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Command\TemplateCommand;
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Arguments;
 use Cake\Command\Command;
+use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\StopException;
 use Cake\Core\Configure;

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -21,7 +21,7 @@ use Bake\Test\App\Controller\PostsController;
 use Bake\Test\App\Model\Table\ArticlesTable;
 use Bake\Test\App\Model\Table\CategoryThreadsTable;
 use Bake\Test\TestCase\TestCase;
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest as Request;


### PR DESCRIPTION
This will allow the `--force` option to be applied to commands. I've also updated the the various tests to not use the deprecated Command namespace.

Fixes #655