### PR TITLE
omit primary key validation and re-add FK validation rules while baking the model

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -694,7 +694,7 @@ class ModelCommand extends BakeCommand
                 continue;
             }
             $field = $schema->getColumn($fieldName);
-            $validation = $this->fieldValidation($schema, $fieldName, $field);
+            $validation = $this->fieldValidation($schema, $fieldName, $field, $primaryKey);
             if ($validation) {
                 $validate[$fieldName] = $validation;
             }
@@ -709,12 +709,14 @@ class ModelCommand extends BakeCommand
      * @param \Cake\Database\Schema\TableSchemaInterface $schema The table schema for the current field.
      * @param string $fieldName Name of field to be validated.
      * @param array $metaData metadata for field
+     * @param array<string> $primaryKey The primary key field. Unused because PK validation is skipped
      * @return array Array of validation for the field.
      */
     public function fieldValidation(
         TableSchemaInterface $schema,
         string $fieldName,
-        array $metaData
+        array $metaData,
+        array $primaryKey
     ): array {
         $ignoreFields = ['lft', 'rght', 'created', 'modified', 'updated'];
         if (in_array($fieldName, $ignoreFields, true)) {

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -682,15 +682,9 @@ class ModelCommand extends BakeCommand
 
         $validate = [];
         $primaryKey = $schema->getPrimaryKey();
-        $foreignKeys = [];
-        if (isset($associations['belongsTo'])) {
-            foreach ($associations['belongsTo'] as $assoc) {
-                $foreignKeys[] = $assoc['foreignKey'];
-            }
-        }
         foreach ($fields as $fieldName) {
-            // Skip primary key and foreign key validations
-            if (in_array($fieldName, $primaryKey, true) || in_array($fieldName, $foreignKeys, true)) {
+            // Skip primary key
+            if (in_array($fieldName, $primaryKey, true)) {
                 continue;
             }
             $field = $schema->getColumn($fieldName);

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -689,11 +689,12 @@ class ModelCommand extends BakeCommand
             }
         }
         foreach ($fields as $fieldName) {
-            if (in_array($fieldName, $foreignKeys, true)) {
+            // Skip primary key and foreign key validations
+            if (in_array($fieldName, $primaryKey, true) || in_array($fieldName, $foreignKeys, true)) {
                 continue;
             }
             $field = $schema->getColumn($fieldName);
-            $validation = $this->fieldValidation($schema, $fieldName, $field, $primaryKey);
+            $validation = $this->fieldValidation($schema, $fieldName, $field);
             if ($validation) {
                 $validate[$fieldName] = $validation;
             }
@@ -708,14 +709,12 @@ class ModelCommand extends BakeCommand
      * @param \Cake\Database\Schema\TableSchemaInterface $schema The table schema for the current field.
      * @param string $fieldName Name of field to be validated.
      * @param array $metaData metadata for field
-     * @param array<string> $primaryKey The primary key field
      * @return array Array of validation for the field.
      */
     public function fieldValidation(
         TableSchemaInterface $schema,
         string $fieldName,
-        array $metaData,
-        array $primaryKey
+        array $metaData
     ): array {
         $ignoreFields = ['lft', 'rght', 'created', 'modified', 'updated'];
         if (in_array($fieldName, $ignoreFields, true)) {
@@ -774,12 +773,7 @@ class ModelCommand extends BakeCommand
             ];
         }
 
-        if (in_array($fieldName, $primaryKey, true)) {
-            $validation['allowEmpty'] = [
-                'rule' => $this->getEmptyMethod($fieldName, $metaData),
-                'args' => [null, 'create'],
-            ];
-        } elseif ($metaData['null'] === true) {
+        if ($metaData['null'] === true) {
             $validation['allowEmpty'] = [
                 'rule' => $this->getEmptyMethod($fieldName, $metaData),
                 'args' => [],

--- a/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
+++ b/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
@@ -160,6 +160,7 @@ class ModelCommandAssociationDetectionTest extends TestCase
     {
         $driver = ConnectionManager::get('test')->getDriver();
         $this->skipIf($driver instanceof Mysql, 'Incompatible with mysql');
+        $this->skipIf($driver instanceof Sqlite, 'Incompatible with sqlite');
         $this->_compareBakeTableResult('ProductVersions', __FUNCTION__);
     }
 
@@ -171,7 +172,6 @@ class ModelCommandAssociationDetectionTest extends TestCase
     public function testBakeAssociationDetectionProductVersionsTableSigned()
     {
         $driver = ConnectionManager::get('test')->getDriver();
-        $this->skipIf($driver instanceof Sqlite, 'Incompatible with sqlite');
         $this->skipIf($driver instanceof Postgres, 'Incompatible with postgres');
         $this->skipIf($driver instanceof Sqlserver, 'Incompatible with sqlserver');
         $this->_compareBakeTableResult('ProductVersions', __FUNCTION__);

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -964,10 +964,6 @@ class ModelCommandTest extends TestCase
                 'boolean' => ['rule' => 'boolean', 'args' => []],
                 'notEmpty' => ['rule' => 'notEmptyString', 'args' => []],
             ],
-            'uid' => [
-                'integer' => ['rule' => 'integer', 'args' => []],
-                'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => [null, 'create']],
-            ],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -1050,10 +1046,6 @@ class ModelCommandTest extends TestCase
         $args = new Arguments([], [], []);
         $result = $command->getValidation($model, [], $args);
         $expected = [
-            'id' => [
-                'integer' => ['rule' => 'integer', 'args' => []],
-                'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => [null, 'create']],
-            ],
             'name' => [
                 'scalar' => ['rule' => 'scalar', 'args' => []],
                 'requirePresence' => ['rule' => 'requirePresence', 'args' => ['create']],
@@ -1137,10 +1129,6 @@ class ModelCommandTest extends TestCase
             'todo_task_count' => [
                 'integer' => ['rule' => 'integer', 'args' => []],
                 'notEmpty' => ['rule' => 'notEmptyString', 'args' => []],
-            ],
-            'id' => [
-                'integer' => ['rule' => 'integer', 'args' => []],
-                'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => [null, 'create']],
             ],
         ];
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -1069,29 +1069,6 @@ class ModelCommandTest extends TestCase
      *
      * @return void
      */
-    public function testGetValidationExcludeForeignKeys()
-    {
-        $driver = ConnectionManager::get('test')->getDriver();
-        $this->skipIf($driver instanceof Postgres, 'Incompatible with postgres');
-        $this->skipIf($driver instanceof Sqlserver, 'Incompatible with sqlserver');
-
-        $model = $this->getTableLocator()->get('TodoItems');
-        $associations = [
-            'belongsTo' => [
-                'Users' => ['foreignKey' => 'user_id'],
-            ],
-        ];
-        $command = new ModelCommand();
-        $args = new Arguments([], [], []);
-        $result = $command->getValidation($model, $associations, $args);
-        $this->assertArrayNotHasKey('user_id', $result);
-    }
-
-    /**
-     * test getting validation rules and exempting foreign keys
-     *
-     * @return void
-     */
     public function testGetValidationExcludeForeignKeysSigned()
     {
         $driver = ConnectionManager::get('test')->getDriver();
@@ -1128,6 +1105,11 @@ class ModelCommandTest extends TestCase
             ],
             'todo_task_count' => [
                 'integer' => ['rule' => 'integer', 'args' => []],
+                'notEmpty' => ['rule' => 'notEmptyString', 'args' => []],
+            ],
+            'user_id' => [
+                'integer' => ['rule' => 'integer', 'args' => []],
+                'requirePresence' => ['rule' => 'requirePresence', 'args' => ['create']],
                 'notEmpty' => ['rule' => 'notEmptyString', 'args' => []],
             ],
         ];

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -921,10 +921,6 @@ class ModelCommandTest extends TestCase
                 'integer' => ['rule' => 'integer', 'args' => []],
                 'notEmpty' => ['rule' => 'notEmptyString', 'args' => []],
             ],
-            'id' => [
-                'integer' => ['rule' => 'integer', 'args' => []],
-                'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => [null, 'create']],
-            ],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -1020,10 +1016,6 @@ class ModelCommandTest extends TestCase
         $command = new ModelCommand();
         $result = $command->getValidation($model, [], $args);
         $expected = [
-            'id' => [
-                'integer' => ['rule' => 'integer', 'args' => []],
-                'allowEmpty' => ['rule' => 'allowEmptyString', 'args' => [null, 'create']],
-            ],
             'name' => [
                 'scalar' => ['rule' => 'scalar', 'args' => []],
                 'requirePresence' => ['rule' => 'requirePresence', 'args' => ['create']],

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
@@ -63,10 +63,6 @@ class CategoriesTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->integer('id')
-            ->allowEmptyString('id', null, 'create');
-
-        $validator
             ->scalar('name')
             ->maxLength('name', 100)
             ->notEmptyString('name');

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
@@ -63,10 +63,6 @@ class CategoriesTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->nonNegativeInteger('id')
-            ->allowEmptyString('id', null, 'create');
-
-        $validator
             ->scalar('name')
             ->maxLength('name', 100)
             ->notEmptyString('name');

--- a/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
@@ -55,10 +55,6 @@ class OldProductsTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->integer('id')
-            ->allowEmptyString('id', null, 'create');
-
-        $validator
             ->scalar('name')
             ->maxLength('name', 100)
             ->notEmptyString('name');

--- a/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTableSigned.php
@@ -55,10 +55,6 @@ class OldProductsTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->nonNegativeInteger('id')
-            ->allowEmptyString('id', null, 'create');
-
-        $validator
             ->scalar('name')
             ->maxLength('name', 100)
             ->notEmptyString('name');

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
@@ -58,6 +58,11 @@ class ProductVersionsTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
+            ->nonNegativeInteger('product_id')
+            ->requirePresence('product_id', 'create')
+            ->notEmptyString('product_id');
+
+        $validator
             ->dateTime('version')
             ->requirePresence('version', 'create')
             ->notEmptyDateTime('version');

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
@@ -58,7 +58,7 @@ class ProductVersionsTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->nonNegativeInteger('product_id')
+            ->integer('product_id')
             ->requirePresence('product_id', 'create')
             ->notEmptyString('product_id');
 

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
@@ -58,10 +58,6 @@ class ProductVersionsTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->integer('id')
-            ->allowEmptyString('id', null, 'create');
-
-        $validator
             ->dateTime('version')
             ->requirePresence('version', 'create')
             ->notEmptyDateTime('version');

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
@@ -58,6 +58,11 @@ class ProductVersionsTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
+            ->nonNegativeInteger('product_id')
+            ->requirePresence('product_id', 'create')
+            ->notEmptyString('product_id');
+
+        $validator
             ->dateTime('version')
             ->requirePresence('version', 'create')
             ->notEmptyDateTime('version');

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
@@ -58,10 +58,6 @@ class ProductVersionsTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->nonNegativeInteger('id')
-            ->allowEmptyString('id', null, 'create');
-
-        $validator
             ->dateTime('version')
             ->requirePresence('version', 'create')
             ->notEmptyDateTime('version');

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -72,10 +72,6 @@ class ItemsTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->integer('id')
-            ->allowEmptyString('id', null, 'create');
-
-        $validator
             ->scalar('title')
             ->maxLength('title', 50)
             ->requirePresence('title', 'create')

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -72,6 +72,11 @@ class ItemsTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
+            ->integer('user_id')
+            ->requirePresence('user_id', 'create')
+            ->notEmptyString('user_id');
+
+        $validator
             ->scalar('title')
             ->maxLength('title', 50)
             ->requirePresence('title', 'create')

--- a/tests/comparisons/Model/testBakeTableNullableForeignKey.php
+++ b/tests/comparisons/Model/testBakeTableNullableForeignKey.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+/**
+ * TestBakeArticles Model
+ *
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle newEmptyEntity()
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle newEntity(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[] newEntities(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle get($primaryKey, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TestBakeArticle[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ *
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ */
+class TestBakeArticlesTable extends Table
+{
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('bake_articles');
+        $this->setDisplayField('title');
+        $this->setPrimaryKey('id');
+
+        $this->addBehavior('Timestamp');
+    }
+
+    /**
+     * Default validation rules.
+     *
+     * @param \Cake\Validation\Validator $validator Validator instance.
+     * @return \Cake\Validation\Validator
+     */
+    public function validationDefault(Validator $validator): Validator
+    {
+        $validator
+            ->numeric('id')
+            ->allowEmptyString('id', 'create');
+
+        $validator
+            ->scalar('name')
+            ->maxLength('name', 100, 'Name must be shorter than 100 characters.')
+            ->requirePresence('name', 'create')
+            ->allowEmptyString('name', null, false);
+
+        $validator
+            ->nonNegativeInteger('count')
+            ->requirePresence('count', 'create')
+            ->allowEmptyString('count', null, false);
+
+        $validator
+            ->greaterThanOrEqual('price', 0)
+            ->requirePresence('price', 'create')
+            ->allowEmptyString('price', null, false);
+
+        $validator
+            ->email('email')
+            ->add('email', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
+            ->allowEmptyString('email');
+
+        $validator
+            ->uploadedFile('image', [
+                'optional' => true,
+                'types' => ['image/jpeg'],
+            ])
+            ->allowEmptyFile('image');
+
+        return $validator;
+    }
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName(): string
+    {
+        return 'test';
+    }
+}

--- a/tests/comparisons/Model/testBakeWithRulesUnique.php
+++ b/tests/comparisons/Model/testBakeWithRulesUnique.php
@@ -65,10 +65,6 @@ class UsersTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->integer('id')
-            ->allowEmptyString('id', null, 'create');
-
-        $validator
             ->scalar('username')
             ->maxLength('username', 255)
             ->allowEmptyString('username');


### PR DESCRIPTION
Fixes #804

This PR adds checks so that the detected primary key field doesn't get validation rules added as well.