### PR TITLE
Use plugin AppController if present

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "autoload-dev": {
         "psr-4": {
             "BakeTest\\": "tests/test_app/Plugin/BakeTest/src/",
+            "Company\\Pastry\\": "tests/test_app/Plugin/Company/Pastry/src/",
             "Pastry\\PastryTest\\": "tests/test_app/Plugin/PastryTest/src/",
             "Bake\\Test\\": "tests/",
             "Bake\\Test\\App\\": "tests/test_app/App/",

--- a/src/Command/ControllerCommand.php
+++ b/src/Command/ControllerCommand.php
@@ -95,9 +95,15 @@ class ControllerCommand extends BakeCommand
             $prefix = '\\' . str_replace('/', '\\', $prefix);
         }
 
-        $appNamespace = $namespace = Configure::read('App.namespace');
+        // Controllers default to importing AppController from `App`
+        $baseNamespace = $namespace = Configure::read('App.namespace');
         if ($this->plugin) {
             $namespace = $this->_pluginNamespace($this->plugin);
+        }
+        // If the plugin has an AppController other plugin controllers
+        // should inherit from it.
+        if ($this->plugin && class_exists("{$namespace}\Controller\AppController")) {
+            $baseNamespace = $namespace;
         }
 
         $currentModelName = $controllerName;
@@ -134,7 +140,7 @@ class ControllerCommand extends BakeCommand
             'helpers',
             'modelObj',
             'namespace',
-            'appNamespace',
+            'baseNamespace',
             'plugin',
             'pluralHumanName',
             'pluralName',

--- a/templates/bake/Controller/controller.twig
+++ b/templates/bake/Controller/controller.twig
@@ -22,12 +22,8 @@ declare(strict_types=1);
 
 namespace {{ namespace }}\Controller{{ prefix }};
 
-{% if plugin %}
-use {{ appNamespace }}\Controller\AppController;
-
-{% endif %}
-{% if prefix %}
-use {{ namespace }}\Controller\AppController;
+{% if plugin or prefix %}
+use {{ baseNamespace }}\Controller\AppController;
 
 {% endif %}
 /**

--- a/tests/TestCase/Command/ControllerCommandTest.php
+++ b/tests/TestCase/Command/ControllerCommandTest.php
@@ -355,6 +355,7 @@ class ControllerCommandTest extends TestCase
 
         $this->assertFileExists($this->generatedFile);
         $this->assertFileContains('namespace Company\Pastry\Controller;', $this->generatedFile);
+        $this->assertFileContains('use Company\Pastry\Controller\AppController;', $this->generatedFile);
         $this->assertFileContains('BakeArticlesController extends AppController', $this->generatedFile);
     }
 
@@ -375,6 +376,7 @@ class ControllerCommandTest extends TestCase
 
         $this->assertFileExists($this->generatedFile);
         $this->assertFileContains('namespace Company\Pastry\Controller;', $this->generatedFile);
+        $this->assertFileContains('use Company\Pastry\Controller\AppController;', $this->generatedFile);
         $this->assertFileContains('BakeArticlesController extends AppController', $this->generatedFile);
     }
 }

--- a/tests/test_app/Plugin/Company/Pastry/src/Controller/AppController.php
+++ b/tests/test_app/Plugin/Company/Pastry/src/Controller/AppController.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 namespace Company\Pastry\Controller;
 
 use Bake\Test\App\Controller\AppController as BaseController;

--- a/tests/test_app/Plugin/Company/Pastry/src/Controller/AppController.php
+++ b/tests/test_app/Plugin/Company/Pastry/src/Controller/AppController.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+namespace Company\Pastry\Controller;
+
+use Bake\Test\App\Controller\AppController as BaseController;
+
+/**
+ * Test stub for plugin controllers with an appcontroller in the plugin.
+ */
+class AppController extends BaseController
+{
+}


### PR DESCRIPTION
When creating controllers for plugins if there is a plugin AppController we should use it instead of the application's AppController.