### PR TITLE
Plugins don't need plugin-installer as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "require": {
         "php": ">=7.2",
         "cakephp/cakephp": "^4.0",
-        "cakephp/plugin-installer": "^1.0",
         "wyrihaximus/twig-view": "^5.0.1"
     },
     "require-dev": {


### PR DESCRIPTION
Only the app needs cakephp/plugin-installer as dependency.