### PR TITLE
change validateNames logic to prevent special chars in column names

### DIFF
--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -166,13 +166,13 @@ abstract class BakeCommand extends Command
     }
 
     /**
-     * Check if a column name is valid
+     * Check if a column name is valid.
      *
      * The Regex used here basically states that:
      * - the column name has to start with an ASCII character (lower or upper case) or an underscore and
-     * - further characters are allowed to be either lower or upper case ASCII characters, numbers or underscores
+     * - further characters are allowed to be either lower or upper case ASCII characters, numbers or underscores.
      *
-     * @param string $name The name of the column
+     * @param string $name The name of the column.
      * @return bool
      */
     protected function isValidColumnName(string $name): bool

--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -164,4 +164,27 @@ abstract class BakeCommand extends Command
             $io->out(sprintf('<success>Deleted</success> `%s`', $path), 1, ConsoleIo::NORMAL);
         }
     }
+
+    /**
+     * The Regex used here basically states that:
+     *
+     * the column name has to start with a character (lower or upper case) or an underscore and
+     * further characters are allowed to be either lower or upper case characters, numbers or underscores
+     *
+     * Anything else like
+     * - any other special character
+     * - umlauts
+     * - whatever the user thinks is a good idea to use in a table name (emojis?)
+     *
+     * is prevented with this check.
+     *
+     * @param string $name The name of the column
+     * @return bool true, if it is valid, false if not
+     */
+    protected function isValidColumnName(string $name): bool
+    {
+        $re = '/^[a-zA-Z_][a-zA-Z0-9_]*$/';
+
+        return (bool)preg_match($re, $name);
+    }
 }

--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -166,8 +166,9 @@ abstract class BakeCommand extends Command
     }
 
     /**
-     * The Regex used here basically states that:
+     * Check if a column name is valid
      *
+     * The Regex used here basically states that:
      * the column name has to start with a character (lower or upper case) or an underscore and
      * further characters are allowed to be either lower or upper case characters, numbers or underscores
      *

--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -169,23 +169,14 @@ abstract class BakeCommand extends Command
      * Check if a column name is valid
      *
      * The Regex used here basically states that:
-     * the column name has to start with a character (lower or upper case) or an underscore and
-     * further characters are allowed to be either lower or upper case characters, numbers or underscores
-     *
-     * Anything else like
-     * - any other special character
-     * - umlauts
-     * - whatever the user thinks is a good idea to use in a table name (emojis?)
-     *
-     * is prevented with this check.
+     * - the column name has to start with an ASCII character (lower or upper case) or an underscore and
+     * - further characters are allowed to be either lower or upper case ASCII characters, numbers or underscores
      *
      * @param string $name The name of the column
-     * @return bool true, if it is valid, false if not
+     * @return bool
      */
     protected function isValidColumnName(string $name): bool
     {
-        $re = '/^[a-zA-Z_][a-zA-Z0-9_]*$/';
-
-        return (bool)preg_match($re, $name);
+        return (bool)preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $name);
     }
 }

--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -220,9 +220,10 @@ class FixtureCommand extends BakeCommand
     public function validateNames(TableSchemaInterface $schema, ConsoleIo $io): void
     {
         foreach ($schema->columns() as $column) {
-            if (!is_string($column) || (!ctype_alpha($column[0]) && $column[0] !== '_')) {
+            if (!$this->isValidColumnName($column)) {
                 $io->abort(sprintf(
-                    'Unable to bake model. Table column names must start with a letter or underscore. Found `%s`.',
+                    'Unable to bake model. Table column name must start with a letter or underscore and
+                    cannot contain special characters. Found `%s`.',
                     (string)$column
                 ));
             }

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -127,9 +127,7 @@ class ModelCommand extends BakeCommand
     public function validateNames(TableSchemaInterface $schema, ConsoleIo $io): void
     {
         foreach ($schema->columns() as $column) {
-            $re = '/^[a-zA-Z_][a-zA-Z0-9_]*$/m';
-            preg_match_all($re, $column, $matches, PREG_SET_ORDER);
-            if ($matches === []) {
+            if (!$this->isValidColumnName($column)) {
                 $io->abort(sprintf(
                     'Unable to bake model. Table column name must start with a letter or underscore and
                     cannot contain special characters. Found `%s`.',

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -127,9 +127,12 @@ class ModelCommand extends BakeCommand
     public function validateNames(TableSchemaInterface $schema, ConsoleIo $io): void
     {
         foreach ($schema->columns() as $column) {
-            if (!is_string($column) || (!ctype_alpha($column[0]) && $column[0] !== '_')) {
+            $re = '/^[a-zA-Z_][a-zA-Z0-9_]*$/m';
+            preg_match_all($re, $column, $matches, PREG_SET_ORDER);
+            if ($matches === []) {
                 $io->abort(sprintf(
-                    'Unable to bake model. Table column names must start with a letter or underscore. Found `%s`.',
+                    'Unable to bake model. Table column name must start with a letter or underscore and
+                    cannot contain special characters. Found `%s`.',
                     (string)$column
                 ));
             }

--- a/tests/TestCase/Command/FixtureCommandTest.php
+++ b/tests/TestCase/Command/FixtureCommandTest.php
@@ -90,6 +90,22 @@ class FixtureCommandTest extends TestCase
     }
 
     /**
+     * Tests validating supported table and column names.
+     */
+    public function testValidateNamesWithInvalidSpecialChars(): void
+    {
+        $command = new FixtureCommand();
+        $command->connection = 'test';
+
+        $schema = $command->readSchema('Car', 'car');
+        $schema->addColumn('invalid:column', ['type' => 'string', 'length' => null]);
+
+        $io = $this->createMock(ConsoleIo::class);
+        $io->expects($this->once())->method('abort');
+        $command->validateNames($schema, $io);
+    }
+
+    /**
      * test generating a fixture with database rows.
      *
      * @return void


### PR DESCRIPTION
This story started with the following discourse entry: https://discourse.cakephp.org/t/bake-cant-handle-column-name-containing/10046

The changes made here further prevent users to bake code which doesn't work like having a column name `data:3` and therefore we generate code like `$individual->data:3` which obviously doesn't work.

The Regex I used here basically states that:

- the column name has to start with a character (lower or upper case) or an underscore and
- further characters are allowed to be either lower or upper case characters, numbers or underscores

Anything else like
- any other special character
- umlauts
- whatever the user thinks is a good idea to use in a table name (emojis? 😂 )

is prevented with this check.