### PR TITLE
Exclude hidden fields from index and view template generation

### DIFF
--- a/tests/Fixture/HiddenFieldsFixture.php
+++ b/tests/Fixture/HiddenFieldsFixture.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         2.6.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * UserFixture
+ */
+class HiddenFieldsFixture extends TestFixture
+{
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'password' => ['type' => 'string', 'null' => true, 'length' => 255],
+        'auth_token' => ['type' => 'string', 'null' => true, 'length' => 255],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO', 'auth_token' => '12345'],
+        ['password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO', 'auth_token' => '23456'],
+    ];
+}

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -49,6 +49,7 @@ class TemplateCommandTest extends TestCase
         'plugin.Bake.BakeTemplateRoles',
         'plugin.Bake.BakeTemplateProfiles',
         'plugin.Bake.CategoryThreads',
+        'plugin.Bake.HiddenFields',
     ];
 
     /**
@@ -299,6 +300,7 @@ class TemplateCommandTest extends TestCase
             'singularHumanName' => 'Test Template Model',
             'pluralHumanName' => 'Test Template Models',
             'fields' => ['id', 'name', 'body'],
+            'hidden' => ['token', 'password', 'passwd'],
             'associations' => [],
             'keyFields' => [],
             'namespace' => $namespace,
@@ -329,6 +331,7 @@ class TemplateCommandTest extends TestCase
             'singularHumanName' => 'Template Task Comment',
             'pluralHumanName' => 'Template Task Comments',
             'fields' => ['id', 'name', 'body'],
+            'hidden' => ['token', 'password', 'passwd'],
             'associations' => [
                 'belongsTo' => [
                     'Authors' => [
@@ -373,6 +376,7 @@ class TemplateCommandTest extends TestCase
             'singularHumanName' => 'Test Template Model',
             'pluralHumanName' => 'Test Template Models',
             'fields' => ['id', 'name', 'body'],
+            'hidden' => ['token', 'password', 'passwd'],
             'associations' => [],
             'keyFields' => [],
             'namespace' => $namespace,
@@ -414,6 +418,7 @@ class TemplateCommandTest extends TestCase
             'singularHumanName' => 'Test Template Model',
             'pluralHumanName' => 'Test Template Models',
             'fields' => ['id', 'title', 'body'],
+            'hidden' => ['token', 'password', 'passwd'],
             'keyFields' => [],
             'associations' => [],
             'namespace' => $namespace,
@@ -438,6 +443,23 @@ class TemplateCommandTest extends TestCase
     {
         $this->generatedFile = ROOT . 'templates/Authors/view.php';
         $this->exec('bake template authors view');
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+
+        $result = file_get_contents($this->generatedFile);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    /**
+     * Test generating view template with hidden fields
+     *
+     * @return void
+     */
+    public function testBakeViewHiddenFields()
+    {
+        $this->generatedFile = ROOT . 'templates/HiddenFields/view.php';
+        $this->exec('bake template HiddenFields view');
 
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
@@ -489,6 +511,23 @@ class TemplateCommandTest extends TestCase
     {
         $this->generatedFile = ROOT . 'templates/TemplateTaskComments/index.php';
         $this->exec('bake template template_task_comments index');
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+
+        $result = file_get_contents($this->generatedFile);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    /**
+     * Test generating index template with hidden fields
+     *
+     * @return void
+     */
+    public function testBakeIndexHiddenFields()
+    {
+        $this->generatedFile = ROOT . 'templates/HiddenFields/index.php';
+        $this->exec('bake template HiddenFields index');
 
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -175,7 +175,8 @@ class TestCommandTest extends TestCase
         $this->assertOutputContains('2. AuthorsTable');
         $this->assertOutputContains('3. BakeArticlesTable');
         $this->assertOutputContains('4. CategoryThreadsTable');
-        $this->assertOutputContains('5. TemplateTaskCommentsTable');
+        $this->assertOutputContains('5. HiddenFieldsTable');
+        $this->assertOutputContains('6. TemplateTaskCommentsTable');
         $this->assertOutputContains('Re-run your command as `cake bake Table <classname>`');
     }
 

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -42,8 +42,8 @@ abstract class TestCase extends BaseTestCase
     public function setUp(): void
     {
         parent::setUp();
-
         Router::reload();
+
         $this->loadPlugins(['Cake/TwigView']);
     }
 

--- a/tests/comparisons/Template/testBakeIndexHiddenFields.php
+++ b/tests/comparisons/Template/testBakeIndexHiddenFields.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @var \Bake\Test\App\View\AppView $this
+ * @var \Bake\Test\App\Model\Entity\HiddenField[]|\Cake\Collection\CollectionInterface $hiddenFields
+ */
+?>
+<div class="hiddenFields index content">
+    <?= $this->Html->link(__('New Hidden Field'), ['action' => 'add'], ['class' => 'button float-right']) ?>
+    <h3><?= __('Hidden Fields') ?></h3>
+    <div class="table-responsive">
+        <table>
+            <thead>
+                <tr>
+                    <th><?= $this->Paginator->sort('id') ?></th>
+                    <th class="actions"><?= __('Actions') ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($hiddenFields as $hiddenField): ?>
+                <tr>
+                    <td><?= $this->Number->format($hiddenField->id) ?></td>
+                    <td class="actions">
+                        <?= $this->Html->link(__('View'), ['action' => 'view', $hiddenField->id]) ?>
+                        <?= $this->Html->link(__('Edit'), ['action' => 'edit', $hiddenField->id]) ?>
+                        <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', $hiddenField->id], ['confirm' => __('Are you sure you want to delete # {0}?', $hiddenField->id)]) ?>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <div class="paginator">
+        <ul class="pagination">
+            <?= $this->Paginator->first('<< ' . __('first')) ?>
+            <?= $this->Paginator->prev('< ' . __('previous')) ?>
+            <?= $this->Paginator->numbers() ?>
+            <?= $this->Paginator->next(__('next') . ' >') ?>
+            <?= $this->Paginator->last(__('last') . ' >>') ?>
+        </ul>
+        <p><?= $this->Paginator->counter(__('Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?></p>
+    </div>
+</div>

--- a/tests/comparisons/Template/testBakeViewHiddenFields.php
+++ b/tests/comparisons/Template/testBakeViewHiddenFields.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @var \Bake\Test\App\View\AppView $this
+ * @var \Bake\Test\App\Model\Entity\HiddenField $hiddenField
+ */
+?>
+<div class="row">
+    <aside class="column">
+        <div class="side-nav">
+            <h4 class="heading"><?= __('Actions') ?></h4>
+            <?= $this->Html->link(__('Edit Hidden Field'), ['action' => 'edit', $hiddenField->id], ['class' => 'side-nav-item']) ?>
+            <?= $this->Form->postLink(__('Delete Hidden Field'), ['action' => 'delete', $hiddenField->id], ['confirm' => __('Are you sure you want to delete # {0}?', $hiddenField->id), 'class' => 'side-nav-item']) ?>
+            <?= $this->Html->link(__('List Hidden Fields'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
+            <?= $this->Html->link(__('New Hidden Field'), ['action' => 'add'], ['class' => 'side-nav-item']) ?>
+        </div>
+    </aside>
+    <div class="column-responsive column-80">
+        <div class="hiddenFields view content">
+            <h3><?= h($hiddenField->id) ?></h3>
+            <table>
+                <tr>
+                    <th><?= __('Id') ?></th>
+                    <td><?= $this->Number->format($hiddenField->id) ?></td>
+                </tr>
+            </table>
+        </div>
+    </div>
+</div>

--- a/tests/test_app/App/Model/Entity/HiddenField.php
+++ b/tests/test_app/App/Model/Entity/HiddenField.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.6.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+class HiddenField extends Entity
+{
+    protected $_hidden = ['password', 'auth_token'];
+}

--- a/tests/test_app/App/Model/Table/HiddenFieldsTable.php
+++ b/tests/test_app/App/Model/Table/HiddenFieldsTable.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.6.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\App\Model\Table;
+
+use Cake\ORM\Table;
+
+class HiddenFieldsTable extends Table
+{
+    public function initialize(array $config): void
+    {
+        $this->setTable('hidden_fields');
+    }
+}


### PR DESCRIPTION
Closes https://github.com/cakephp/bake/issues/717

Defaults to the same hidden fields as ModelCommand if the entity class is empty.