### PR TITLE
Add association variables to add and edit templates

### DIFF
--- a/templates/bake/Template/add.twig
+++ b/templates/bake/Template/add.twig
@@ -17,6 +17,19 @@
 /**
  * @var \{{ namespace }}\View\AppView $this
  * @var \{{ entityClass }} ${{ singularVar }}
+        {{- "\n" }}
+{%- if associations.BelongsTo is defined %}
+    {%- for assocName, assocData in associations.BelongsTo %}
+ * @var array ${{ assocData.variable }}
+        {{- "\n" }}
+    {%- endfor %}
+{% endif %}
+{%- if associations.BelongsToMany is defined %}
+    {%- for assocName, assocData in associations.BelongsToMany %}
+ * @var array ${{ assocData.variable }}
+        {{- "\n" }}
+    {%- endfor %}
+{% endif %}
  */
 ?>
 {{ element('Bake.form') }}

--- a/templates/bake/Template/edit.twig
+++ b/templates/bake/Template/edit.twig
@@ -17,6 +17,19 @@
 /**
  * @var \{{ namespace }}\View\AppView $this
  * @var \{{ entityClass }} ${{ singularVar }}
+        {{- "\n" }}
+{%- if associations.BelongsTo is defined %}
+    {%- for assocName, assocData in associations.BelongsTo %}
+ * @var array ${{ assocData.variable }}
+        {{- "\n" }}
+    {%- endfor %}
+{% endif %}
+{%- if associations.BelongsToMany is defined %}
+    {%- for assocName, assocData in associations.BelongsToMany %}
+ * @var array ${{ assocData.variable }}
+        {{- "\n" }}
+    {%- endfor %}
+{% endif %}
  */
 ?>
 {{ element('Bake.form') }}

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -464,6 +464,23 @@ class TemplateCommandTest extends TestCase
     }
 
     /**
+     * test baking an edit file with a BelongsToMany association
+     *
+     * @return void
+     */
+    public function testBakeEditWithBelongsToManyAssociation()
+    {
+        $this->generatedFile = ROOT . 'templates/Articles/edit.php';
+        $this->exec('bake template articles edit');
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+
+        $result = file_get_contents($this->generatedFile);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    /**
      * test baking an index
      *
      * @return void

--- a/tests/comparisons/Template/testBakeEdit.php
+++ b/tests/comparisons/Template/testBakeEdit.php
@@ -2,6 +2,7 @@
 /**
  * @var \Bake\Test\App\View\AppView $this
  * @var \Cake\Datasource\EntityInterface $author
+ * @var array $roles
  */
 ?>
 <div class="row">

--- a/tests/comparisons/Template/testBakeEditWithBelongsToManyAssociation.php
+++ b/tests/comparisons/Template/testBakeEditWithBelongsToManyAssociation.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @var \Bake\Test\App\View\AppView $this
+ * @var \Cake\Datasource\EntityInterface $article
+ * @var array $authors
+ * @var array $tags
+ */
+?>
+<div class="row">
+    <aside class="column">
+        <div class="side-nav">
+            <h4 class="heading"><?= __('Actions') ?></h4>
+            <?= $this->Form->postLink(
+                __('Delete'),
+                ['action' => 'delete', $article->id],
+                ['confirm' => __('Are you sure you want to delete # {0}?', $article->id), 'class' => 'side-nav-item']
+            ) ?>
+            <?= $this->Html->link(__('List Articles'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
+        </div>
+    </aside>
+    <div class="column-responsive column-80">
+        <div class="articles form content">
+            <?= $this->Form->create($article) ?>
+            <fieldset>
+                <legend><?= __('Edit Article') ?></legend>
+                <?php
+                    echo $this->Form->control('author_id', ['options' => $authors, 'empty' => true]);
+                    echo $this->Form->control('title');
+                    echo $this->Form->control('body');
+                    echo $this->Form->control('published');
+                    echo $this->Form->control('tags._ids', ['options' => $tags]);
+                ?>
+            </fieldset>
+            <?= $this->Form->button(__('Submit')) ?>
+            <?= $this->Form->end() ?>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Adds proper docblock variables for associations in `add` and `edit`templates.

See #759 