### PR TITLE
Add support for multiple field unique constraints

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -887,10 +887,7 @@ class ModelCommand extends BakeCommand
             if ($constraint['type'] !== TableSchema::CONSTRAINT_UNIQUE) {
                 continue;
             }
-            if (count($constraint['columns']) > 1) {
-                continue;
-            }
-            $rules[$constraint['columns'][0]] = ['name' => 'isUnique'];
+            $rules[$constraint['columns'][0]] = ['name' => 'isUnique', 'fields' => $constraint['columns']];
         }
 
         if (empty($associations['belongsTo'])) {

--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -125,7 +125,8 @@ class {{ name }}Table extends Table
     public function buildRules(RulesChecker $rules): RulesChecker
     {
 {% for field, rule in rulesChecker %}
-        $rules->add($rules->{{ rule.name }}(['{{ field }}']{{ (rule.extra is defined and rule.extra ? (", '#{rule.extra}'") : '')|raw }}), ['errorField' => '{{ field }}']);
+{% set fields = Bake.exportArray(rule.fields is defined ? rule.fields : [field]) %}
+        $rules->add($rules->{{ rule.name }}({{ fields|raw }}{{ (rule.extra is defined and rule.extra ? (", '#{rule.extra}'") : '')|raw }}), ['errorField' => '{{ field }}']);
 {% endfor %}
 
         return $rules;

--- a/tests/Fixture/UniqueFieldsFixture.php
+++ b/tests/Fixture/UniqueFieldsFixture.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         2.6.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * UniqueFiUniqueFieldsFixturexture
+ */
+class UniqueFieldsFixture extends TestFixture
+{
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'username' => ['type' => 'string', 'null' => true, 'length' => 255],
+        'email' => ['type' => 'string', 'null' => true, 'length' => 255],
+        'field_1' => ['type' => 'string', 'null' => true, 'length' => 255],
+        'field_2' => ['type' => 'string', 'null' => true,'length' => 255],
+        '_constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => ['id'],
+            ],
+            'multiple_fields_unique' => [
+                'type' => 'unique',
+                'columns' => [
+                    'field_1',
+                    'field_2',
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['field_1' => 'unique_value_1', 'field_2' => 'unique_value_2'],
+        ['field_1' => 'unique_value_2', 'field_2' => 'unique_value_3'],
+    ];
+}

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -56,6 +56,7 @@ class ModelCommandTest extends TestCase
         'plugin.Bake.Invitations',
         'plugin.Bake.NumberTrees',
         'plugin.Bake.Users',
+        'plugin.Bake.UniqueFields',
     ];
 
     /**
@@ -1223,6 +1224,7 @@ class ModelCommandTest extends TestCase
         $expected = [
             'title' => [
                 'name' => 'isUnique',
+                'fields' => ['title', 'user_id'],
             ],
         ];
         $this->assertEquals($expected, $result);
@@ -1443,6 +1445,32 @@ class ModelCommandTest extends TestCase
             'belongsToMany' => [],
         ];
         $data['rulesChecker'] = [];
+        $command->bakeTable($tableObject, $data, $args, $io);
+
+        $result = file_get_contents($this->generatedFiles[0]);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    /**
+     * Tests generating table with rules checker.
+     */
+    public function testBakeTableRules(): void
+    {
+        $this->generatedFiles = [
+            APP . 'Model/Table/UniqueFieldsTable.php',
+        ];
+
+        $command = new ModelCommand();
+        $command->connection = 'test';
+
+        $name = 'UniqueFields';
+        $args = new Arguments([$name], ['table' => 'unique_fields', 'force' => true], []);
+        $io = new ConsoleIo($this->_out, $this->_err, $this->_in);
+
+        $table = $command->getTable($name, $args);
+        $tableObject = $command->getTableObject($name, $table);
+        $data = $command->getTableContext($tableObject, $table, $name, $args, $io);
+        $data['validation'] = [];
         $command->bakeTable($tableObject, $data, $args, $io);
 
         $result = file_get_contents($this->generatedFiles[0]);

--- a/tests/comparisons/Model/testBakeTableRules.php
+++ b/tests/comparisons/Model/testBakeTableRules.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+/**
+ * UniqueFields Model
+ *
+ * @method \Bake\Test\App\Model\Entity\UniqueField newEmptyEntity()
+ * @method \Bake\Test\App\Model\Entity\UniqueField newEntity(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[] newEntities(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField get($primaryKey, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ */
+class UniqueFieldsTable extends Table
+{
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('unique_fields');
+        $this->setDisplayField('id');
+        $this->setPrimaryKey('id');
+    }
+
+    /**
+     * Returns a rules checker object that will be used for validating
+     * application integrity.
+     *
+     * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
+     * @return \Cake\ORM\RulesChecker
+     */
+    public function buildRules(RulesChecker $rules): RulesChecker
+    {
+        $rules->add($rules->isUnique(['username']), ['errorField' => 'username']);
+        $rules->add($rules->isUnique(['field_1', 'field_2']), ['errorField' => 'field_1']);
+
+        return $rules;
+    }
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName(): string
+    {
+        return 'test';
+    }
+}


### PR DESCRIPTION
Closes https://github.com/cakephp/bake/issues/197
Refs https://github.com/cakephp/bake/issues/34

This adds a `fields` key to the rule if there are multiple fields. We could always add `fields` if the rule expects an array.
