### PR TITLE
Fix baking controller tests without models.

### DIFF
--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -32,6 +32,7 @@ use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use ReflectionClass;
+use UnexpectedValueException;
 
 /**
  * Command class for generating test files.
@@ -479,7 +480,14 @@ class TestCommand extends BakeCommand
      */
     protected function _processController(Controller $subject): void
     {
-        $models = [$subject->loadModel()->getAlias()];
+        try {
+            $model = $subject->loadModel();
+        } catch (UnexpectedValueException $exception) {
+            // No fixtures needed or possible
+            return;
+        }
+
+        $models = [$model->getAlias()];
         foreach ($models as $model) {
             [, $model] = pluginSplit($model);
             $this->_processModel($subject->{$model});

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -446,6 +446,23 @@ class TestCommandTest extends TestCase
      *
      * @return void
      */
+    public function testBakeControllerWithoutModelTest()
+    {
+        $this->generatedFiles = [
+            ROOT . 'tests/TestCase/Controller/NoModelControllerTest.php',
+        ];
+        $this->exec('bake test controller NoModelController');
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFilesExist($this->generatedFiles);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
+    }
+
+    /**
+     * test baking controller test files
+     *
+     * @return void
+     */
     public function testBakePrefixControllerTest()
     {
         $this->generatedFiles = [

--- a/tests/comparisons/Test/testBakeControllerWithoutModelTest.php
+++ b/tests/comparisons/Test/testBakeControllerWithoutModelTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Test\TestCase\Controller;
+
+use Bake\Test\App\Controller\NoModelController;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Bake\Test\App\Controller\NoModelController Test Case
+ *
+ * @uses \Bake\Test\App\Controller\NoModelController
+ */
+class NoModelControllerTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    /**
+     * Test index method
+     *
+     * @return void
+     */
+    public function testIndex(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+}

--- a/tests/test_app/App/Controller/NoModelController.php
+++ b/tests/test_app/App/Controller/NoModelController.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link      http://cakephp.org CakePHP(tm) Project
+ * @since     0.1.0
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\App\Controller;
+
+/**
+ * NoModelController class
+ */
+class NoModelController extends AppController
+{
+    /**
+     * @var string
+     */
+    protected $modelClass = '';
+
+    /**
+     * Index method.
+     *
+     * @return void
+     */
+    public function index()
+    {
+        $this->set('test', 'value');
+    }
+}


### PR DESCRIPTION
A controller with
```php
	/**
	 * @var string
	 */
	protected $modelClass = '';
```
and

```
cake bake test Controller ServiceExamplesController -p Sandbox
```
leads to

```
Exception: Default modelClass is empty
In [/home/vagrant/Apps/sandbox.local/vendor/cakephp/cakephp/src/Datasource/ModelAwareTrait.php, line 98]

2020-03-16 16:59:47 Error: [UnexpectedValueException] Default modelClass is empty in /home/vagrant/Apps/sandbox.local/vendor/cakephp/cakephp/src/Datasource/ModelAwareTrait.php on line 98
Stack Trace:
- /home/vagrant/Apps/sandbox.local/vendor/cakephp/bake/src/Command/TestCommand.php:482
- /home/vagrant/Apps/sandbox.local/vendor/cakephp/bake/src/Command/TestCommand.php:440
- /home/vagrant/Apps/sandbox.local/vendor/cakephp/bake/src/Command/TestCommand.php:246
- /home/vagrant/Apps/sandbox.local/vendor/cakephp/bake/src/Command/TestCommand.php:120
- /home/vagrant/Apps/sandbox.local/vendor/cakephp/cakephp/src/Console/BaseCommand.php:175
- /home/vagrant/Apps/sandbox.local/vendor/cakephp/cakephp/src/Console/CommandRunner.php:336
- /home/vagrant/Apps/sandbox.local/vendor/cakephp/cakephp/src/Console/CommandRunner.php:171
- /home/vagrant/Apps/sandbox.local/bin/cake.php:12
```


The core states though:
```php
    /**
     * ...
     *
     * Use empty string to not use auto-loading on this object. Null auto-detects based on
     * controller name.
     *
     * @var string|null
     */
    protected $modelClass;
```

Baking such a test should then still work as it just wouldnt try to use any fixture injection here.

Also refs https://github.com/cakephp/cakephp/pull/14356 as this would be a bit cleaner than try/catch.
But for a bake tool this solution is also fine IMO.