### PR TITLE
Focus on primary key protection.

### DIFF
--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -369,14 +369,14 @@ class BakeHelper extends Helper
         $accessible = [];
 
         if (!isset($fields) || $fields !== false) {
-            if (!empty($fields)) {
-                foreach ($fields as $field) {
-                    $accessible[$field] = 'true';
-                }
-            } elseif (!empty($primaryKey)) {
+            if (!empty($primaryKey)) {
                 $accessible['*'] = 'true';
                 foreach ($primaryKey as $field) {
                     $accessible[$field] = 'false';
+                }
+            } elseif (!empty($fields)) {
+                foreach ($fields as $field) {
+                    $accessible[$field] = 'true';
                 }
             }
         }

--- a/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
+++ b/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
@@ -34,16 +34,7 @@ class TodoItem extends Entity
      * @var array
      */
     protected $_accessible = [
-        'user_id' => true,
-        'title' => true,
-        'body' => true,
-        'effort' => true,
-        'completed' => true,
-        'todo_task_count' => true,
-        'created' => true,
-        'updated' => true,
-        'user' => true,
-        'todo_tasks' => true,
-        'todo_labels' => true,
+        '*' => true,
+        'id' => false,
     ];
 }

--- a/tests/comparisons/Model/testBakeEntityFieldsWhiteList.php
+++ b/tests/comparisons/Model/testBakeEntityFieldsWhiteList.php
@@ -34,9 +34,7 @@ class TodoItem extends Entity
      * @var array
      */
     protected $_accessible = [
-        'id' => true,
-        'title' => true,
-        'body' => true,
-        'completed' => true,
+        '*' => true,
+        'id' => false,
     ];
 }

--- a/tests/comparisons/Model/testBakeEntityFullContext.php
+++ b/tests/comparisons/Model/testBakeEntityFullContext.php
@@ -29,12 +29,8 @@ class User extends Entity
      * @var array
      */
     protected $_accessible = [
-        'username' => true,
-        'password' => true,
-        'created' => true,
-        'updated' => true,
-        'comments' => true,
-        'todo_items' => true,
+        '*' => true,
+        'id' => false,
     ];
 
     /**


### PR DESCRIPTION
Too many people trip over this.
I think we should rather focus on the primary key exclusion than having all fields listed, as latter always get out of sync and then especially beginners, but also more experienced devs need forever to find out why.
So switching the check order here.

I always have been using the simplified version for years now, and it absolutely suffices for applications. And keeps dev life simple and balanced here.