### PR TITLE
Allow regex pattern for ignore

### DIFF
--- a/src/Utility/TableScanner.php
+++ b/src/Utility/TableScanner.php
@@ -91,7 +91,7 @@ class TableScanner
     }
 
     /**
-     * @param string $table
+     * @param string $table Table name.
      *
      * @return bool
      */

--- a/src/Utility/TableScanner.php
+++ b/src/Utility/TableScanner.php
@@ -43,14 +43,14 @@ class TableScanner
      * Constructor
      *
      * @param \Cake\Database\Connection $connection The connection name in ConnectionManager
-     * @param string[]|null $ignore List of tables to ignore. If null, the default ignore
+     * @param string[]|null $ignore List of tables or regex pattern to ignore. If null, the default ignore
      *   list will be used.
      */
     public function __construct(Connection $connection, ?array $ignore = null)
     {
         $this->connection = $connection;
         if ($ignore === null) {
-            $ignore = ['i18n', 'cake_sessions', 'phinxlog', 'users_phinxlog'];
+            $ignore = ['i18n', 'cake_sessions', 'sessions', '/phinxlog/'];
         }
         $this->ignore = $ignore;
     }
@@ -69,7 +69,7 @@ class TableScanner
         }
         sort($tables);
 
-        return $tables;
+        return array_combine($tables, $tables);
     }
 
     /**
@@ -81,6 +81,34 @@ class TableScanner
     {
         $tables = $this->listAll();
 
-        return array_diff($tables, $this->ignore);
+        foreach ($tables as $key => $table) {
+            if ($this->shouldSkip($table)) {
+                unset($tables[$key]);
+            }
+        }
+
+        return $tables;
+    }
+
+    /**
+     * @param string $table
+     *
+     * @return bool
+     */
+    protected function shouldSkip(string $table): bool
+    {
+        foreach ($this->ignore as $ignore) {
+            if (strpos($ignore, '/') === 0) {
+                if ((bool)preg_match($ignore, $table)) {
+                    return true;
+                }
+            }
+
+            if ($ignore === $table) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/TestCase/Command/AllCommandTest.php
+++ b/tests/TestCase/Command/AllCommandTest.php
@@ -31,7 +31,7 @@ class AllCommandTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'plugin.Bake.Products',
         'plugin.Bake.ProductVersions',
     ];

--- a/tests/TestCase/Command/ControllerAllCommandTest.php
+++ b/tests/TestCase/Command/ControllerAllCommandTest.php
@@ -33,7 +33,7 @@ class ControllerAllCommandTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'plugin.Bake.BakeArticles',
         'plugin.Bake.BakeComments',
     ];

--- a/tests/TestCase/Command/ControllerCommandTest.php
+++ b/tests/TestCase/Command/ControllerCommandTest.php
@@ -34,7 +34,7 @@ class ControllerCommandTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'plugin.Bake.BakeArticles',
         'plugin.Bake.BakeArticlesBakeTags',
         'plugin.Bake.BakeComments',

--- a/tests/TestCase/Command/FixtureAllCommandTest.php
+++ b/tests/TestCase/Command/FixtureAllCommandTest.php
@@ -32,7 +32,7 @@ class FixtureAllCommandTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'core.Articles',
         'core.Comments',
     ];

--- a/tests/TestCase/Command/FixtureCommandTest.php
+++ b/tests/TestCase/Command/FixtureCommandTest.php
@@ -33,7 +33,7 @@ class FixtureCommandTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'core.Articles',
         'core.Comments',
         'plugin.Bake.Datatypes',

--- a/tests/TestCase/Command/ModelAllCommandTest.php
+++ b/tests/TestCase/Command/ModelAllCommandTest.php
@@ -33,7 +33,7 @@ class ModelAllCommandTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'plugin.Bake.TodoTasks',
         'plugin.Bake.TodoItems',
     ];

--- a/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
+++ b/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
@@ -39,7 +39,7 @@ class ModelCommandAssociationDetectionTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'plugin.Bake.Categories',
         'plugin.Bake.CategoriesProducts',
         'plugin.Bake.OldProducts',

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -43,7 +43,7 @@ class ModelCommandTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'core.Comments',
         'core.Tags',
         'core.ArticlesTags',

--- a/tests/TestCase/Command/TemplateAllCommandTest.php
+++ b/tests/TestCase/Command/TemplateAllCommandTest.php
@@ -33,7 +33,7 @@ class TemplateAllCommandTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'core.Articles',
         'core.Comments',
     ];

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -37,7 +37,7 @@ class TemplateCommandTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'core.Articles',
         'core.Tags',
         'core.ArticlesTags',

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -37,7 +37,7 @@ class TestCommandTest extends TestCase
      *
      * @var string
      */
-    public $fixtures = [
+    protected $fixtures = [
         'plugin.Bake.BakeArticles',
         'plugin.Bake.BakeArticlesBakeTags',
         'plugin.Bake.BakeComments',

--- a/tests/TestCase/Utility/Model/AssociationFilterTest.php
+++ b/tests/TestCase/Utility/Model/AssociationFilterTest.php
@@ -33,7 +33,7 @@ class AssociationFilterTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'core.Authors',
         'core.Tags',
         'core.Articles',

--- a/tests/TestCase/Utility/TableScannerTest.php
+++ b/tests/TestCase/Utility/TableScannerTest.php
@@ -18,7 +18,6 @@ namespace Bake\Test\TestCase\Utility;
 
 use Bake\Test\TestCase\TestCase;
 use Bake\Utility\TableScanner;
-use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 
 class TableScannerTest extends TestCase

--- a/tests/TestCase/Utility/TableScannerTest.php
+++ b/tests/TestCase/Utility/TableScannerTest.php
@@ -1,0 +1,129 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\TestCase\Utility;
+
+use Bake\Test\TestCase\TestCase;
+use Bake\Utility\TableScanner;
+use Cake\Core\Plugin;
+use Cake\Datasource\ConnectionManager;
+
+class TableScannerTest extends TestCase
+{
+    /**
+     * @var string[]
+     */
+    protected $fixtures = [
+        'plugin.Bake.TodoTasks',
+        'plugin.Bake.TodoItems',
+    ];
+
+    /**
+     * @var \Bake\Utility\TableScanner
+     */
+    protected $tableScanner;
+
+    /**
+     * @var \Cake\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = ConnectionManager::get('test');
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->tableScanner);
+    }
+
+    /**
+     * @return void
+     */
+    public function testListAll()
+    {
+        $this->tableScanner = new TableScanner($this->connection);
+
+        $result = $this->tableScanner->listAll();
+        $list = [
+            'todo_items' => true,
+            'todo_tasks' => true,
+        ];
+        foreach ($list as $key => $expected) {
+            if ($expected) {
+                $this->assertArrayHasKey($key, $result);
+            } else {
+                $this->assertArrayNotHasKey($key, $result);
+            }
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testListUnskipped()
+    {
+        $this->tableScanner = new TableScanner($this->connection, ['todo_items']);
+
+        $result = $this->tableScanner->listUnskipped();
+        $list = [
+            'todo_items' => false,
+            'todo_tasks' => true,
+        ];
+        foreach ($list as $key => $expected) {
+            if ($expected) {
+                $this->assertArrayHasKey($key, $result);
+            } else {
+                $this->assertArrayNotHasKey($key, $result);
+            }
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testListUnskippedRegex()
+    {
+        $this->tableScanner = new TableScanner($this->connection, ['/tasks$/']);
+
+        $result = $this->tableScanner->listUnskipped();
+        $list = [
+            'todo_items' => true,
+            'todo_tasks' => false,
+        ];
+        foreach ($list as $key => $expected) {
+            if ($expected) {
+                $this->assertArrayHasKey($key, $result);
+            } else {
+                $this->assertArrayNotHasKey($key, $result);
+            }
+        }
+    }
+}

--- a/tests/TestCase/Utility/TemplateRendererTest.php
+++ b/tests/TestCase/Utility/TemplateRendererTest.php
@@ -26,7 +26,7 @@ use Cake\Core\Plugin;
 class TemplateRendererTest extends TestCase
 {
     /**
-     * @var \Bake\Utility\TemplateRenderer|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Bake\Utility\TemplateRenderer
      */
     protected $renderer;
 

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -36,7 +36,7 @@ class BakeHelperTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected $fixtures = [
         'plugin.Bake.BakeArticles',
         'plugin.Bake.BakeComments',
         'plugin.Bake.BakeArticlesBakeTags',


### PR DESCRIPTION
I need the TableScanner for the IDE plugin, and I found that having multiple plugins with their own phinxlog is cumbersome to exclude them properly.
People should be able to pass also a regex pattern. If `/` is detected it will use regexp matching.

Also: Isn't `cake_sessions` `sessions` nowadays by default? I added that one as well.
