### PR TITLE
Default to PHP type `string` for unknown/custom database types.

### DIFF
--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -165,11 +165,11 @@ class DocBlockHelper extends Helper
      * Converts a column type to its DocBlock type counterpart.
      *
      * This method only supports the default CakePHP column types,
-     * custom column/database types will be ignored.
+     * for custom column/database types `'string'` will be returned.
      *
      * @see \Cake\Database\Type
      * @param string $type The column type.
-     * @return string|null The DocBlock type, or `null` for unsupported column types.
+     * @return string|null The DocBlock type, or `'string'` for unsupported column types.
      */
     public function columnTypeToHintType(string $type): ?string
     {
@@ -215,7 +215,8 @@ class DocBlockHelper extends Helper
                 return '\Cake\I18n\Time';
         }
 
-        return null;
+        // Any unique or custom types will have a `string` type hint
+        return 'string';
     }
 
     /**

--- a/tests/comparisons/Model/testBakeEntityWithPropertyTypeHints.php
+++ b/tests/comparisons/Model/testBakeEntityWithPropertyTypeHints.php
@@ -19,7 +19,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\FrozenTime|null $updated
  * @property array $array_type
  * @property array $json_type
- * @property $unknown_type
+ * @property string $unknown_type
  *
  * @property \Bake\Test\App\Model\Entity\User $user
  * @property \BakeTest\Model\Entity\TodoTask[] $todo_tasks


### PR DESCRIPTION
Prior to this fix if a table column was mapped to a custom database type class
the `@property` annotation generated for the field in entity class did not
have a type specified.