### PR TITLE
feat: Add stub for console() to bake templates

### DIFF
--- a/templates/bake/Plugin/src/Plugin.php.twig
+++ b/templates/bake/Plugin/src/Plugin.php.twig
@@ -22,6 +22,7 @@ use Cake\Core\BasePlugin;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\RouteBuilder;
+use Cake\Console\CommandCollection;
 
 /**
  * Plugin for {{ namespace }}
@@ -75,5 +76,20 @@ class Plugin extends BasePlugin
         // Add your middlewares here
 
         return $middlewareQueue;
+    }
+
+    /**
+     * Add commands for the plugin.
+     *
+     * @param \Cake\Console\CommandCollection $commands The command collection to update.
+     * @return \Cake\Console\CommandCollection
+     */
+    public function console(CommandCollection $commands) : CommandCollection
+    {
+        // Add your commands here
+
+        $commands = parent::console($commands);
+
+        return $commands;
     }
 }

--- a/tests/comparisons/Plugin/Company/Example/src/Plugin.php
+++ b/tests/comparisons/Plugin/Company/Example/src/Plugin.php
@@ -7,6 +7,7 @@ use Cake\Core\BasePlugin;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\RouteBuilder;
+use Cake\Console\CommandCollection;
 
 /**
  * Plugin for Company\Example
@@ -60,5 +61,20 @@ class Plugin extends BasePlugin
         // Add your middlewares here
 
         return $middlewareQueue;
+    }
+
+    /**
+     * Add commands for the plugin.
+     *
+     * @param \Cake\Console\CommandCollection $commands The command collection to update.
+     * @return \Cake\Console\CommandCollection
+     */
+    public function console(CommandCollection $commands) : CommandCollection
+    {
+        // Add your commands here
+
+        $commands = parent::console($commands);
+
+        return $commands;
     }
 }

--- a/tests/comparisons/Plugin/SimpleExample/src/Plugin.php
+++ b/tests/comparisons/Plugin/SimpleExample/src/Plugin.php
@@ -7,6 +7,7 @@ use Cake\Core\BasePlugin;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\RouteBuilder;
+use Cake\Console\CommandCollection;
 
 /**
  * Plugin for SimpleExample
@@ -60,5 +61,20 @@ class Plugin extends BasePlugin
         // Add your middlewares here
 
         return $middlewareQueue;
+    }
+
+    /**
+     * Add commands for the plugin.
+     *
+     * @param \Cake\Console\CommandCollection $commands The command collection to update.
+     * @return \Cake\Console\CommandCollection
+     */
+    public function console(CommandCollection $commands) : CommandCollection
+    {
+        // Add your commands here
+
+        $commands = parent::console($commands);
+
+        return $commands;
     }
 }


### PR DESCRIPTION
Using `console()` is described in [the Book](https://book.cakephp.org/4/en/plugins.html#commands) (although it's missing the `CommandCollection` return type hint there; I'll open a PR in that repo to update that).  Since this method wasn't added as part of `bake` or the examples here, it took awhile to track down how to use it in practice.  This PR adds it to all 3 locations.