### PR TITLE
Add support for multiple field unique validation

### DIFF
--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -373,13 +373,22 @@ class BakeHelper extends Helper
             }
 
             if ($rule['rule'] && isset($rule['provider'])) {
-                $validationMethods[] = sprintf(
-                    "->add('%s', '%s', ['rule' => '%s', 'provider' => '%s'])",
-                    $field,
-                    $ruleName,
-                    $rule['rule'],
-                    $rule['provider']
-                );
+                if (is_string($rule['rule'])) {
+                    $validationMethods[] = sprintf(
+                        "->add('%s', '%s', ['rule' => '%s', 'provider' => '%s'])",
+                        $field,
+                        $ruleName,
+                        $rule['rule'],
+                        $rule['provider']
+                    );
+                } else {
+                    $validationMethods[] = sprintf(
+                        "->add('%s', '%s', %s)",
+                        $field,
+                        $ruleName,
+                        $this->exportVar($rule, 3, VarExporter::INLINE_NUMERIC_SCALAR_ARRAY)
+                    );
+                }
                 continue;
             }
 

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -1201,9 +1201,6 @@ class ModelCommandTest extends TestCase
     /**
      * Tests the getRules with unique keys.
      *
-     * Multi-column constraints are ignored as they would
-     * require a break in compatibility.
-     *
      * @return void
      */
     public function testGetRulesUniqueKeys()
@@ -1213,7 +1210,7 @@ class ModelCommandTest extends TestCase
             'type' => 'unique',
             'columns' => ['title'],
         ]);
-        $model->getSchema()->addConstraint('ignored_constraint', [
+        $model->getSchema()->addConstraint('multi_unique', [
             'type' => 'unique',
             'columns' => ['title', 'user_id'],
         ]);
@@ -1444,6 +1441,32 @@ class ModelCommandTest extends TestCase
             'hasMany' => [],
             'belongsToMany' => [],
         ];
+        $data['rulesChecker'] = [];
+        $command->bakeTable($tableObject, $data, $args, $io);
+
+        $result = file_get_contents($this->generatedFiles[0]);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    /**
+     * Tests generating table validation with unique constraints.
+     */
+    public function testBakeTableValidationUnique(): void
+    {
+        $this->generatedFiles = [
+            APP . 'Model/Table/UniqueFieldsTable.php',
+        ];
+
+        $command = new ModelCommand();
+        $command->connection = 'test';
+
+        $name = 'UniqueFields';
+        $args = new Arguments([$name], ['table' => 'unique_fields', 'force' => true], []);
+        $io = new ConsoleIo($this->_out, $this->_err, $this->_in);
+
+        $table = $command->getTable($name, $args);
+        $tableObject = $command->getTableObject($name, $table);
+        $data = $command->getTableContext($tableObject, $table, $name, $args, $io);
         $data['rulesChecker'] = [];
         $command->bakeTable($tableObject, $data, $args, $io);
 

--- a/tests/comparisons/Model/testBakeTableValidationUnique.php
+++ b/tests/comparisons/Model/testBakeTableValidationUnique.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+/**
+ * UniqueFields Model
+ *
+ * @method \Bake\Test\App\Model\Entity\UniqueField newEmptyEntity()
+ * @method \Bake\Test\App\Model\Entity\UniqueField newEntity(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[] newEntities(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField get($primaryKey, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\UniqueField[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ */
+class UniqueFieldsTable extends Table
+{
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('unique_fields');
+        $this->setDisplayField('id');
+        $this->setPrimaryKey('id');
+    }
+
+    /**
+     * Default validation rules.
+     *
+     * @param \Cake\Validation\Validator $validator Validator instance.
+     * @return \Cake\Validation\Validator
+     */
+    public function validationDefault(Validator $validator): Validator
+    {
+        $validator
+            ->integer('id')
+            ->allowEmptyString('id', null, 'create');
+
+        $validator
+            ->scalar('username')
+            ->maxLength('username', 255)
+            ->allowEmptyString('username');
+
+        $validator
+            ->email('email')
+            ->allowEmptyString('email');
+
+        $validator
+            ->scalar('field_1')
+            ->maxLength('field_1', 255)
+            ->allowEmptyString('field_1')
+            ->add('field_1', 'unique', [
+                'rule' => [
+                    'validateUnique',
+                    [
+                        'pass' => [
+                            'scope' => ['field_2'],
+                        ],
+                    ],
+                ],
+                'provider' => 'table',
+            ]);
+
+        $validator
+            ->scalar('field_2')
+            ->maxLength('field_2', 255)
+            ->allowEmptyString('field_2')
+            ->add('field_2', 'unique', [
+                'rule' => [
+                    'validateUnique',
+                    [
+                        'pass' => [
+                            'scope' => ['field_1'],
+                        ],
+                    ],
+                ],
+                'provider' => 'table',
+            ]);
+
+        return $validator;
+    }
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName(): string
+    {
+        return 'test';
+    }
+}


### PR DESCRIPTION
Closes https://github.com/cakephp/bake/issues/34

This implements multi-column unique index supports that matches the support added in application rules: https://github.com/cakephp/bake/pull/780

A unique rule is added for each field in a multi-field constraint. I'm not sure if we need to validate both "sets" of fields separately. The IsUnique rule should probably fail properly if the field isn't set in the entity and the column isn't nullable in the schema.