### PR TITLE
Allow using "Command/Bake" subfolder for bake commands.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
             "BakeTest\\": "tests/test_app/Plugin/BakeTest/src/",
             "Company\\Pastry\\": "tests/test_app/Plugin/Company/Pastry/src/",
             "Pastry\\PastryTest\\": "tests/test_app/Plugin/PastryTest/src/",
+            "WithBakeSubFolder\\": "tests/test_app/Plugin/WithBakeSubFolder/src/",
             "Bake\\Test\\": "tests/",
             "Bake\\Test\\App\\": "tests/test_app/App/",
             "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -29,7 +29,7 @@ class PluginTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        $this->removePlugins(['BakeTest']);
+        $this->removePlugins(['BakeTest', 'WithBakeSubFolder']);
     }
 
     public function testRoutes()
@@ -71,6 +71,21 @@ class PluginTest extends TestCase
         $this->assertTrue($commands->has('bake zergling'));
         $this->assertFalse($commands->has('bake bake_test.zergling'));
         $this->assertFalse($commands->has('bake BakeTest.zergling'));
+    }
+
+    public function testConsoleDiscoverPluginCommandsInSubFolder()
+    {
+        $this->_loadTestPlugin('WithBakeSubFolder');
+
+        $commands = new CommandCollection();
+        $plugin = new Plugin();
+        $commands = $plugin->console($commands);
+
+        $this->assertTrue($commands->has('bake led_zepplin'));
+        $this->assertFalse(
+            $commands->has('bake the_who'),
+            'Only commands from "Bake" subfolder should be loaded'
+        );
     }
 
     public function testConsoleDiscoverAppCommands()

--- a/tests/test_app/Plugin/WithBakeSubFolder/src/Command/Bake/LedZepplinCommand.php
+++ b/tests/test_app/Plugin/WithBakeSubFolder/src/Command/Bake/LedZepplinCommand.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link      http://cakephp.org CakePHP(tm) Project
+ * @since     2.3.0
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace WithBakeSubFolder\Command\Bake;
+
+use Bake\Command\BakeCommand;
+
+/**
+ * Test stub for command discovery
+ */
+class LedZepplinCommand extends BakeCommand
+{
+}

--- a/tests/test_app/Plugin/WithBakeSubFolder/src/Command/TheWhoCommand.php
+++ b/tests/test_app/Plugin/WithBakeSubFolder/src/Command/TheWhoCommand.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link      http://cakephp.org CakePHP(tm) Project
+ * @since     2.3.0
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace WithBakeSubFolder\Command;
+
+use Bake\Command\BakeCommand;
+use Exception;
+
+/**
+ * Test stub for command discovery
+ */
+class TheWhoCommand extends BakeCommand
+{
+    public static function defaultName(): string
+    {
+        throw new Exception('This command should not be loaded as there\'s a "Bake" subfolder');
+    }
+}


### PR DESCRIPTION
If this subfolder exists, bake plugin will only use commands under that
directory as bake commands by default and will not check the command
files directly under "Command" folder.