### PR TITLE
Add model validation generation test.

### DIFF
--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -46,6 +46,7 @@ class ModelCommandTest extends TestCase
         'core.Comments',
         'core.Tags',
         'core.ArticlesTags',
+        'plugin.Bake.BakeArticles',
         'plugin.Bake.TodoTasks',
         'plugin.Bake.TodoItems',
         'plugin.Bake.TodoLabels',
@@ -1302,6 +1303,133 @@ class ModelCommandTest extends TestCase
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileNotExists(ROOT . 'tests/Fixture/TodoItemsFixture.php');
+    }
+
+    /**
+     * test baking validation
+     *
+     * @return void
+     */
+    public function testBakeTableValidation()
+    {
+        $this->generatedFiles = [
+            APP . 'Model/Table/TestBakeArticlesTable.php',
+        ];
+
+        $validation = [
+            'id' => [
+                'valid' => [
+                    'rule' => 'numeric',
+                    'args' => [],
+                ],
+                'allowEmpty' => [
+                    'rule' => 'allowEmptyString',
+                    'args' => ["'create'"],
+                ],
+            ],
+            'name' => [
+                'valid' => [
+                    'rule' => 'scalar',
+                    'args' => [],
+                ],
+                'maxLength' => [
+                    'rule' => 'maxLength',
+                    'args' => [
+                        100,
+                        "'Name must be shorter than 100 characters.'",
+                    ],
+                ],
+                'requirePresense' => [
+                    'rule' => 'requirePresence',
+                    'args' => ["'create'"],
+                ],
+                'allowEmpty' => [
+                    'rule' => 'allowEmptyString',
+                    'args' => ['null', 'false'],
+                ],
+            ],
+            'count' => [
+                'valid' => [
+                    'rule' => 'nonNegativeInteger',
+                    'args' => [],
+                ],
+                'requirePresense' => [
+                    'rule' => 'requirePresence',
+                    'args' => ["'create'"],
+                ],
+                'allowEmpty' => [
+                    'rule' => 'allowEmptyString',
+                    'args' => ['null', 'false'],
+                ],
+            ],
+            'price' => [
+                'valid' => [
+                    'rule' => 'greaterThanOrEqual',
+                    'args' => [
+                        0,
+                    ],
+                ],
+                'requirePresense' => [
+                    'rule' => 'requirePresence',
+                    'args' => ["'create'"],
+                ],
+                'allowEmpty' => [
+                    'rule' => 'allowEmptyString',
+                    'args' => ['null', 'false'],
+                ],
+            ],
+            'email' => [
+                'valid' => [
+                    'rule' => 'email',
+                    'args' => [],
+                ],
+                'unique' => [
+                    'rule' => 'validateUnique',
+                    'provider' => 'table',
+                ],
+                'allowEmpty' => [
+                    'rule' => 'allowEmptyString',
+                    'args' => [],
+                ],
+            ],
+            'image' => [
+                'uploadedFile' => [
+                    'rule' => 'uploadedFile',
+                    'args' => [
+                        [
+                            'optional' => 'true',
+                            'types' => ["'image/jpeg'"],
+                        ],
+                    ],
+                ],
+                'allowEmpty' => [
+                    'rule' => 'allowEmptyFile',
+                    'args' => [],
+                ],
+            ],
+        ];
+
+        $command = new ModelCommand();
+        $command->connection = 'test';
+
+        $name = 'TestBakeArticles';
+        $args = new Arguments([$name], ['table' => 'bake_articles', 'force' => true], []);
+        $io = new ConsoleIo($this->_out, $this->_err, $this->_in);
+
+        $table = $command->getTable($name, $args);
+        $tableObject = $command->getTableObject($name, $table);
+        $data = $command->getTableContext($tableObject, $table, $name, $args, $io);
+        $data['validation'] = $validation;
+        $data['associations'] = [
+            'belongsTo' => [],
+            'hasMany' => [],
+            'belongsToMany' => [],
+        ];
+        $data['rulesChecker'] = [];
+        $command->bakeTable($tableObject, $data, $args, $io);
+
+        $result = file_get_contents($this->generatedFiles[0]);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }
 
     /**

--- a/tests/comparisons/Model/testBakeTableValidation.php
+++ b/tests/comparisons/Model/testBakeTableValidation.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Model\Table;
+namespace Bake\Test\App\Model\Table;
 
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -9,23 +9,25 @@ use Cake\ORM\Table;
 use Cake\Validation\Validator;
 
 /**
- * BakeArticles Model
+ * TestBakeArticles Model
  *
- * @method \App\Model\Entity\BakeArticle newEmptyEntity()
- * @method \App\Model\Entity\BakeArticle newEntity(array $data, array $options = [])
- * @method \App\Model\Entity\BakeArticle[] newEntities(array $data, array $options = [])
- * @method \App\Model\Entity\BakeArticle get($primaryKey, $options = [])
- * @method \App\Model\Entity\BakeArticle findOrCreate($search, ?callable $callback = null, $options = [])
- * @method \App\Model\Entity\BakeArticle patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method \App\Model\Entity\BakeArticle[] patchEntities(iterable $entities, array $data, array $options = [])
- * @method \App\Model\Entity\BakeArticle|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
- * @method \App\Model\Entity\BakeArticle saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
- * @method \App\Model\Entity\BakeArticle[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
- * @method \App\Model\Entity\BakeArticle[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
- * @method \App\Model\Entity\BakeArticle[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
- * @method \App\Model\Entity\BakeArticle[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle newEmptyEntity()
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle newEntity(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[] newEntities(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle get($primaryKey, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ *
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */
-class BakeArticlesTable extends Table
+class TestBakeArticlesTable extends Table
 {
     /**
      * Initialize method
@@ -37,7 +39,11 @@ class BakeArticlesTable extends Table
     {
         parent::initialize($config);
 
+        $this->setTable('bake_articles');
+        $this->setDisplayField('title');
         $this->setPrimaryKey('id');
+
+        $this->addBehavior('Timestamp');
     }
 
     /**
@@ -56,17 +62,17 @@ class BakeArticlesTable extends Table
             ->scalar('name')
             ->maxLength('name', 100, 'Name must be shorter than 100 characters.')
             ->requirePresence('name', 'create')
-            ->allowEmptyString('name', false);
+            ->allowEmptyString('name', null, false);
 
         $validator
             ->nonNegativeInteger('count')
             ->requirePresence('count', 'create')
-            ->allowEmptyString('count', false);
+            ->allowEmptyString('count', null, false);
 
         $validator
             ->greaterThanOrEqual('price', 0)
             ->requirePresence('price', 'create')
-            ->allowEmptyString('price', false);
+            ->allowEmptyString('price', null, false);
 
         $validator
             ->email('email')
@@ -74,7 +80,6 @@ class BakeArticlesTable extends Table
             ->allowEmptyString('email');
 
         $validator
-            ->uploadError('image', true)
             ->uploadedFile('image', ['optional' => true, 'types' => ['image/jpeg']])
             ->allowEmptyFile('image');
 


### PR DESCRIPTION
This test was lost when bake tasks were converted to commands for CakePHP 4.x.
Without the `ModelCommandTest::testBakeTableValidation()` test the comparison file
`testBakeTableValidation.php` was unused.