### PR TITLE
Add `@uses` annotation to method level tests.

### DIFF
--- a/templates/bake/tests/test_case.twig
+++ b/templates/bake/tests/test_case.twig
@@ -130,6 +130,7 @@ class {{ className }}Test extends TestCase
      * Test {{ method }} method
      *
      * @return void
+     * @uses \{{ fullClassName }}::{{ method }}()
      */
     public function test{{ method|camelize }}(): void
     {

--- a/tests/TestCase/Command/AllCommandTest.php
+++ b/tests/TestCase/Command/AllCommandTest.php
@@ -188,7 +188,7 @@ class AllCommandTest extends TestCase
     }
 
     /**
-     * Test docblock \@\uses generated for test methods
+     * Test docblock @uses generated for test methods
      *
      * @return void
      */

--- a/tests/TestCase/Command/AllCommandTest.php
+++ b/tests/TestCase/Command/AllCommandTest.php
@@ -186,4 +186,46 @@ class AllCommandTest extends TestCase
         );
         $this->assertOutputContains('Bake All complete');
     }
+
+    /**
+     * Test docblock \@\uses generated for test methods
+     *
+     * @return void
+     */
+    public function testGenerateUsesDocBlockController()
+    {
+        $path = APP;
+        $testsPath = ROOT . 'tests' . DS;
+        $templatesPath = ROOT . 'templates' . DS;
+
+        $this->generatedFiles = [
+            $templatesPath . 'Products/add.php',
+            $templatesPath . 'Products/edit.php',
+            $templatesPath . 'Products/index.php',
+            $templatesPath . 'Products/view.php',
+            $path . 'Controller/ProductsController.php',
+            $path . 'Model/Table/ProductsTable.php',
+            $path . 'Model/Entity/Product.php',
+            $testsPath . 'Fixture/ProductsFixture.php',
+            $testsPath . 'TestCase/Model/Table/ProductsTableTest.php',
+            $testsPath . 'TestCase/Controller/ProductsControllerTest.php',
+        ];
+        $this->exec('bake all --connection test Products', ['y', 'y', 'y', 'y']);
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFileContains(
+            '@uses \Bake\Test\App\Controller\ProductsController::index()',
+            $testsPath . 'TestCase/Controller/ProductsControllerTest.php'
+        );
+        $this->assertFileContains(
+            '@uses \Bake\Test\App\Model\Table\ProductsTable::validationDefault()',
+            $testsPath . 'TestCase/Model/Table/ProductsTableTest.php'
+        );
+        $this->assertOutputContains('Bake All complete');
+        foreach ($this->generatedFiles as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
 }

--- a/tests/TestCase/Command/CommandCommandTest.php
+++ b/tests/TestCase/Command/CommandCommandTest.php
@@ -98,7 +98,7 @@ class CommandCommandTest extends TestCase
     }
 
     /**
-     * Test docblock \@\uses generated for test methods
+     * Test docblock @uses generated for test methods
      *
      * @return void
      */
@@ -120,7 +120,7 @@ class CommandCommandTest extends TestCase
     }
 
     /**
-     * Test docblock \@\uses generated for test methods
+     * Test docblock @uses generated for test methods
      * Plugin command
      *
      * @return void

--- a/tests/TestCase/Command/CommandCommandTest.php
+++ b/tests/TestCase/Command/CommandCommandTest.php
@@ -96,4 +96,49 @@ class CommandCommandTest extends TestCase
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
+
+    /**
+     * Test docblock \@\uses generated for test methods
+     *
+     * @return void
+     */
+    public function testGenerateUsesDocBlock()
+    {
+        $testsPath = ROOT . 'tests' . DS;
+
+        $this->exec('bake command Docblock', ['y', 'y']);
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFileContains(
+            '@uses \Bake\Test\App\Command\DocblockCommand::buildOptionParser()',
+            $testsPath . 'TestCase/Command/DocblockCommandTest.php'
+        );
+        $this->assertFileContains(
+            '@uses \Bake\Test\App\Command\DocblockCommand::execute()',
+            $testsPath . 'TestCase/Command/DocblockCommandTest.php'
+        );
+    }
+
+    /**
+     * Test docblock \@\uses generated for test methods
+     * Plugin command
+     *
+     * @return void
+     */
+    public function testGenerateUsesDocBlockPlugin()
+    {
+        $testsPath = ROOT . 'Plugin' . DS . 'BakeTest' . DS . 'tests' . DS;
+
+        $this->exec('bake command Docblock --plugin BakeTest', ['y', 'y']);
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFileContains(
+            '@uses \BakeTest\Command\DocblockCommand::buildOptionParser()',
+            $testsPath . 'TestCase/Command/DocblockCommandTest.php'
+        );
+        $this->assertFileContains(
+            '@uses \BakeTest\Command\DocblockCommand::execute()',
+            $testsPath . 'TestCase/Command/DocblockCommandTest.php'
+        );
+    }
 }

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -813,7 +813,7 @@ class TestCommandTest extends TestCase
     }
 
     /**
-     * Test docblock \@\uses generated for test methods
+     * Test docblock @uses generated for test methods
      *
      * @return void
      */
@@ -831,7 +831,7 @@ class TestCommandTest extends TestCase
     }
 
     /**
-     * Test docblock \@\uses generated for test methods
+     * Test docblock @uses generated for test methods
      *
      * @return void
      */

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -811,4 +811,44 @@ class TestCommandTest extends TestCase
         $command = new TestCommand();
         $this->assertEquals($expected, $command->mapType($original));
     }
+
+    /**
+     * Test docblock \@\uses generated for test methods
+     *
+     * @return void
+     */
+    public function testGenerateUsesDocBlockController()
+    {
+        $testsPath = ROOT . 'tests' . DS;
+
+        $this->exec('bake test --connection test controller Products', ['y']);
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFileContains(
+            '@uses \Bake\Test\App\Controller\ProductsController::index()',
+            $testsPath . 'TestCase/Controller/ProductsControllerTest.php'
+        );
+    }
+
+    /**
+     * Test docblock \@\uses generated for test methods
+     *
+     * @return void
+     */
+    public function testGenerateUsesDocBlockTable()
+    {
+        $testsPath = ROOT . 'tests' . DS;
+
+        $this->generatedFiles = [
+            $testsPath . 'TestCase/Model/Table/ProductsTableTest.php',
+            $testsPath . 'TestCase/Controller/ProductsControllerTest.php',
+        ];
+        $this->exec('bake test --connection test table Products', ['y']);
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFileContains(
+            '@uses \Bake\Test\App\Model\Table\ProductsTable::validationDefault()',
+            $testsPath . 'TestCase/Model/Table/ProductsTableTest.php'
+        );
+    }
 }

--- a/tests/comparisons/Test/testBakeComponentTest.php
+++ b/tests/comparisons/Test/testBakeComponentTest.php
@@ -47,6 +47,7 @@ class AppleComponentTest extends TestCase
      * Test startup method
      *
      * @return void
+     * @uses \Bake\Test\App\Controller\Component\AppleComponent::startup()
      */
     public function testStartup(): void
     {

--- a/tests/comparisons/Test/testBakeControllerTest.php
+++ b/tests/comparisons/Test/testBakeControllerTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Test\TestCase\Controller;
 
+use Bake\Test\App\Controller\PostsController;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 

--- a/tests/comparisons/Test/testBakeControllerTest.php
+++ b/tests/comparisons/Test/testBakeControllerTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Test\TestCase\Controller;
 
-use Bake\Test\App\Controller\PostsController;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -29,6 +28,7 @@ class PostsControllerTest extends TestCase
      * Test index method
      *
      * @return void
+     * @uses \Bake\Test\App\Controller\PostsController::index()
      */
     public function testIndex(): void
     {

--- a/tests/comparisons/Test/testBakeControllerWithoutModelTest.php
+++ b/tests/comparisons/Test/testBakeControllerWithoutModelTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Test\TestCase\Controller;
 
-use Bake\Test\App\Controller\NoModelController;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -20,6 +19,7 @@ class NoModelControllerTest extends TestCase
      * Test index method
      *
      * @return void
+     * @uses \Bake\Test\App\Controller\NoModelController::index()
      */
     public function testIndex(): void
     {

--- a/tests/comparisons/Test/testBakeControllerWithoutModelTest.php
+++ b/tests/comparisons/Test/testBakeControllerWithoutModelTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Test\TestCase\Controller;
 
+use Bake\Test\App\Controller\NoModelController;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 

--- a/tests/comparisons/Test/testBakeModelTest.php
+++ b/tests/comparisons/Test/testBakeModelTest.php
@@ -58,6 +58,7 @@ class ArticlesTableTest extends TestCase
      * Test findPublished method
      *
      * @return void
+     * @uses \Bake\Test\App\Model\Table\ArticlesTable::findPublished()
      */
     public function testFindPublished(): void
     {
@@ -68,6 +69,7 @@ class ArticlesTableTest extends TestCase
      * Test doSomething method
      *
      * @return void
+     * @uses \Bake\Test\App\Model\Table\ArticlesTable::doSomething()
      */
     public function testDoSomething(): void
     {
@@ -78,6 +80,7 @@ class ArticlesTableTest extends TestCase
      * Test doSomethingElse method
      *
      * @return void
+     * @uses \Bake\Test\App\Model\Table\ArticlesTable::doSomethingElse()
      */
     public function testDoSomethingElse(): void
     {

--- a/tests/comparisons/Test/testBakePrefixControllerTest.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Test\TestCase\Controller\Admin;
 
-use Bake\Test\App\Controller\Admin\PostsController;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -29,6 +28,7 @@ class PostsControllerTest extends TestCase
      * Test index method
      *
      * @return void
+     * @uses \Bake\Test\App\Controller\Admin\PostsController::index()
      */
     public function testIndex(): void
     {
@@ -39,6 +39,7 @@ class PostsControllerTest extends TestCase
      * Test add method
      *
      * @return void
+     * @uses \Bake\Test\App\Controller\Admin\PostsController::add()
      */
     public function testAdd(): void
     {

--- a/tests/comparisons/Test/testBakePrefixControllerTest.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Test\TestCase\Controller\Admin;
 
+use Bake\Test\App\Controller\Admin\PostsController;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 

--- a/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Test\TestCase\Controller\Admin;
 
-use Bake\Test\App\Controller\Admin\PostsController;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -29,6 +28,7 @@ class PostsControllerTest extends TestCase
      * Test index method
      *
      * @return void
+     * @uses \Bake\Test\App\Controller\Admin\PostsController::index()
      */
     public function testIndex(): void
     {
@@ -39,6 +39,7 @@ class PostsControllerTest extends TestCase
      * Test add method
      *
      * @return void
+     * @uses \Bake\Test\App\Controller\Admin\PostsController::add()
      */
     public function testAdd(): void
     {

--- a/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Test\TestCase\Controller\Admin;
 
+use Bake\Test\App\Controller\Admin\PostsController;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 


### PR DESCRIPTION
This PR adds `@uses` annotations to test methods to indicate which method is being tested, and makes navigation to the code being tested easier. This is especially useful for ORM `find` methods, Command `execute` method and controller actions.

Example of the `index` action on `PostsController`:
```php
/**
 * Test index method
 *
 * @return void
 * @uses \Bake\Test\App\Controller\PostsController::index()
 */
public function testIndex(): void
{
    $this->markTestIncomplete('Not implemented yet.');
}
```

Solves #755