### PR TITLE
Fix exception. Cleanup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - if [[ $CODECOVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
 
   - if [[ $CHECKS = 1 ]]; then composer cs-check; fi
-  - if [[ $CHECKS = 1 ]]; then composer phpstan-setup && composer phpstan; fi
+  - if [[ $CHECKS = 1 ]]; then composer stan-setup && composer stan; fi
 
 after_success:
   - if [[ $CODECOVERAGE = 1 ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,8 @@
         ],
         "cs-check": "phpcs --parallel=16 -p src/ tests/",
         "cs-fix": "phpcbf --parallel=16 -p src/ tests/",
-        "phpstan": "phpstan analyse src/",
-        "phpstan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12.7 && mv composer.backup composer.json",
+        "stan": "phpstan analyse src/",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12.7 && mv composer.backup composer.json",
         "test": "phpunit",
         "test-coverage": "phpunit --coverage-clover=clover.xml"
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,4 @@
 parameters:
-    level: 4
+    level: 5
     autoload_files:
         - tests/bootstrap.php

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -55,7 +55,7 @@ class AllCommand extends BakeCommand
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
@@ -66,6 +66,7 @@ class AllCommand extends BakeCommand
         $io->out('Bake All');
         $io->hr();
 
+        /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get($this->connection);
         $scanner = new TableScanner($connection);
         if (empty($name) && !$args->getOption('everything')) {

--- a/src/Command/ControllerAllCommand.php
+++ b/src/Command/ControllerAllCommand.php
@@ -51,12 +51,13 @@ class ControllerAllCommand extends BakeCommand
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $this->extractCommonProperties($args);
 
+        /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get($this->connection);
         $scanner = new TableScanner($connection);
         foreach ($scanner->listUnskipped() as $table) {

--- a/src/Command/ControllerCommand.php
+++ b/src/Command/ControllerCommand.php
@@ -42,7 +42,7 @@ class ControllerCommand extends BakeCommand
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
@@ -51,7 +51,9 @@ class ControllerCommand extends BakeCommand
         $name = $this->_getName($name);
 
         if (empty($name)) {
-            $scanner = new TableScanner(ConnectionManager::get($this->connection));
+            /** @var \Cake\Database\Connection $connection */
+            $connection = ConnectionManager::get($this->connection);
+            $scanner = new TableScanner($connection);
             $io->out('Possible controllers based on your current database:');
             foreach ($scanner->listUnskipped() as $table) {
                 $io->out('- ' . $this->_camelize($table));

--- a/src/Command/EntryCommand.php
+++ b/src/Command/EntryCommand.php
@@ -104,7 +104,7 @@ class EntryCommand extends Command implements CommandCollectionAwareInterface
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
@@ -127,7 +127,15 @@ class EntryCommand extends Command implements CommandCollectionAwareInterface
                     }
                 }
 
-                return $task->runCommand($argList);
+                $result = $task->runCommand($argList);
+                if ($result === false) {
+                    return static::CODE_ERROR;
+                }
+                if ($result === true) {
+                    return static::CODE_SUCCESS;
+                }
+
+                return $result;
             }
             $io->err("<error>Could not find a task named `{$name}`.</error>");
 

--- a/src/Command/FixtureAllCommand.php
+++ b/src/Command/FixtureAllCommand.php
@@ -74,6 +74,7 @@ class FixtureAllCommand extends BakeCommand
     {
         $this->extractCommonProperties($args);
 
+        /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get($args->getOption('connection') ?? 'default');
         $scanner = new TableScanner($connection);
         $fixture = new FixtureCommand();

--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -95,7 +95,7 @@ class FixtureCommand extends BakeCommand
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
@@ -103,6 +103,7 @@ class FixtureCommand extends BakeCommand
         $name = $args->getArgument('name') ?? '';
         $name = $this->_getName($name);
 
+        /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get($this->connection);
         $scanner = new TableScanner($connection);
         if (empty($name)) {

--- a/src/Command/ModelAllCommand.php
+++ b/src/Command/ModelAllCommand.php
@@ -67,11 +67,12 @@ class ModelAllCommand extends BakeCommand
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $this->extractCommonProperties($args);
+        /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get($this->connection);
         $scanner = new TableScanner($connection);
         foreach ($scanner->listUnskipped() as $table) {

--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -57,7 +57,7 @@ class PluginCommand extends BakeCommand
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {

--- a/src/Command/SimpleBakeCommand.php
+++ b/src/Command/SimpleBakeCommand.php
@@ -71,7 +71,7 @@ abstract class SimpleBakeCommand extends BakeCommand
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {

--- a/src/Command/TemplateAllCommand.php
+++ b/src/Command/TemplateAllCommand.php
@@ -53,7 +53,9 @@ class TemplateAllCommand extends BakeCommand
     public function execute(Arguments $args, ConsoleIo $io): int
     {
         $this->extractCommonProperties($args);
-        $scanner = new TableScanner(ConnectionManager::get($this->connection));
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get($this->connection);
+        $scanner = new TableScanner($connection);
 
         foreach ($scanner->listUnskipped() as $table) {
             $templateArgs = new Arguments([$table], $args->getOptions(), ['name']);

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -42,14 +42,14 @@ class TemplateCommand extends BakeCommand
      *
      * @var string
      */
-    public $controllerName = null;
+    public $controllerName;
 
     /**
      * Classname of the controller being used
      *
      * @var string
      */
-    public $controllerClass = null;
+    public $controllerClass;
 
     /**
      * Name with plugin of the model being used
@@ -70,7 +70,7 @@ class TemplateCommand extends BakeCommand
      *
      * @var \Bake\Utility\Model\AssociationFilter|null
      */
-    protected $_associationFilter = null;
+    protected $_associationFilter;
 
     /**
      * Template path.
@@ -94,7 +94,7 @@ class TemplateCommand extends BakeCommand
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
@@ -104,7 +104,9 @@ class TemplateCommand extends BakeCommand
 
         if (empty($name)) {
             $io->out('Possible tables to bake view templates for based on your current database:');
-            $scanner = new TableScanner(ConnectionManager::get($this->connection));
+            /** @var \Cake\Database\Connection $connection */
+            $connection = ConnectionManager::get($this->connection);
+            $scanner = new TableScanner($connection);
             foreach ($scanner->listUnskipped() as $table) {
                 $io->out('- ' . $this->_camelize($table));
             }

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -102,7 +102,7 @@ class TestCommand extends BakeCommand
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {

--- a/src/Shell/Task/BakeTask.php
+++ b/src/Shell/Task/BakeTask.php
@@ -116,7 +116,7 @@ class BakeTask extends Shell
      * Base execute method parses some parameters and sets some properties on the bake tasks.
      * call when overriding execute()
      *
-     * @return null|int
+     * @return int|null
      */
     public function main()
     {

--- a/tests/comparisons/Command/testBake.php
+++ b/tests/comparisons/Command/testBake.php
@@ -33,7 +33,7 @@ class ExampleCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {


### PR DESCRIPTION
```
bin/cake bake migration_snapshot
```

throws

> Exception: Return value of Bake\Command\EntryCommand::execute() must be of the type int or null, bool returned
In [/sandbox.local/vendor/cakephp/bake/src/Command/EntryCommand.php, line 130]

As the Shell return value is still

    @return int|bool|null

So this fixes it


Also fixed phpstan level to 5, as everything below is not a good quality.
Did some minor cleanup along the way.

I don't think anyone is extending the public methods of those classes.
But we can make this a minor if needed.