### PR TITLE
fix multiple test run issue

### DIFF
--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -153,6 +153,7 @@ class TestCommandTest extends TestCase
             ROOT . 'tests/TestCase/Model/Table/BakeArticlesTableTest.php',
             ROOT . 'tests/TestCase/Model/Table/CategoryThreadsTableTest.php',
             ROOT . 'tests/TestCase/Model/Table/TemplateTaskCommentsTableTest.php',
+            ROOT . 'tests/TestCase/Model/Table/HiddenFieldsTableTest.php',
         ];
         $this->exec('bake test table --all');
 


### PR DESCRIPTION
when you run tests with `composer test` multiple times `TestCommandTest::testExecuteWithAll` starts failing. It works for the first time only and this PR fixes this.