### PR TITLE
Add support for detecting/generating `hasOne` associations.

### DIFF
--- a/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
+++ b/tests/comparisons/Model/testBakeEntityFieldsDefaults.php
@@ -19,6 +19,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\FrozenTime|null $updated
  *
  * @property \Bake\Test\App\Model\Entity\User $user
+ * @property \Bake\Test\App\Model\Entity\TodoReminder $todo_reminder
  * @property \Bake\Test\App\Model\Entity\TodoTask[] $todo_tasks
  * @property \Bake\Test\App\Model\Entity\TodoLabel[] $todo_labels
  */
@@ -43,6 +44,7 @@ class TodoItem extends Entity
         'created' => true,
         'updated' => true,
         'user' => true,
+        'todo_reminder' => true,
         'todo_tasks' => true,
         'todo_labels' => true,
     ];

--- a/tests/comparisons/Model/testBakeEntityFieldsWhiteList.php
+++ b/tests/comparisons/Model/testBakeEntityFieldsWhiteList.php
@@ -19,6 +19,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\FrozenTime|null $updated
  *
  * @property \Bake\Test\App\Model\Entity\User $user
+ * @property \Bake\Test\App\Model\Entity\TodoReminder $todo_reminder
  * @property \Bake\Test\App\Model\Entity\TodoTask[] $todo_tasks
  * @property \Bake\Test\App\Model\Entity\TodoLabel[] $todo_labels
  */

--- a/tests/comparisons/Model/testBakeEntityNoFields.php
+++ b/tests/comparisons/Model/testBakeEntityNoFields.php
@@ -19,6 +19,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\FrozenTime|null $updated
  *
  * @property \Bake\Test\App\Model\Entity\User $user
+ * @property \Bake\Test\App\Model\Entity\TodoReminder $todo_reminder
  * @property \Bake\Test\App\Model\Entity\TodoTask[] $todo_tasks
  * @property \Bake\Test\App\Model\Entity\TodoLabel[] $todo_labels
  */

--- a/tests/comparisons/Model/testBakeEntityWithPropertyTypeHints.php
+++ b/tests/comparisons/Model/testBakeEntityWithPropertyTypeHints.php
@@ -22,6 +22,7 @@ use Cake\ORM\Entity;
  * @property string $unknown_type
  *
  * @property \Bake\Test\App\Model\Entity\User $user
+ * @property \Bake\Test\App\Model\Entity\TodoReminder $todo_reminder
  * @property \BakeTest\Model\Entity\TodoTask[] $todo_tasks
  * @property \Bake\Test\App\Model\Entity\TodoLabel[] $todo_labels
  */

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -12,6 +12,7 @@ use Cake\Validation\Validator;
  * Items Model
  *
  * @property \Bake\Test\App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
+ * @property \Bake\Test\App\Model\Table\TodoRemindersTable&\Cake\ORM\Association\HasOne $TodoReminders
  * @property \Bake\Test\App\Model\Table\TodoTasksTable&\Cake\ORM\Association\HasMany $TodoTasks
  * @property \Bake\Test\App\Model\Table\TodoLabelsTable&\Cake\ORM\Association\BelongsToMany $TodoLabels
  *
@@ -52,6 +53,9 @@ class ItemsTable extends Table
         $this->belongsTo('Users', [
             'foreignKey' => 'user_id',
             'joinType' => 'INNER',
+        ]);
+        $this->hasOne('TodoReminders', [
+            'foreignKey' => 'todo_item_id',
         ]);
         $this->hasMany('TodoTasks', [
             'foreignKey' => 'todo_item_id',

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -443,6 +443,18 @@ return [
         'constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ],
     [
+        'table' => 'todo_reminders',
+        'columns' => [
+            'id' => ['type' => 'integer', 'null' => false],
+            'todo_item_id' => ['type' => 'integer', 'null' => false],
+            'triggered_at' => ['type' => 'datetime'],
+        ],
+        'constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'unique_todo_item' => ['type' => 'unique', 'columns' => ['todo_item_id']],
+        ],
+    ],
+    [
         'table' => 'todo_labels',
         'columns' => [
             'id' => ['type' => 'integer'],
@@ -509,6 +521,17 @@ return [
                     'field_2',
                 ],
             ],
+        ],
+    ],
+    [
+        'table' => 'self_referencing_unique_keys',
+        'columns' => [
+            'id' => ['type' => 'integer'],
+            'parent_id' => ['type' => 'integer'],
+        ],
+        'constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'unique_self_referencing_parent' => ['type' => 'unique', 'columns' => ['parent_id']],
         ],
     ],
 ];


### PR DESCRIPTION
The code is pretty much identical for `findHasOne()` and `findHasMany()`, let me know if you'd rather like to see this split out further into some shared method(s).