### PR TITLE
Use correct path for --theme option with bake

### DIFF
--- a/src/Utility/CommonOptionsTrait.php
+++ b/src/Utility/CommonOptionsTrait.php
@@ -81,6 +81,11 @@ trait CommonOptionsTrait
     {
         $bakeThemes = [];
         foreach (Plugin::loaded() as $plugin) {
+            print_r([
+                'plugin'=>$plugin,
+                'path'=>Plugin::path($plugin),
+                'classPath'=>Plugin::classPath($plugin),
+            ]);
             $path = Plugin::classPath($plugin);
             if (is_dir($path . 'Template' . DS . 'Bake')) {
                 $bakeThemes[] = $plugin;

--- a/src/Utility/CommonOptionsTrait.php
+++ b/src/Utility/CommonOptionsTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  * @since         1.4.3
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Bake\Utility;
 
 use Cake\Console\Arguments;
@@ -80,14 +81,10 @@ trait CommonOptionsTrait
     protected function _setCommonOptions(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $bakeThemes = [];
+        $templates = 'templates' . DS . 'bake';
         foreach (Plugin::loaded() as $plugin) {
-            print_r([
-                'plugin'=>$plugin,
-                'path'=>Plugin::path($plugin),
-                'classPath'=>Plugin::classPath($plugin),
-            ]);
-            $path = Plugin::classPath($plugin);
-            if (is_dir($path . 'Template' . DS . 'Bake')) {
+            $path = Plugin::path($plugin);
+            if (is_dir($path . $templates)) {
                 $bakeThemes[] = $plugin;
             }
         }


### PR DESCRIPTION
Fixes issue #674 - look in templates/bake rather than src/Template/Bake when collecting the list of available themes to use when baking.