### PR TITLE
Remove not needed testInitialize test

### DIFF
--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -81,6 +81,15 @@ class TestCommand extends BakeCommand
     ];
 
     /**
+     * Blacklisted methods for controller test cases.
+     *
+     * @var string[]
+     */
+    protected $blacklistedMethods = [
+        'initialize',
+    ];
+
+    /**
      * Internal list of fixtures that have been added so far.
      *
      * @var string[]
@@ -415,7 +424,7 @@ class TestCommand extends BakeCommand
             if ($method->getDeclaringClass()->getName() !== $className) {
                 continue;
             }
-            if (!$method->isPublic()) {
+            if (!$method->isPublic() || in_array($method->getName(), $this->blacklistedMethods, true)) {
                 continue;
             }
             $out[] = $method->getName();

--- a/templates/bake/tests/test_case.twig
+++ b/templates/bake/tests/test_case.twig
@@ -136,19 +136,4 @@ class {{ className }}Test extends TestCase
         $this->markTestIncomplete('Not implemented yet.');
     }
 {% endfor %}
-
-{%- if not methods %}
-{%- if traitName or properties or fixtures or construction or methods %}
-
-{% endif %}
-    /**
-     * Test initial setup
-     *
-     * @return void
-     */
-    public function testInitialization(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
-{% endif %}
 }

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -209,7 +209,7 @@ class TestCommandTest extends TestCase
     {
         $command = new TestCommand();
         $result = $command->getTestableMethods('Bake\Test\App\Model\Table\ArticlesTable');
-        $expected = ['initialize', 'findpublished', 'dosomething', 'dosomethingelse'];
+        $expected = ['findpublished', 'dosomething', 'dosomethingelse'];
         $this->assertEquals($expected, array_map('strtolower', $result));
     }
 

--- a/tests/comparisons/Test/testBakeBehaviorTest.php
+++ b/tests/comparisons/Test/testBakeBehaviorTest.php
@@ -40,14 +40,4 @@ class ExampleBehaviorTest extends TestCase
 
         parent::tearDown();
     }
-
-    /**
-     * Test initial setup
-     *
-     * @return void
-     */
-    public function testInitialization(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
 }

--- a/tests/comparisons/Test/testBakeCellTest.php
+++ b/tests/comparisons/Test/testBakeCellTest.php
@@ -56,14 +56,4 @@ class ArticlesCellTest extends TestCase
 
         parent::tearDown();
     }
-
-    /**
-     * Test initial setup
-     *
-     * @return void
-     */
-    public function testInitialization(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
 }

--- a/tests/comparisons/Test/testBakeCommandTest.php
+++ b/tests/comparisons/Test/testBakeCommandTest.php
@@ -26,14 +26,4 @@ class OtherExampleCommandTest extends TestCase
         parent::setUp();
         $this->useCommandRunner();
     }
-
-    /**
-     * Test initial setup
-     *
-     * @return void
-     */
-    public function testInitialization(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
 }

--- a/tests/comparisons/Test/testBakeControllerTest.php
+++ b/tests/comparisons/Test/testBakeControllerTest.php
@@ -26,16 +26,6 @@ class PostsControllerTest extends TestCase
     ];
 
     /**
-     * Test initialize method
-     *
-     * @return void
-     */
-    public function testInitialize(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
-
-    /**
      * Test index method
      *
      * @return void

--- a/tests/comparisons/Test/testBakeFixturesParam.php
+++ b/tests/comparisons/Test/testBakeFixturesParam.php
@@ -53,14 +53,4 @@ class AuthorsTableTest extends TestCase
 
         parent::tearDown();
     }
-
-    /**
-     * Test initialize method
-     *
-     * @return void
-     */
-    public function testInitialize(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
 }

--- a/tests/comparisons/Test/testBakeHelperTest.php
+++ b/tests/comparisons/Test/testBakeHelperTest.php
@@ -42,14 +42,4 @@ class ExampleHelperTest extends TestCase
 
         parent::tearDown();
     }
-
-    /**
-     * Test initial setup
-     *
-     * @return void
-     */
-    public function testInitialization(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
 }

--- a/tests/comparisons/Test/testBakeModelTest.php
+++ b/tests/comparisons/Test/testBakeModelTest.php
@@ -56,16 +56,6 @@ class ArticlesTableTest extends TestCase
     }
 
     /**
-     * Test initialize method
-     *
-     * @return void
-     */
-    public function testInitialize(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
-
-    /**
      * Test findPublished method
      *
      * @return void

--- a/tests/comparisons/Test/testBakeNoFixtureParam.php
+++ b/tests/comparisons/Test/testBakeNoFixtureParam.php
@@ -42,14 +42,4 @@ class AuthorsTableTest extends TestCase
 
         parent::tearDown();
     }
-
-    /**
-     * Test initialize method
-     *
-     * @return void
-     */
-    public function testInitialize(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
 }

--- a/tests/comparisons/Test/testBakeShellHelperTest.php
+++ b/tests/comparisons/Test/testBakeShellHelperTest.php
@@ -58,14 +58,4 @@ class ExampleHelperTest extends TestCase
 
         parent::tearDown();
     }
-
-    /**
-     * Test initial setup
-     *
-     * @return void
-     */
-    public function testInitialization(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
 }

--- a/tests/comparisons/Test/testBakeShellTaskTest.php
+++ b/tests/comparisons/Test/testBakeShellTaskTest.php
@@ -48,14 +48,4 @@ class ArticlesTaskTest extends TestCase
 
         parent::tearDown();
     }
-
-    /**
-     * Test initial setup
-     *
-     * @return void
-     */
-    public function testInitialization(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
 }

--- a/tests/comparisons/Test/testBakeShellTest.php
+++ b/tests/comparisons/Test/testBakeShellTest.php
@@ -51,14 +51,4 @@ class ArticlesShellTest extends TestCase
 
         parent::tearDown();
     }
-
-    /**
-     * Test initial setup
-     *
-     * @return void
-     */
-    public function testInitialization(): void
-    {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
 }


### PR DESCRIPTION
Resolves https://github.com/cakephp/bake/issues/658

I do have a weird thing showing up now though:
```
+\n
+    /**\n
+     * Test initial setup\n
+     *\n
+     * @return void\n
+     */\n
+    public function testInitialization(): void\n
+    {\n
+        $this->markTestIncomplete('Not implemented yet.');\n
+    }\n
 }\n
```

Where does this one now come from?