### PR TITLE
Add `CommandHelper` bake command

### DIFF
--- a/src/Command/CommandHelperCommand.php
+++ b/src/Command/CommandHelperCommand.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.6.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Command;
+
+/**
+ * CommandHelper code generator.
+ */
+class CommandHelperCommand extends SimpleBakeCommand
+{
+    /**
+     * Task name used in path generation.
+     *
+     * @var string
+     */
+    public $pathFragment = 'Command/Helper/';
+
+    /**
+     * @inheritDoc
+     */
+    public function name(): string
+    {
+        return 'command_helper';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function fileName(string $name): string
+    {
+        return $name . 'Helper.php';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function template(): string
+    {
+        return 'Bake.Command/helper';
+    }
+}

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -57,6 +57,7 @@ class TestCommand extends BakeCommand
         'Form' => 'Form',
         'Mailer' => 'Mailer',
         'Command' => 'Command',
+        'CommandHelper' => 'Command\Helper',
     ];
 
     /**
@@ -78,6 +79,7 @@ class TestCommand extends BakeCommand
         'Form' => 'Form',
         'Mailer' => 'Mailer',
         'Command' => 'Command',
+        'CommandHelper' => 'Helper',
     ];
 
     /**
@@ -576,7 +578,7 @@ class TestCommand extends BakeCommand
             $pre .= "        \$this->response = \$this->getMockBuilder('Cake\Http\Response')->getMock();";
             $construct = "new {$className}(\$this->request, \$this->response);";
         }
-        if ($type === 'ShellHelper') {
+        if ($type === 'ShellHelper' || $type === 'CommandHelper') {
             $pre = "\$this->stub = new ConsoleOutput();\n";
             $pre .= '        $this->io = new ConsoleIo($this->stub);';
             $construct = "new {$className}(\$this->io);";
@@ -626,6 +628,7 @@ class TestCommand extends BakeCommand
                 ];
                 break;
 
+            case 'CommandHelper':
             case 'ShellHelper':
                 $properties[] = [
                     'description' => 'ConsoleOutput stub',
@@ -667,7 +670,7 @@ class TestCommand extends BakeCommand
         if ($type === 'Helper') {
             $uses[] = 'Cake\View\View';
         }
-        if ($type === 'ShellHelper') {
+        if ($type === 'ShellHelper' || $type === 'CommandHelper') {
             $uses[] = 'Cake\TestSuite\Stub\ConsoleOutput';
             $uses[] = 'Cake\Console\ConsoleIo';
         }

--- a/templates/bake/Command/helper.twig
+++ b/templates/bake/Command/helper.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.6.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+#}
+<?php
+declare(strict_types=1);
+
+namespace {{ namespace }}\Command\Helper;
+
+use Cake\Console\Helper;
+
+/**
+ * {{ name }} command helper.
+ */
+class {{ name }}Helper extends Helper
+{
+    /**
+     * This method should output content using `$this->_io`.
+     *
+     * @param array $args The arguments for the helper.
+     * @return void
+     */
+    public function output(array $args): void
+    {
+    }
+}

--- a/tests/TestCase/Command/CommandHelperTest.php
+++ b/tests/TestCase/Command/CommandHelperTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.6.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\TestCase\Command;
+
+use Bake\Test\TestCase\TestCase;
+use Cake\Command\Command;
+use Cake\Core\Plugin;
+
+/**
+ * CommandHelperTest class
+ */
+class CommandHelperTest extends TestCase
+{
+    /**
+     * setup method
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->_compareBasePath = Plugin::path('Bake') . 'tests' . DS . 'comparisons' . DS . 'Command' . DS;
+        $this->setAppNamespace('Bake\Test\App');
+        $this->useCommandRunner();
+    }
+
+    /**
+     * Test the excute method.
+     *
+     * @return void
+     */
+    public function testBakeCommandHelper()
+    {
+        $this->generatedFiles = [
+            APP . 'Command/Helper/ErrorHelper.php',
+            ROOT . 'tests/TestCase/Command/Helper/ErrorHelperTest.php',
+        ];
+        $this->exec('bake command_helper Error');
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFilesExist($this->generatedFiles);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
+
+        $testsPath = dirname($this->_compareBasePath) . DS . 'Test' . DS;
+        $this->assertSameAsFile($testsPath . __FUNCTION__ . 'Test.php', file_get_contents($this->generatedFiles[1]));
+    }
+
+    /**
+     * Test the excute method with plugin
+     *
+     * @return void
+     */
+    public function testBakeCommandHelperPlugin()
+    {
+        $this->_loadTestPlugin('TestBake');
+        $path = Plugin::path('TestBake');
+
+        $this->generatedFiles = [
+            $path . 'src/Command/Helper/ErrorHelper.php',
+            $path . 'tests/TestCase/Command/Helper/ErrorHelperTest.php',
+        ];
+        $this->exec('bake command_helper TestBake.Error');
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFilesExist($this->generatedFiles);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
+    }
+}

--- a/tests/comparisons/Command/testBakeCommandHelper.php
+++ b/tests/comparisons/Command/testBakeCommandHelper.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Command\Helper;
+
+use Cake\Console\Helper;
+
+/**
+ * Error command helper.
+ */
+class ErrorHelper extends Helper
+{
+    /**
+     * This method should output content using `$this->_io`.
+     *
+     * @param array $args The arguments for the helper.
+     * @return void
+     */
+    public function output(array $args): void
+    {
+    }
+}

--- a/tests/comparisons/Command/testBakeCommandHelperPlugin.php
+++ b/tests/comparisons/Command/testBakeCommandHelperPlugin.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace TestBake\Command\Helper;
+
+use Cake\Console\Helper;
+
+/**
+ * Error command helper.
+ */
+class ErrorHelper extends Helper
+{
+    /**
+     * This method should output content using `$this->_io`.
+     *
+     * @param array $args The arguments for the helper.
+     * @return void
+     */
+    public function output(array $args): void
+    {
+    }
+}

--- a/tests/comparisons/Test/testBakeCommandHelperTest.php
+++ b/tests/comparisons/Test/testBakeCommandHelperTest.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Test\TestCase\Command\Helper;
+
+use Bake\Test\App\Command\Helper\ErrorHelper;
+use Cake\Console\ConsoleIo;
+use Cake\TestSuite\Stub\ConsoleOutput;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Bake\Test\App\Command\Helper\ErrorHelper Test Case
+ */
+class ErrorHelperTest extends TestCase
+{
+    /**
+     * ConsoleOutput stub
+     *
+     * @var \Cake\TestSuite\Stub\ConsoleOutput
+     */
+    protected $stub;
+
+    /**
+     * ConsoleIo mock
+     *
+     * @var \Cake\Console\ConsoleIo
+     */
+    protected $io;
+
+    /**
+     * Test subject
+     *
+     * @var \Bake\Test\App\Command\Helper\ErrorHelper
+     */
+    protected $Error;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->stub = new ConsoleOutput();
+        $this->io = new ConsoleIo($this->stub);
+        $this->Error = new ErrorHelper($this->io);
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        unset($this->Error);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test output method
+     *
+     * @return void
+     * @uses \Bake\Test\App\Command\Helper\ErrorHelper::output()
+     */
+    public function testOutput(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+}


### PR DESCRIPTION
This PR adds a command to bake `CommandHelper` classes.

See #633 