### PR TITLE
Add allowMultipleNulls to unique rules for nullable fields

### DIFF
--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -120,7 +120,11 @@ class {{ name }}Table extends Table
     {
 {% for field, rule in rulesChecker %}
 {% set fields = rule.fields is defined ? Bake.exportArray(rule.fields) : Bake.exportVar(field) %}
-        $rules->add($rules->{{ rule.name }}({{ fields|raw }}{{ (rule.extra is defined and rule.extra ? (", '#{rule.extra}'") : '')|raw }}), ['errorField' => '{{ field }}']);
+{% set options = '' %}
+{% for optionName, optionValue in rule.options %}
+    {%~ set options = (loop.first ? '[' : options) ~ "'#{optionName}' => " ~ Bake.exportVar(optionValue) ~ (loop.last ? ']' : ', ') %}
+{% endfor %}
+        $rules->add($rules->{{ rule.name }}({{ fields|raw }}{{ (rule.extra|default ? ", '#{rule.extra}'" : '')|raw }}{{ (options ? ', ' ~ options : '')|raw }}), ['errorField' => '{{ field }}']);
 {% endfor %}
 
         return $rules;

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -1186,14 +1186,17 @@ class ModelCommandTest extends TestCase
             'username' => [
                 'name' => 'isUnique',
                 'fields' => ['username'],
+                'options' => [],
             ],
             'country_id' => [
                 'name' => 'existsIn',
                 'extra' => 'Countries',
+                'options' => [],
             ],
             'site_id' => [
                 'name' => 'existsIn',
                 'extra' => 'Sites',
+                'options' => [],
             ],
         ];
         $this->assertEquals($expected, $result);
@@ -1226,6 +1229,7 @@ class ModelCommandTest extends TestCase
             'title' => [
                 'name' => 'isUnique',
                 'fields' => ['title', 'user_id'],
+                'options' => [],
             ],
         ];
         $this->assertEquals($expected, $result);
@@ -1475,7 +1479,11 @@ class ModelCommandTest extends TestCase
         $command->bakeTable($tableObject, $data, $args, $io);
 
         $result = file_get_contents($this->generatedFiles[0]);
-        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+        $expected = file_get_contents($this->_compareBasePath . __FUNCTION__ . '.php');
+        if (ConnectionManager::get('test')->getDriver() instanceof Sqlserver) {
+            $expected = preg_replace("/'allowMultipleNulls' => true/", "'allowMultipleNulls' => false", $expected);
+        }
+        $this->assertTextEquals($expected, $result, 'Content does not match file ' . __FUNCTION__ . '.php');
     }
 
     /**

--- a/tests/comparisons/Model/testBakeTableRules.php
+++ b/tests/comparisons/Model/testBakeTableRules.php
@@ -52,7 +52,7 @@ class UniqueFieldsTable extends Table
     public function buildRules(RulesChecker $rules): RulesChecker
     {
         $rules->add($rules->isUnique(['username']), ['errorField' => 'username']);
-        $rules->add($rules->isUnique(['field_1', 'field_2']), ['errorField' => 'field_1']);
+        $rules->add($rules->isUnique(['field_1', 'field_2'], ['allowMultipleNulls' => true]), ['errorField' => 'field_1']);
 
         return $rules;
     }


### PR DESCRIPTION
This adds the appropriate default for databases where unique indexes allow multiple nulls.

`allowMultipleNulls` is set to true for all non-sql server dbs.