### PR TITLE
Add decimal to fixture records test

### DIFF
--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -21,6 +21,7 @@ use Bake\Utility\TemplateRenderer;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use Cake\Console\Exception\StopException;
 use Cake\Core\Configure;
 use Cake\Database\Exception;
 use Cake\Database\Schema\TableSchemaInterface;
@@ -166,6 +167,8 @@ class FixtureCommand extends BakeCommand
             $data = $this->readSchema($model, $useTable);
         }
 
+        $this->validateNames($data);
+
         if ($modelImport === null) {
             $schema = $this->_generateSchema($data);
         }
@@ -204,6 +207,25 @@ class FixtureCommand extends BakeCommand
         }
 
         return $model->getSchema();
+    }
+
+    /**
+     * Validates table and column names are supported.
+     *
+     * @param \Cake\Database\Schema\TableSchemaInterface $schema Table schema
+     * @return void
+     * @throws \Cake\Console\Exception\StopException When table or column names are not supported
+     */
+    public function validateNames(TableSchemaInterface $schema): void
+    {
+        foreach ($schema->columns() as $column) {
+            if (!is_string($column) || !ctype_alpha($column[0])) {
+                throw new StopException(sprintf(
+                    'Unable to bake table with integer column names or names that start with digits. Found `%s`.',
+                    (string)$column
+                ));
+            }
+        }
     }
 
     /**

--- a/tests/Fixture/DatatypesFixture.php
+++ b/tests/Fixture/DatatypesFixture.php
@@ -35,6 +35,7 @@ class DatatypesFixture extends TestFixture
         'tiny_int' => ['type' => 'tinyinteger'],
         'bool' => ['type' => 'boolean', 'null' => false, 'default' => false],
         'uuid' => ['type' => 'uuid'],
+        'timestamp_field' => ['type' => 'timestamp'],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
@@ -44,6 +45,6 @@ class DatatypesFixture extends TestFixture
      * @var array
      */
     public $records = [
-        ['float_field' => 42.23, 'huge_int' => '1234567891234567891', 'small_int' => '1234', 'tiny_int' => '12', 'bool' => 0],
+        ['decimal_field' => '30.123', 'float_field' => 42.23, 'huge_int' => '1234567891234567891', 'small_int' => '1234', 'tiny_int' => '12', 'bool' => 0, 'timestamp_field' => '2007-03-17 01:16:23'],
     ];
 }

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -21,6 +21,7 @@ use Bake\Test\TestCase\TestCase;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
+use Cake\Console\Exception\StopException;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Database\Driver\Mysql;
@@ -157,6 +158,22 @@ class ModelCommandTest extends TestCase
         $result = $command->getTableObject('Authors', 'todo_items');
         $this->assertSame('my_prefix_todo_items', $result->getTable());
         $this->assertInstanceOf('BakeTest\Model\Table\AuthorsTable', $result);
+    }
+
+    /**
+     * Tests validating supported table and column names.
+     */
+    public function testValidateNames(): void
+    {
+        $command = new ModelCommand();
+        $command->connection = 'test';
+
+        $schema = $command->getTableObject('TodoItems', 'todo_items')->getSchema();
+        $schema->addColumn('0invalid', ['type' => 'string', 'length' => null]);
+
+        $this->expectException(StopException::class);
+        $this->expectExceptionMessage('Unable to bake table with integer column names or names that start with digits. Found `0invalid`');
+        $command->validateNames($schema);
     }
 
     /**

--- a/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
+++ b/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
@@ -6,16 +6,16 @@ namespace Bake\Test\App\Test\Fixture;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
- * UsersFixture
+ * DatatypesFixture
  */
-class UsersFixture extends TestFixture
+class DatatypesFixture extends TestFixture
 {
     /**
      * Import
      *
      * @var array
      */
-    public $import = ['table' => 'users', 'connection' => 'test'];
+    public $import = ['table' => 'datatypes', 'connection' => 'test'];
 
     /**
      * Init method
@@ -27,17 +27,14 @@ class UsersFixture extends TestFixture
         $this->records = [
             [
                 'id' => 1,
-                'username' => 'mariano',
-                'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
-                'created' => '2007-03-17 01:16:23',
-                'updated' => '2007-03-17 01:18:31',
-            ],
-            [
-                'id' => 2,
-                'username' => 'nate',
-                'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
-                'created' => '2008-03-17 01:18:23',
-                'updated' => '2008-03-17 01:20:31',
+                'decimal_field' => '30.123',
+                'float_field' => 42.23,
+                'huge_int' => 1234567891234567891,
+                'small_int' => 1234,
+                'tiny_int' => 12,
+                'bool' => false,
+                'uuid' => null,
+                'timestamp_field' => '2007-03-17 01:16:23',
             ],
         ];
         parent::init();


### PR DESCRIPTION
Closes https://github.com/cakephp/bake/issues/569

Decimal types are returned as strings in CakePHP 4. The fix for CakePHP 3 is overriding the decimcal type.