### PR TITLE
Add new helper method for exporting vars.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "php": ">=7.2",
         "cakephp/cakephp": "^4.1",
-        "cakephp/twig-view": "^1.0.2"
+        "cakephp/twig-view": "^1.0.2",
+        "brick/varexporter": "^0.3.5"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^4.0",

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -913,7 +913,7 @@ class ModelCommand extends BakeCommand
      * Get CounterCaches
      *
      * @param \Cake\ORM\Table $model The table to get counter cache fields for.
-     * @return string[] CounterCache configurations
+     * @return array<string, array> CounterCache configurations
      */
     public function getCounterCache(Table $model): array
     {
@@ -933,7 +933,7 @@ class ModelCommand extends BakeCommand
             $alias = $model->getAlias();
             $field = Inflector::singularize(Inflector::underscore($alias)) . '_count';
             if (in_array($field, $otherFields, true)) {
-                $counterCache[] = "'{$otherAlias}' => ['{$field}']";
+                $counterCache[$otherAlias] = [$field];
             }
         }
 

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Bake\View\Helper;
 
 use Bake\Utility\Model\AssociationFilter;
+use Brick\VarExporter\VarExporter;
 use Cake\Core\Configure;
 use Cake\Core\ConventionsTrait;
 use Cake\Database\Schema\TableSchema;
@@ -64,6 +65,7 @@ class BakeHelper extends Helper
      * @param array $list array of items to be stringified
      * @param array $options options to use
      * @return string
+     * @deprecated 2.5.0 Use BakeHelper::exportVar() instead.
      */
     public function stringifyList(array $list, array $options = []): string
     {
@@ -123,6 +125,24 @@ class BakeHelper extends Helper
         }
 
         return $start . implode($join, $list) . $end;
+    }
+
+    /**
+     * Export variable to string representation.
+     *
+     * (Similar to `var_export()` but better).
+     *
+     * @param mixed $var Variable to export.
+     * @param int $indentLevel Identation level.
+     * @param int $options Exporting options.
+     * @return string
+     * @see https://github.com/brick/varexporter#options
+     */
+    public function exportVar($var, int $indentLevel = 0, int $options = 0): string
+    {
+        $options |= VarExporter::TRAILING_COMMA_IN_ARRAY;
+
+        return VarExporter::export($var, $options, $indentLevel);
     }
 
     /**
@@ -362,7 +382,7 @@ class BakeHelper extends Helper
      *
      * @param string[]|false|null $fields Fields list.
      * @param string[]|null $primaryKey Primary key.
-     * @return string[]
+     * @return array<string, bool>
      */
     public function getFieldAccessibility($fields = null, $primaryKey = null): array
     {
@@ -371,12 +391,12 @@ class BakeHelper extends Helper
         if (!isset($fields) || $fields !== false) {
             if (!empty($fields)) {
                 foreach ($fields as $field) {
-                    $accessible[$field] = 'true';
+                    $accessible[$field] = true;
                 }
             } elseif (!empty($primaryKey)) {
-                $accessible['*'] = 'true';
+                $accessible['*'] = true;
                 foreach ($primaryKey as $field) {
-                    $accessible[$field] = 'false';
+                    $accessible[$field] = false;
                 }
             }
         }

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -134,7 +134,7 @@ class BakeHelper extends Helper
      *
      * @param mixed $var Variable to export.
      * @param int $indentLevel Identation level.
-     * @param int $options Exporting options.
+     * @param int $options VarExporter option flags
      * @return string
      * @see https://github.com/brick/varexporter#options
      */
@@ -152,7 +152,7 @@ class BakeHelper extends Helper
      *
      * @param array $var Array to export.
      * @param int $indentLevel Identation level.
-     * @param bool $inline Inline numeric scalar array.
+     * @param bool $inline Inline numeric scalar array (adds INLINE_NUMERIC_SCALAR_ARRAY flag)
      * @return string
      */
     public function exportArray(array $var, int $indentLevel = 0, bool $inline = true): string

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -146,6 +146,26 @@ class BakeHelper extends Helper
     }
 
     /**
+     * Export array to string representation.
+     *
+     * (Similar to `var_export()` but better).
+     *
+     * @param array $var Array to export.
+     * @param int $indentLevel Identation level.
+     * @param bool $inline Inline numeric scalar array.
+     * @return string
+     */
+    public function exportArray(array $var, int $indentLevel = 0, bool $inline = true): string
+    {
+        $options = 0;
+        if ($inline) {
+            $options = VarExporter::INLINE_NUMERIC_SCALAR_ARRAY;
+        }
+
+        return $this->exportVar($var, $indentLevel, $options);
+    }
+
+    /**
      * Extract the aliases for associations, filters hasMany associations already extracted as
      * belongsToMany
      *

--- a/templates/bake/Controller/controller.twig
+++ b/templates/bake/Controller/controller.twig
@@ -58,7 +58,7 @@ class {{ name }}Controller extends AppController
         $this->loadComponent('{{ component }}');
 {% endfor %}
 {% if helpers %}
-        $this->viewBuilder()->setHelpers([{{ Bake.stringifyList(helpers, {'indent': false})|raw }}]);
+        $this->viewBuilder()->setHelpers({{ Bake.exportVar(helpers, 0, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }});
 {% endif %}
     }
 {% if actions|length %}{{ "\n" }}{% endif %}

--- a/templates/bake/Controller/controller.twig
+++ b/templates/bake/Controller/controller.twig
@@ -58,7 +58,7 @@ class {{ name }}Controller extends AppController
         $this->loadComponent('{{ component }}');
 {% endfor %}
 {% if helpers %}
-        $this->viewBuilder()->setHelpers({{ Bake.exportVar(helpers, 0, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }});
+        $this->viewBuilder()->setHelpers({{ Bake.exportArray(helpers)|raw }});
 {% endif %}
     }
 {% if actions|length %}{{ "\n" }}{% endif %}

--- a/templates/bake/Model/entity.twig
+++ b/templates/bake/Model/entity.twig
@@ -43,7 +43,7 @@ class {{ name }} extends Entity
      *
      * @var array
      */
-    protected $_accessible = [{{ Bake.stringifyList(accessible, {'quotes': false})|raw }}];
+    protected $_accessible = {{ Bake.exportVar(accessible, 1)|raw }};
 {% endif %}
 {% if accessible and hidden %}
 
@@ -54,6 +54,6 @@ class {{ name }} extends Entity
      *
      * @var array
      */
-    protected $_hidden = [{{ Bake.stringifyList(hidden)|raw }}];
+    protected $_hidden = {{ Bake.exportVar(hidden, 1)|raw }};
 {% endif %}
 }

--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -45,7 +45,7 @@ class {{ name }}Table extends Table
 
 {%- if primaryKey %}
     {%- if primaryKey is iterable and primaryKey|length > 1 %}
-        $this->setPrimaryKey([{{ Bake.stringifyList(primaryKey, {'indent': false})|raw }}]);
+        $this->setPrimaryKey({{ Bake.exportVar(primaryKey, 0, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }});
         {{- "\n" }}
     {%- else %}
         $this->setPrimaryKey('{{ primaryKey|as_array|first }}');
@@ -58,7 +58,7 @@ class {{ name }}Table extends Table
 {% endif %}
 
 {%- for behavior, behaviorData in behaviors %}
-        $this->addBehavior('{{ behavior }}'{{ (behaviorData ? (", [" ~ Bake.stringifyList(behaviorData, {'indent': 3, 'quotes': false})|raw ~ ']') : '')|raw }});
+        $this->addBehavior('{{ behavior }}'{{ (behaviorData ? (", " ~ Bake.exportVar(behaviorData, 2, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw ~ '') : '')|raw }});
 {% endfor %}
 
 {%- if associations.belongsTo or associations.hasMany or associations.belongsToMany %}
@@ -73,7 +73,7 @@ class {{ name }}Table extends Table
                 {%- set assocData = assocData|merge({(key): val}) %}
             {%- endif %}
         {%- endfor %}
-        $this->{{ type }}('{{ assoc.alias }}', [{{ Bake.stringifyList(assocData, {'indent': 3})|raw }}]);
+        $this->{{ type }}('{{ assoc.alias }}', {{ Bake.exportVar(assocData, 2, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }});
         {{- "\n" }}
     {%- endfor %}
 {% endfor %}

--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -45,7 +45,7 @@ class {{ name }}Table extends Table
 
 {%- if primaryKey %}
     {%- if primaryKey is iterable and primaryKey|length > 1 %}
-        $this->setPrimaryKey({{ Bake.exportVar(primaryKey, 0, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }});
+        $this->setPrimaryKey({{ Bake.exportArray(primaryKey)|raw }});
         {{- "\n" }}
     {%- else %}
         $this->setPrimaryKey('{{ primaryKey|as_array|first }}');
@@ -58,7 +58,7 @@ class {{ name }}Table extends Table
 {% endif %}
 
 {%- for behavior, behaviorData in behaviors %}
-        $this->addBehavior('{{ behavior }}'{{ (behaviorData ? (", " ~ Bake.exportVar(behaviorData, 2, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw ~ '') : '')|raw }});
+        $this->addBehavior('{{ behavior }}'{{ (behaviorData ? (", " ~ Bake.exportArray(behaviorData, 2)|raw ~ '') : '')|raw }});
 {% endfor %}
 
 {%- if associations.belongsTo or associations.hasMany or associations.belongsToMany %}
@@ -73,7 +73,7 @@ class {{ name }}Table extends Table
                 {%- set assocData = assocData|merge({(key): val}) %}
             {%- endif %}
         {%- endfor %}
-        $this->{{ type }}('{{ assoc.alias }}', {{ Bake.exportVar(assocData, 2, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }});
+        $this->{{ type }}('{{ assoc.alias }}', {{ Bake.exportArray(assocData, 2)|raw }});
         {{- "\n" }}
     {%- endfor %}
 {% endfor %}

--- a/templates/bake/element/Controller/edit.twig
+++ b/templates/bake/element/Controller/edit.twig
@@ -26,7 +26,7 @@
     public function edit($id = null)
     {
         ${{ singularName }} = $this->{{ currentModelName }}->get($id, [
-            'contain' => {{ Bake.exportVar(belongsToMany, 0, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }},
+            'contain' => {{ Bake.exportArray(belongsToMany)|raw }},
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
             ${{ singularName }} = $this->{{ currentModelName }}->patchEntity(${{ singularName }}, $this->request->getData());

--- a/templates/bake/element/Controller/edit.twig
+++ b/templates/bake/element/Controller/edit.twig
@@ -26,7 +26,7 @@
     public function edit($id = null)
     {
         ${{ singularName }} = $this->{{ currentModelName }}->get($id, [
-            'contain' => [{{ Bake.stringifyList(belongsToMany, {'indent': false})|raw }}],
+            'contain' => {{ Bake.exportVar(belongsToMany, 0, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }},
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
             ${{ singularName }} = $this->{{ currentModelName }}->patchEntity(${{ singularName }}, $this->request->getData());

--- a/templates/bake/element/Controller/index.twig
+++ b/templates/bake/element/Controller/index.twig
@@ -23,7 +23,7 @@
 {% set belongsTo = Bake.aliasExtractor(modelObj, 'BelongsTo') %}
 {% if belongsTo %}
         $this->paginate = [
-            'contain' => [{{ Bake.stringifyList(belongsTo, {'indent': false})|raw }}],
+            'contain' => {{ Bake.exportVar(belongsTo, 0, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }},
         ];
 {% endif %}
         ${{ pluralName }} = $this->paginate($this->{{ currentModelName }});

--- a/templates/bake/element/Controller/index.twig
+++ b/templates/bake/element/Controller/index.twig
@@ -23,7 +23,7 @@
 {% set belongsTo = Bake.aliasExtractor(modelObj, 'BelongsTo') %}
 {% if belongsTo %}
         $this->paginate = [
-            'contain' => {{ Bake.exportVar(belongsTo, 0, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }},
+            'contain' => {{ Bake.exportArray(belongsTo)|raw }},
         ];
 {% endif %}
         ${{ pluralName }} = $this->paginate($this->{{ currentModelName }});

--- a/templates/bake/element/Controller/view.twig
+++ b/templates/bake/element/Controller/view.twig
@@ -27,7 +27,7 @@
     public function view($id = null)
     {
         ${{ singularName }} = $this->{{ currentModelName }}->get($id, [
-            'contain' => {{ Bake.exportVar(allAssociations, 0, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }},
+            'contain' => {{ Bake.exportArray(allAssociations)|raw }},
         ]);
 
         $this->set(compact('{{ singularName }}'));

--- a/templates/bake/element/Controller/view.twig
+++ b/templates/bake/element/Controller/view.twig
@@ -27,7 +27,7 @@
     public function view($id = null)
     {
         ${{ singularName }} = $this->{{ currentModelName }}->get($id, [
-            'contain' => [{{ Bake.stringifyList(allAssociations, {'indent': false})|raw }}],
+            'contain' => {{ Bake.exportVar(allAssociations, 0, constant('Brick\\VarExporter\\VarExporter::INLINE_NUMERIC_SCALAR_ARRAY'))|raw }},
         ]);
 
         $this->set(compact('{{ singularName }}'));

--- a/templates/bake/element/array_property.twig
+++ b/templates/bake/element/array_property.twig
@@ -3,4 +3,4 @@
      *
      * @var array
      */
-    public ${{ name }} = [{{ Bake.stringifyList(value, {'indent': false})|raw }}];
+    public ${{ name }} = {{ Bake.exportVar(value)|raw }};

--- a/templates/bake/element/array_property.twig
+++ b/templates/bake/element/array_property.twig
@@ -3,4 +3,4 @@
      *
      * @var array
      */
-    public ${{ name }} = {{ Bake.exportVar(value)|raw }};
+    public ${{ name }} = {{ Bake.exportArray(value)|raw }};

--- a/templates/bake/tests/test_case.twig
+++ b/templates/bake/tests/test_case.twig
@@ -76,7 +76,7 @@ class {{ className }}Test extends TestCase
      *
      * @var array
      */
-    protected $fixtures = [{{ Bake.stringifyList(fixtures|values)|raw }}];
+    protected $fixtures = {{ Bake.exportVar(fixtures|values, 1)|raw }};
 {% if construction or methods %}
 
 {% endif %}


### PR DESCRIPTION
The existing `BakeHelper::stringifyList()` is very simplistic
and only supports an array of strings, which requires crafting
config arrays in a specific way which is quite cumbersome.