### PR TITLE
Add decimal data type to record import test

### DIFF
--- a/tests/Fixture/DatatypesFixture.php
+++ b/tests/Fixture/DatatypesFixture.php
@@ -35,6 +35,7 @@ class DatatypesFixture extends TestFixture
         'tiny_int' => ['type' => 'tinyinteger'],
         'bool' => ['type' => 'boolean', 'null' => false, 'default' => false],
         'uuid' => ['type' => 'uuid'],
+        'timestamp_field' => ['type' => 'timestamp'],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
@@ -44,6 +45,6 @@ class DatatypesFixture extends TestFixture
      * @var array
      */
     public $records = [
-        ['float_field' => 42.23, 'huge_int' => '1234567891234567891', 'small_int' => '1234', 'tiny_int' => '12', 'bool' => 0],
+        ['decimal_field' => '30.123', 'float_field' => 42.23, 'huge_int' => '1234567891234567891', 'small_int' => '1234', 'tiny_int' => '12', 'bool' => 0, 'timestamp_field' => '2007-03-17 01:16:23'],
     ];
 }

--- a/tests/TestCase/Command/FixtureCommandTest.php
+++ b/tests/TestCase/Command/FixtureCommandTest.php
@@ -80,9 +80,9 @@ class FixtureCommandTest extends TestCase
      */
     public function testImportRecordsFromDatabase()
     {
-        $this->generatedFile = ROOT . 'tests/Fixture/UsersFixture.php';
-        $this->exec('bake fixture --connection test --schema --records --count 2 Users');
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->generatedFile = ROOT . 'tests/Fixture/DatatypesFixture.php';
+        $this->exec('bake fixture --connection test --schema --records --count 2 Datatypes');
+        $this->assertExitSuccess();
 
         $this->assertSameAsFile(
             __FUNCTION__ . '.php',

--- a/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
+++ b/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
@@ -6,16 +6,16 @@ namespace Bake\Test\App\Test\Fixture;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
- * UsersFixture
+ * DatatypesFixture
  */
-class UsersFixture extends TestFixture
+class DatatypesFixture extends TestFixture
 {
     /**
      * Import
      *
      * @var array
      */
-    public $import = ['table' => 'users', 'connection' => 'test'];
+    public $import = ['table' => 'datatypes', 'connection' => 'test'];
 
     /**
      * Init method
@@ -27,17 +27,14 @@ class UsersFixture extends TestFixture
         $this->records = [
             [
                 'id' => 1,
-                'username' => 'mariano',
-                'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
-                'created' => '2007-03-17 01:16:23',
-                'updated' => '2007-03-17 01:18:31',
-            ],
-            [
-                'id' => 2,
-                'username' => 'nate',
-                'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
-                'created' => '2008-03-17 01:18:23',
-                'updated' => '2008-03-17 01:20:31',
+                'decimal_field' => '30.123',
+                'float_field' => 42.23,
+                'huge_int' => 1234567891234567891,
+                'small_int' => 1234,
+                'tiny_int' => 12,
+                'bool' => false,
+                'uuid' => null,
+                'timestamp_field' => '2007-03-17 01:16:23',
             ],
         ];
         parent::init();


### PR DESCRIPTION
Closes https://github.com/cakephp/bake/issues/569

Decimal types are returned as strings in CakePHP 4. The fix for CakePHP 3 is overriding the decimcal type.

I messed up the git history in the original PR.