### PR TITLE
Fix template override paths

### DIFF
--- a/docs/en/development.rst
+++ b/docs/en/development.rst
@@ -194,7 +194,7 @@ If you wish to modify the default output produced by the "bake" command, you can
 create your own bake templates in your application. This way does not use the
 ``--theme`` option in the command line when baking. The best way to do this is:
 
-#. Create a new directory **/templates/bake/**.
+#. Create a new directory **/templates/plugin/Bake/**.
 #. Copy any templates you want to override from
    **vendor/cakephp/bake/templates/bake/** to matching files in your
    application.

--- a/src/View/BakeView.php
+++ b/src/View/BakeView.php
@@ -88,11 +88,7 @@ class BakeView extends TwigView
     public function render(?string $view = null, $layout = null): string
     {
         $viewFileName = $this->_getTemplateFileName($view);
-        $templateEventName = str_replace(
-            ['.twig', DS],
-            ['', '.'],
-            explode('templates' . DS . static::BAKE_TEMPLATE_FOLDER . DS, $viewFileName)[1]
-        );
+        $templateEventName = str_replace(DS, '.', $view);
 
         $this->_currentType = static::TYPE_TEMPLATE;
         $this->dispatchEvent('View.beforeRender', [$viewFileName]);
@@ -142,7 +138,10 @@ class BakeView extends TwigView
     {
         $paths = parent::_paths($plugin, false);
         foreach ($paths as &$path) {
-            $path .= static::BAKE_TEMPLATE_FOLDER . DS;
+            // Append 'bake' to all directories that aren't the application override directory.
+            if (strpos($path, 'plugin' . DS . 'Bake') === false) {
+                $path .= static::BAKE_TEMPLATE_FOLDER . DS;
+            }
         }
 
         return $paths;

--- a/tests/TestCase/View/BakeViewTest.php
+++ b/tests/TestCase/View/BakeViewTest.php
@@ -170,4 +170,15 @@ class BakeViewTest extends TestCase
             $result
         );
     }
+
+    /**
+     * Ensure that application override templates don't have a double path in them.
+     *
+     * @return void
+     */
+    public function testApplicationOverride()
+    {
+        $result = $this->View->render('Bake.override');
+        $this->assertSame("Application override.\n", $result);
+    }
 }

--- a/tests/test_app/templates/plugin/Bake/override.twig
+++ b/tests/test_app/templates/plugin/Bake/override.twig
@@ -1,0 +1,1 @@
+Application override.


### PR DESCRIPTION
The changes in #680 broke compatibility and changed the documented paths that bake would use. I'm reluctant to add another break and go back to what it was as I think the changes to use CakePHP's conventions were generally good ones. This change updates the documentation and removes the `Bake/bake` path from application overrides.

Fixes #698