### PR TITLE
remove parent::buildOptionParser()

### DIFF
--- a/templates/bake/Command/command.twig
+++ b/templates/bake/Command/command.twig
@@ -37,7 +37,6 @@ class {{ name }}Command extends Command
      */
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
-        $parser = parent::buildOptionParser($parser);
 
         return $parser;
     }


### PR DESCRIPTION
I think calling parent is redundant
I will fix testCases