### PR TITLE
Test enhancement about assert equals checking

### DIFF
--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -109,11 +109,11 @@ class ModelCommandTest extends TestCase
         $command = new ModelCommand();
         $args = new Arguments([], [], []);
         $result = $command->getTable('TodoItems', $args);
-        $this->assertEquals('todo_items', $result);
+        $this->assertSame('todo_items', $result);
 
         $args = new Arguments([], ['table' => 'items'], []);
         $result = $command->getTable('TodoItems', $args);
-        $this->assertEquals('items', $result);
+        $this->assertSame('items', $result);
     }
 
     /**
@@ -128,8 +128,8 @@ class ModelCommandTest extends TestCase
 
         $result = $command->getTableObject('TodoItems', 'todo_items');
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('todo_items', $result->getTable());
-        $this->assertEquals('TodoItems', $result->getAlias());
+        $this->assertSame('todo_items', $result->getTable());
+        $this->assertSame('TodoItems', $result->getAlias());
 
         $command->plugin = 'BakeTest';
         $result = $command->getTableObject('Authors', 'todo_items');
@@ -148,13 +148,13 @@ class ModelCommandTest extends TestCase
         $command->tablePrefix = 'my_prefix_';
 
         $result = $command->getTableObject('TodoItems', 'todo_items');
-        $this->assertEquals('my_prefix_todo_items', $result->getTable());
+        $this->assertSame('my_prefix_todo_items', $result->getTable());
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('TodoItems', $result->getAlias());
+        $this->assertSame('TodoItems', $result->getAlias());
 
         $command->plugin = 'BakeTest';
         $result = $command->getTableObject('Authors', 'todo_items');
-        $this->assertEquals('my_prefix_todo_items', $result->getTable());
+        $this->assertSame('my_prefix_todo_items', $result->getTable());
         $this->assertInstanceOf('BakeTest\Model\Table\AuthorsTable', $result);
     }
 
@@ -1240,11 +1240,11 @@ class ModelCommandTest extends TestCase
         $command = new ModelCommand();
         $args = new Arguments([], [], []);
         $result = $command->getDisplayField($model, $args);
-        $this->assertEquals('title', $result);
+        $this->assertSame('title', $result);
 
         $args = new Arguments([], ['display-field' => 'custom'], []);
         $result = $command->getDisplayField($model, $args);
-        $this->assertEquals('custom', $result);
+        $this->assertSame('custom', $result);
     }
 
     /**

--- a/tests/TestCase/Command/PluginCommandTest.php
+++ b/tests/TestCase/Command/PluginCommandTest.php
@@ -176,11 +176,11 @@ class PluginCommandTest extends TestCase
         $this->assertArrayHasKey('ComposerExample\\Test\\', $result['autoload-dev']['psr-4']);
 
         $pluginPath = App::path('plugins')[0];
-        $this->assertEquals(
+        $this->assertSame(
             $pluginPath . 'ComposerExample' . DS . 'src' . DS,
             $result['autoload']['psr-4']['ComposerExample\\']
         );
-        $this->assertEquals(
+        $this->assertSame(
             $pluginPath . 'ComposerExample' . DS . 'tests' . DS,
             $result['autoload-dev']['psr-4']['ComposerExample\\Test\\']
         );
@@ -211,7 +211,7 @@ class PluginCommandTest extends TestCase
         $result = $command->findPath($paths, $io);
 
         $this->assertNull($result, 'no return');
-        $this->assertEquals(TMP . 'plugin_task' . DS, $command->path);
+        $this->assertSame(TMP . 'plugin_task' . DS, $command->path);
     }
 
     /**
@@ -249,9 +249,9 @@ class PluginCommandTest extends TestCase
         $bakedRoot = App::path('plugins')[0] . $pluginName . DS;
         $bakedFiles = $this->getFiles($bakedRoot);
 
-        $this->assertSame(
+        $this->assertCount(
             count($comparisonFiles),
-            count($bakedFiles),
+            $bakedFiles,
             'A different number of files were created than expected'
         );
 

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -92,8 +92,8 @@ class TemplateCommandTest extends TestCase
         $command = new TemplateCommand();
         $args = new Arguments([], [], []);
         $command->controller($args, 'Comments');
-        $this->assertEquals('Comments', $command->controllerName);
-        $this->assertEquals(
+        $this->assertSame('Comments', $command->controllerName);
+        $this->assertSame(
             'Bake\Test\App\Controller\CommentsController',
             $command->controllerClass
         );
@@ -111,7 +111,7 @@ class TemplateCommandTest extends TestCase
         $command = new TemplateCommand();
         $args = new Arguments([], [], []);
         $command->controller($args, $name);
-        $this->assertEquals('TemplateTaskComments', $command->controllerName);
+        $this->assertSame('TemplateTaskComments', $command->controllerName);
     }
 
     /**
@@ -126,8 +126,8 @@ class TemplateCommandTest extends TestCase
         $args = new Arguments([], [], []);
         $command->controller($args, 'Tests');
 
-        $this->assertEquals('Tests', $command->controllerName);
-        $this->assertEquals(
+        $this->assertSame('Tests', $command->controllerName);
+        $this->assertSame(
             'BakeTest\Controller\TestsController',
             $command->controllerClass
         );
@@ -144,16 +144,16 @@ class TemplateCommandTest extends TestCase
 
         $args = new Arguments([], ['prefix' => 'Admin'], []);
         $command->controller($args, 'Posts');
-        $this->assertEquals('Posts', $command->controllerName);
-        $this->assertEquals(
+        $this->assertSame('Posts', $command->controllerName);
+        $this->assertSame(
             'Bake\Test\App\Controller\Admin\PostsController',
             $command->controllerClass
         );
 
         $command->plugin = 'BakeTest';
         $command->controller($args, 'Comments');
-        $this->assertEquals('Comments', $command->controllerName);
-        $this->assertEquals(
+        $this->assertSame('Comments', $command->controllerName);
+        $this->assertSame(
             'BakeTest\Controller\Admin\CommentsController',
             $command->controllerClass
         );
@@ -170,8 +170,8 @@ class TemplateCommandTest extends TestCase
         $args = new Arguments([], ['prefix' => 'Admin/Management'], []);
 
         $command->controller($args, 'Posts');
-        $this->assertEquals('Posts', $command->controllerName);
-        $this->assertEquals(
+        $this->assertSame('Posts', $command->controllerName);
+        $this->assertSame(
             'Bake\Test\App\Controller\Admin\Management\PostsController',
             $command->controllerClass
         );
@@ -188,8 +188,8 @@ class TemplateCommandTest extends TestCase
         $args = new Arguments([], [], []);
 
         $command->controller($args, 'Comments', 'Posts');
-        $this->assertEquals('Posts', $command->controllerName);
-        $this->assertEquals(
+        $this->assertSame('Posts', $command->controllerName);
+        $this->assertSame(
             'Bake\Test\App\Controller\PostsController',
             $command->controllerClass
         );
@@ -204,10 +204,10 @@ class TemplateCommandTest extends TestCase
     {
         $command = new TemplateCommand();
         $command->model('Articles');
-        $this->assertEquals('Articles', $command->modelName);
+        $this->assertSame('Articles', $command->modelName);
 
         $command->model('NotThere');
-        $this->assertEquals('NotThere', $command->modelName);
+        $this->assertSame('NotThere', $command->modelName);
     }
 
     /**
@@ -220,7 +220,7 @@ class TemplateCommandTest extends TestCase
         $command = new TemplateCommand();
         $command->plugin = 'BakeTest';
         $command->model('BakeTestComments');
-        $this->assertEquals(
+        $this->assertSame(
             'BakeTest.BakeTestComments',
             $command->modelName
         );

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -320,7 +320,7 @@ class TestCommandTest extends TestCase
 
         $result = $command->getRealClassname('Helper', 'Asset');
         $expected = 'TestBake\View\Helper\AssetHelper';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -334,7 +334,7 @@ class TestCommandTest extends TestCase
         $result = $command->getRealClassname('Controller', 'Posts', 'Api/Public');
 
         $expected = 'Bake\Test\App\Controller\Api\Public\PostsController';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace and make `assertEquals` assertion strictly.