### PR TITLE
Add more specific docblock typehinting for `add` and `edit` templates

### DIFF
--- a/templates/bake/Template/add.twig
+++ b/templates/bake/Template/add.twig
@@ -20,13 +20,13 @@
         {{- "\n" }}
 {%- if associations.BelongsTo is defined %}
     {%- for assocName, assocData in associations.BelongsTo %}
- * @var array ${{ assocData.variable }}
+ * @var \Cake\Collection\CollectionInterface|string[] ${{ assocData.variable }}
         {{- "\n" }}
     {%- endfor %}
 {% endif %}
 {%- if associations.BelongsToMany is defined %}
     {%- for assocName, assocData in associations.BelongsToMany %}
- * @var array ${{ assocData.variable }}
+ * @var \Cake\Collection\CollectionInterface|string[] ${{ assocData.variable }}
         {{- "\n" }}
     {%- endfor %}
 {% endif %}

--- a/templates/bake/Template/edit.twig
+++ b/templates/bake/Template/edit.twig
@@ -20,13 +20,13 @@
         {{- "\n" }}
 {%- if associations.BelongsTo is defined %}
     {%- for assocName, assocData in associations.BelongsTo %}
- * @var array ${{ assocData.variable }}
+ * @var string[]|\Cake\Collection\CollectionInterface ${{ assocData.variable }}
         {{- "\n" }}
     {%- endfor %}
 {% endif %}
 {%- if associations.BelongsToMany is defined %}
     {%- for assocName, assocData in associations.BelongsToMany %}
- * @var array ${{ assocData.variable }}
+ * @var string[]|\Cake\Collection\CollectionInterface ${{ assocData.variable }}
         {{- "\n" }}
     {%- endfor %}
 {% endif %}

--- a/tests/comparisons/Template/testBakeEdit.php
+++ b/tests/comparisons/Template/testBakeEdit.php
@@ -2,7 +2,7 @@
 /**
  * @var \Bake\Test\App\View\AppView $this
  * @var \Cake\Datasource\EntityInterface $author
- * @var array $roles
+ * @var string[]|\Cake\Collection\CollectionInterface $roles
  */
 ?>
 <div class="row">

--- a/tests/comparisons/Template/testBakeEditWithBelongsToManyAssociation.php
+++ b/tests/comparisons/Template/testBakeEditWithBelongsToManyAssociation.php
@@ -2,8 +2,8 @@
 /**
  * @var \Bake\Test\App\View\AppView $this
  * @var \Cake\Datasource\EntityInterface $article
- * @var array $authors
- * @var array $tags
+ * @var string[]|\Cake\Collection\CollectionInterface $authors
+ * @var string[]|\Cake\Collection\CollectionInterface $tags
  */
 ?>
 <div class="row">


### PR DESCRIPTION
See conversation #761.

This PR adds a more specific typehint to association variables in the `add` and `edit` templates.

While @othercorey suggested `\Cake\Collection\CollectionInterface|string[]`, I used `string[]|\Cake\Collection\CollectionInterface` as to match the order used in `index` template.