### PR TITLE
@codingStandards syntax is deprecated

### DIFF
--- a/templates/bake/tests/fixture.twig
+++ b/templates/bake/tests/fixture.twig
@@ -54,9 +54,9 @@ class {{ name }}Fixture extends TestFixture
      *
      * @var array
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:disable
     public $fields = {{ schema|raw }};
-    // @codingStandardsIgnoreEnd
+    // phpcs:enable
 {% endif %}
 
 {%- if records %}

--- a/tests/Fixture/CategoriesFixture.php
+++ b/tests/Fixture/CategoriesFixture.php
@@ -26,7 +26,7 @@ class CategoriesFixture extends TestFixture
      *
      * @var array
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:disable
     public $fields = [
         'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
         'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
@@ -40,7 +40,7 @@ class CategoriesFixture extends TestFixture
             'collation' => 'utf8_general_ci'
         ],
     ];
-    // @codingStandardsIgnoreEnd
+    // phpcs:enable
 
     /**
      * Records

--- a/tests/Fixture/CategoriesProductsFixture.php
+++ b/tests/Fixture/CategoriesProductsFixture.php
@@ -26,7 +26,7 @@ class CategoriesProductsFixture extends TestFixture
      *
      * @var array
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:disable
     public $fields = [
         'category_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
         'product_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
@@ -38,7 +38,7 @@ class CategoriesProductsFixture extends TestFixture
             'collation' => 'utf8_general_ci'
         ],
     ];
-    // @codingStandardsIgnoreEnd
+    // phpcs:enable
 
     /**
      * Records

--- a/tests/Fixture/OldProductsFixture.php
+++ b/tests/Fixture/OldProductsFixture.php
@@ -26,7 +26,7 @@ class OldProductsFixture extends TestFixture
      *
      * @var array
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:disable
     public $fields = [
         'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
         'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
@@ -40,7 +40,7 @@ class OldProductsFixture extends TestFixture
             'collation' => 'utf8_general_ci'
         ],
     ];
-    // @codingStandardsIgnoreEnd
+    // phpcs:enable
 
     /**
      * Records

--- a/tests/Fixture/ProductVersionsFixture.php
+++ b/tests/Fixture/ProductVersionsFixture.php
@@ -26,7 +26,7 @@ class ProductVersionsFixture extends TestFixture
      *
      * @var array
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:disable
     public $fields = [
         'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
         'product_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
@@ -39,7 +39,7 @@ class ProductVersionsFixture extends TestFixture
             'collation' => 'utf8_general_ci'
         ],
     ];
-    // @codingStandardsIgnoreEnd
+    // phpcs:enable
 
     /**
      * Records

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -26,7 +26,7 @@ class ProductsFixture extends TestFixture
      *
      * @var array
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:disable
     public $fields = [
         'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
         'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
@@ -40,7 +40,7 @@ class ProductsFixture extends TestFixture
             'collation' => 'utf8_general_ci'
         ],
     ];
-    // @codingStandardsIgnoreEnd
+    // phpcs:enable
 
     /**
      * Records

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-// @codingStandardsIgnoreFile
+// phpcs:ignoreFile
 
 use Cake\Cache\Cache;
 use Cake\Core\Configure;


### PR DESCRIPTION
I fixed it because it is deprecated syntax.

```
@codingStandardsIgnoreStart → phpcs:disable
@codingStandardsIgnoreEnd → phpcs:enable
@codingStandardsIgnoreFile → phpcs:ignoreFile
```

`@codingStandardsIgnoreLine` is also deprecated, but not used in this repository.

ref. https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file

> Note: Before PHP_CodeSniffer version 3.2.0, use // @codingStandardsIgnoreStart instead of // phpcs:disable, and use // @codingStandardsIgnoreEnd instead of // phpcs:enable. The @codingStandards syntax is deprecated and will be removed in PHP_CodeSniffer version 4.0.