### PR TITLE
Fix up templates for generics in docblocks, more precise assoc def.

### DIFF
--- a/templates/bake/Controller/component.twig
+++ b/templates/bake/Controller/component.twig
@@ -29,7 +29,7 @@ class {{ name }}Component extends Component
     /**
      * Default configuration.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_defaultConfig = [];
 }

--- a/templates/bake/Model/behavior.twig
+++ b/templates/bake/Model/behavior.twig
@@ -29,7 +29,7 @@ class {{ name }}Behavior extends Behavior
     /**
      * Default configuration.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_defaultConfig = [];
 }

--- a/templates/bake/Model/entity.twig
+++ b/templates/bake/Model/entity.twig
@@ -41,7 +41,7 @@ class {{ name }} extends Entity
      * be mass assigned. For security purposes, it is advised to set '*' to false
      * (or remove it), and explicitly make individual fields accessible as needed.
      *
-     * @var array
+     * @var array<string, bool>
      */
     protected $_accessible = {{ Bake.exportVar(accessible, 1)|raw }};
 {% endif %}
@@ -52,7 +52,7 @@ class {{ name }} extends Entity
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
-     * @var array
+     * @var array<string>
      */
     protected $_hidden = {{ Bake.exportVar(hidden, 1)|raw }};
 {% endif %}

--- a/templates/bake/View/cell.twig
+++ b/templates/bake/View/cell.twig
@@ -29,7 +29,7 @@ class {{ name }}Cell extends Cell
      * List of valid options that can be passed into this
      * cell's constructor.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_validCellOptions = [];
 

--- a/templates/bake/View/helper.twig
+++ b/templates/bake/View/helper.twig
@@ -29,7 +29,7 @@ class {{ name }}Helper extends Helper
     /**
      * Default configuration.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_defaultConfig = [];
 

--- a/templates/bake/tests/fixture.twig
+++ b/templates/bake/tests/fixture.twig
@@ -42,7 +42,7 @@ class {{ name }}Fixture extends TestFixture
     /**
      * Import
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $import = {{ import|raw }};
 
@@ -52,7 +52,7 @@ class {{ name }}Fixture extends TestFixture
     /**
      * Fields
      *
-     * @var array
+     * @var array<string, mixed>
      */
     // phpcs:disable
     public $fields = {{ schema|raw }};

--- a/templates/bake/tests/test_case.twig
+++ b/templates/bake/tests/test_case.twig
@@ -74,7 +74,7 @@ class {{ className }}Test extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = {{ Bake.exportVar(fixtures|values, 1)|raw }};
 {% if construction or methods %}

--- a/tests/Fixture/BakeArticlesBakeTagsFixture.php
+++ b/tests/Fixture/BakeArticlesBakeTagsFixture.php
@@ -24,7 +24,7 @@ class BakeArticlesBakeTagsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'bake_article_id' => ['type' => 'integer', 'null' => false],

--- a/tests/Fixture/BakeArticlesFixture.php
+++ b/tests/Fixture/BakeArticlesFixture.php
@@ -24,7 +24,7 @@ class BakeArticlesFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/BakeCarFixture.php
+++ b/tests/Fixture/BakeCarFixture.php
@@ -29,7 +29,7 @@ class BakeCarFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/BakeCommentsFixture.php
+++ b/tests/Fixture/BakeCommentsFixture.php
@@ -24,7 +24,7 @@ class BakeCommentsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'otherid' => ['type' => 'integer'],

--- a/tests/Fixture/BakeTagsFixture.php
+++ b/tests/Fixture/BakeTagsFixture.php
@@ -24,7 +24,7 @@ class BakeTagsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/BakeTemplateAuthorsFixture.php
+++ b/tests/Fixture/BakeTemplateAuthorsFixture.php
@@ -32,7 +32,7 @@ class BakeTemplateAuthorsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/BakeTemplateProfilesFixture.php
+++ b/tests/Fixture/BakeTemplateProfilesFixture.php
@@ -32,7 +32,7 @@ class BakeTemplateProfilesFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/BakeTemplateRolesFixture.php
+++ b/tests/Fixture/BakeTemplateRolesFixture.php
@@ -29,7 +29,7 @@ class BakeTemplateRolesFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/BinaryTestsFixture.php
+++ b/tests/Fixture/BinaryTestsFixture.php
@@ -24,7 +24,7 @@ class BinaryTestsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/CategoryThreadsFixture.php
+++ b/tests/Fixture/CategoryThreadsFixture.php
@@ -24,7 +24,7 @@ class CategoryThreadsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/DatatypesFixture.php
+++ b/tests/Fixture/DatatypesFixture.php
@@ -24,7 +24,7 @@ class DatatypesFixture extends TestFixture
     /**
      * Fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer', 'null' => false],

--- a/tests/Fixture/HiddenFieldsFixture.php
+++ b/tests/Fixture/HiddenFieldsFixture.php
@@ -24,7 +24,7 @@ class HiddenFieldsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/InvitationsFixture.php
+++ b/tests/Fixture/InvitationsFixture.php
@@ -24,7 +24,7 @@ class InvitationsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/NumberTreesFixture.php
+++ b/tests/Fixture/NumberTreesFixture.php
@@ -26,7 +26,7 @@ class NumberTreesFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/TodoItemsFixture.php
+++ b/tests/Fixture/TodoItemsFixture.php
@@ -27,7 +27,7 @@ class TodoItemsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer', 'null' => false],

--- a/tests/Fixture/TodoItemsTodoLabelsFixture.php
+++ b/tests/Fixture/TodoItemsTodoLabelsFixture.php
@@ -27,7 +27,7 @@ class TodoItemsTodoLabelsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'todo_item_id' => ['type' => 'integer', 'null' => false],

--- a/tests/Fixture/TodoLabelsFixture.php
+++ b/tests/Fixture/TodoLabelsFixture.php
@@ -27,7 +27,7 @@ class TodoLabelsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/TodoTasksFixture.php
+++ b/tests/Fixture/TodoTasksFixture.php
@@ -27,7 +27,7 @@ class TodoTasksFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'uid' => ['type' => 'integer'],

--- a/tests/Fixture/UniqueFieldsFixture.php
+++ b/tests/Fixture/UniqueFieldsFixture.php
@@ -24,7 +24,7 @@ class UniqueFieldsFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -24,7 +24,7 @@ class UsersFixture extends TestFixture
     /**
      * fields property
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $fields = [
         'id' => ['type' => 'integer'],

--- a/tests/TestCase/Command/AllCommandTest.php
+++ b/tests/TestCase/Command/AllCommandTest.php
@@ -29,7 +29,7 @@ class AllCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.Products',
@@ -37,7 +37,7 @@ class AllCommandTest extends TestCase
     ];
 
     /**
-     * @var array
+     * @var array<string>
      */
     protected $tables = ['products', 'product_versions'];
 

--- a/tests/TestCase/Command/ControllerAllCommandTest.php
+++ b/tests/TestCase/Command/ControllerAllCommandTest.php
@@ -30,7 +30,7 @@ class ControllerAllCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.BakeArticles',
@@ -38,7 +38,7 @@ class ControllerAllCommandTest extends TestCase
     ];
 
     /**
-     * @var array
+     * @var array<string>
      */
     protected $tables = ['bake_articles', 'bake_comments'];
 

--- a/tests/TestCase/Command/ControllerCommandTest.php
+++ b/tests/TestCase/Command/ControllerCommandTest.php
@@ -31,7 +31,7 @@ class ControllerCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.BakeArticles',

--- a/tests/TestCase/Command/FixtureAllCommandTest.php
+++ b/tests/TestCase/Command/FixtureAllCommandTest.php
@@ -30,7 +30,7 @@ class FixtureAllCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.Articles',
@@ -38,7 +38,7 @@ class FixtureAllCommandTest extends TestCase
     ];
 
     /**
-     * @var array
+     * @var array<string>
      */
     protected $tables = ['articles', 'comments'];
 

--- a/tests/TestCase/Command/FixtureCommandTest.php
+++ b/tests/TestCase/Command/FixtureCommandTest.php
@@ -32,7 +32,7 @@ class FixtureCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.Articles',

--- a/tests/TestCase/Command/ModelAllCommandTest.php
+++ b/tests/TestCase/Command/ModelAllCommandTest.php
@@ -30,7 +30,7 @@ class ModelAllCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.TodoTasks',
@@ -38,7 +38,7 @@ class ModelAllCommandTest extends TestCase
     ];
 
     /**
-     * @var array
+     * @var array<string>
      */
     protected $tables = ['todo_tasks', 'todo_items'];
 

--- a/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
+++ b/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
@@ -36,7 +36,7 @@ class ModelCommandAssociationDetectionTest extends TestCase
      * Don't sort this list alphabetically - otherwise there are table constraints
      * which fail when using postgres
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.Categories',

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -40,7 +40,7 @@ class ModelCommandTest extends TestCase
      * Don't sort this list alphabetically - otherwise there are table constraints
      * which fail when using postgres
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.Comments',

--- a/tests/TestCase/Command/TemplateAllCommandTest.php
+++ b/tests/TestCase/Command/TemplateAllCommandTest.php
@@ -30,7 +30,7 @@ class TemplateAllCommandTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.Articles',
@@ -38,7 +38,7 @@ class TemplateAllCommandTest extends TestCase
     ];
 
     /**
-     * @var array
+     * @var array<string>
      */
     protected $tables = ['articles', 'comments'];
 

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -35,7 +35,7 @@ class TemplateCommandTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.Articles',

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -35,7 +35,7 @@ abstract class TestCase extends BaseTestCase
     protected $generatedFile = '';
 
     /**
-     * @var array
+     * @var array<string>
      */
     protected $generatedFiles = [];
 

--- a/tests/TestCase/Utility/Model/AssociationFilterTest.php
+++ b/tests/TestCase/Utility/Model/AssociationFilterTest.php
@@ -30,7 +30,7 @@ class AssociationFilterTest extends TestCase
      * Don't sort this list alphabetically - otherwise there are table constraints
      * which fail when using postgres
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.Authors',

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -33,7 +33,7 @@ class BakeHelperTest extends TestCase
      * Don't sort this list alphabetically - otherwise there are table constraints
      * which fail when using postgres
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'plugin.Bake.BakeArticles',

--- a/tests/comparisons/Cell/testBakePlugin.php
+++ b/tests/comparisons/Cell/testBakePlugin.php
@@ -14,7 +14,7 @@ class ExampleCell extends Cell
      * List of valid options that can be passed into this
      * cell's constructor.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_validCellOptions = [];
 

--- a/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
+++ b/tests/comparisons/Fixture/testImportRecordsFromDatabase.php
@@ -13,7 +13,7 @@ class DatatypesFixture extends TestFixture
     /**
      * Import
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $import = ['table' => 'datatypes', 'connection' => 'test'];
 

--- a/tests/comparisons/Model/testBakeEntityCustomHidden.php
+++ b/tests/comparisons/Model/testBakeEntityCustomHidden.php
@@ -22,7 +22,7 @@ class User extends Entity
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
-     * @var array
+     * @var array<string>
      */
     protected $_hidden = [
         'foo',

--- a/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
+++ b/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
@@ -31,7 +31,7 @@ class TodoItem extends Entity
      * be mass assigned. For security purposes, it is advised to set '*' to false
      * (or remove it), and explicitly make individual fields accessible as needed.
      *
-     * @var array
+     * @var array<string, bool>
      */
     protected $_accessible = [
         'user_id' => true,

--- a/tests/comparisons/Model/testBakeEntityFieldsWhiteList.php
+++ b/tests/comparisons/Model/testBakeEntityFieldsWhiteList.php
@@ -31,7 +31,7 @@ class TodoItem extends Entity
      * be mass assigned. For security purposes, it is advised to set '*' to false
      * (or remove it), and explicitly make individual fields accessible as needed.
      *
-     * @var array
+     * @var array<string, bool>
      */
     protected $_accessible = [
         'id' => true,

--- a/tests/comparisons/Model/testBakeEntityFullContext.php
+++ b/tests/comparisons/Model/testBakeEntityFullContext.php
@@ -26,7 +26,7 @@ class User extends Entity
      * be mass assigned. For security purposes, it is advised to set '*' to false
      * (or remove it), and explicitly make individual fields accessible as needed.
      *
-     * @var array
+     * @var array<string, bool>
      */
     protected $_accessible = [
         'username' => true,
@@ -40,7 +40,7 @@ class User extends Entity
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
-     * @var array
+     * @var array<string>
      */
     protected $_hidden = [
         'password',

--- a/tests/comparisons/Model/testBakeEntityHidden.php
+++ b/tests/comparisons/Model/testBakeEntityHidden.php
@@ -22,7 +22,7 @@ class User extends Entity
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
-     * @var array
+     * @var array<string>
      */
     protected $_hidden = [
         'password',

--- a/tests/comparisons/Plugin/Simple/testBake.php
+++ b/tests/comparisons/Plugin/Simple/testBake.php
@@ -14,7 +14,7 @@ class ExampleBehavior extends Behavior
     /**
      * Default configuration.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_defaultConfig = [];
 }

--- a/tests/comparisons/Plugin/Simple/testBakePlugin.php
+++ b/tests/comparisons/Plugin/Simple/testBakePlugin.php
@@ -14,7 +14,7 @@ class ExampleBehavior extends Behavior
     /**
      * Default configuration.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_defaultConfig = [];
 }

--- a/tests/comparisons/Test/testBakeControllerTest.php
+++ b/tests/comparisons/Test/testBakeControllerTest.php
@@ -19,7 +19,7 @@ class PostsControllerTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'app.Posts',

--- a/tests/comparisons/Test/testBakeFixturesParam.php
+++ b/tests/comparisons/Test/testBakeFixturesParam.php
@@ -21,7 +21,7 @@ class AuthorsTableTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'app.Posts',

--- a/tests/comparisons/Test/testBakeModelTest.php
+++ b/tests/comparisons/Test/testBakeModelTest.php
@@ -21,7 +21,7 @@ class ArticlesTableTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'app.Articles',

--- a/tests/comparisons/Test/testBakePrefixControllerTest.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTest.php
@@ -19,7 +19,7 @@ class PostsControllerTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'app.Posts',

--- a/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
@@ -19,7 +19,7 @@ class PostsControllerTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'app.Posts',

--- a/tests/test_app/Plugin/TestBakeTheme/templates/bake/Model/behavior.twig
+++ b/tests/test_app/Plugin/TestBakeTheme/templates/bake/Model/behavior.twig
@@ -30,7 +30,7 @@ class {{ name }}Behavior extends Behavior
     /**
      * Default configuration.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_defaultConfig = [];
 }


### PR DESCRIPTION
This should also match the core code

It avoids PHPStan complaining about it not being consistent with the extended core code here.