### PR TITLE
Set fields key for all rules that expect an array

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -879,7 +879,7 @@ class ModelCommand extends BakeCommand
         $rules = [];
         foreach ($fields as $fieldName) {
             if (in_array($fieldName, $uniqueColumns, true)) {
-                $rules[$fieldName] = ['name' => 'isUnique'];
+                $rules[$fieldName] = ['name' => 'isUnique', 'fields' => [$fieldName]];
             }
         }
         foreach ($schema->constraints() as $name) {

--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -119,7 +119,7 @@ class {{ name }}Table extends Table
     public function buildRules(RulesChecker $rules): RulesChecker
     {
 {% for field, rule in rulesChecker %}
-{% set fields = Bake.exportArray(rule.fields is defined ? rule.fields : [field]) %}
+{% set fields = rule.fields is defined ? Bake.exportArray(rule.fields) : Bake.exportVar(field) %}
         $rules->add($rules->{{ rule.name }}({{ fields|raw }}{{ (rule.extra is defined and rule.extra ? (", '#{rule.extra}'") : '')|raw }}), ['errorField' => '{{ field }}']);
 {% endfor %}
 

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -1185,6 +1185,7 @@ class ModelCommandTest extends TestCase
         $expected = [
             'username' => [
                 'name' => 'isUnique',
+                'fields' => ['username'],
             ],
             'country_id' => [
                 'name' => 'existsIn',

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
@@ -63,8 +63,8 @@ class CategoriesProductsTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->existsIn(['category_id'], 'Categories'), ['errorField' => 'category_id']);
-        $rules->add($rules->existsIn(['product_id'], 'Products'), ['errorField' => 'product_id']);
+        $rules->add($rules->existsIn('category_id', 'Categories'), ['errorField' => 'category_id']);
+        $rules->add($rules->existsIn('product_id', 'Products'), ['errorField' => 'product_id']);
 
         return $rules;
     }

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
@@ -78,7 +78,7 @@ class ProductVersionsTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->existsIn(['product_id'], 'Products'), ['errorField' => 'product_id']);
+        $rules->add($rules->existsIn('product_id', 'Products'), ['errorField' => 'product_id']);
 
         return $rules;
     }

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
@@ -78,7 +78,7 @@ class ProductVersionsTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->existsIn(['product_id'], 'Products'), ['errorField' => 'product_id']);
+        $rules->add($rules->existsIn('product_id', 'Products'), ['errorField' => 'product_id']);
 
         return $rules;
     }

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -109,7 +109,7 @@ class ItemsTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->existsIn(['user_id'], 'Users'), ['errorField' => 'user_id']);
+        $rules->add($rules->existsIn('user_id', 'Users'), ['errorField' => 'user_id']);
 
         return $rules;
     }

--- a/tests/comparisons/Model/testBakeTableWithCounterCache.php
+++ b/tests/comparisons/Model/testBakeTableWithCounterCache.php
@@ -66,7 +66,7 @@ class TodoTasksTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->existsIn(['todo_item_id'], 'TodoItems'), ['errorField' => 'todo_item_id']);
+        $rules->add($rules->existsIn('todo_item_id', 'TodoItems'), ['errorField' => 'todo_item_id']);
 
         return $rules;
     }


### PR DESCRIPTION
This seemed cleaner and more consistent for custom templates.

If a rule *requires* an array of fields, then we always set the `fields` key with an array.

Along with this, we export an array only when `fields` is set.