### PR TITLE
added timestamptimezone field type

### DIFF
--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -358,6 +358,7 @@ class FixtureCommand extends BakeCommand
                         }
                         break;
                     case 'timestamp':
+                    case 'timestamptimezone':
                     case 'timestampfractional':
                         $insert = time();
                         break;


### PR DESCRIPTION
With PostgreSQL and timestamptimezone field type you get empty '' record values in fixtures and because of that running phpunit tests fails in some cases.