### PR TITLE
don't use Number helper if baked field is nullable

### DIFF
--- a/templates/bake/Template/index.twig
+++ b/templates/bake/Template/index.twig
@@ -49,8 +49,10 @@
 {% endif %}
 {% if isKey is not same as(true) %}
 {% set columnData = Bake.columnData(field, schema) %}
-{% if columnData.type not in ['integer', 'float', 'decimal', 'biginteger', 'smallinteger', 'tinyinteger'] or columnData.null is same as(true)  %}
+{% if columnData.type not in ['integer', 'float', 'decimal', 'biginteger', 'smallinteger', 'tinyinteger'] %}
                     <td><?= h(${{ singularVar }}->{{ field }}) ?></td>
+{% elseif columnData.null %}
+                    <td><?= ${{ singularVar }}->{{ field }} === null ? '' : $this->Number->format(${{ singularVar }}->{{ field }}) ?></td>
 {% else %}
                     <td><?= $this->Number->format(${{ singularVar }}->{{ field }}) ?></td>
 {% endif %}

--- a/templates/bake/Template/index.twig
+++ b/templates/bake/Template/index.twig
@@ -49,7 +49,7 @@
 {% endif %}
 {% if isKey is not same as(true) %}
 {% set columnData = Bake.columnData(field, schema) %}
-{% if columnData.type not in ['integer', 'float', 'decimal', 'biginteger', 'smallinteger', 'tinyinteger'] %}
+{% if columnData.type not in ['integer', 'float', 'decimal', 'biginteger', 'smallinteger', 'tinyinteger'] or columnData.null is same as(true)  %}
                     <td><?= h(${{ singularVar }}->{{ field }}) ?></td>
 {% else %}
                     <td><?= $this->Number->format(${{ singularVar }}->{{ field }}) ?></td>

--- a/templates/bake/Template/view.twig
+++ b/templates/bake/Template/view.twig
@@ -68,8 +68,8 @@
                 <tr>
                     <th><?= __('{{ field|humanize }}') ?></th>
 {% set columnData = Bake.columnData(field, schema) %}
-{% if columnData.null is same as(true) %}
-                    <td><?= h(${{ singularVar }}->{{ field }}) ?></td>
+{% if columnData.null %}
+                    <td><?= ${{ singularVar }}->{{ field }} === null ? '' : $this->Number->format(${{ singularVar }}->{{ field }}) ?></td>
 {% else %}
                     <td><?= $this->Number->format(${{ singularVar }}->{{ field }}) ?></td>
 {% endif %}

--- a/templates/bake/Template/view.twig
+++ b/templates/bake/Template/view.twig
@@ -67,7 +67,12 @@
 {% for field in groupedFields.number %}
                 <tr>
                     <th><?= __('{{ field|humanize }}') ?></th>
+{% set columnData = Bake.columnData(field, schema) %}
+{% if columnData.null is same as(true) %}
+                    <td><?= h(${{ singularVar }}->{{ field }}) ?></td>
+{% else %}
                     <td><?= $this->Number->format(${{ singularVar }}->{{ field }}) ?></td>
+{% endif %}
                 </tr>
 {% endfor %}
 {% endif %}

--- a/tests/comparisons/Template/testBakeView.php
+++ b/tests/comparisons/Template/testBakeView.php
@@ -36,11 +36,11 @@
                 </tr>
                 <tr>
                     <th><?= __('Member Number') ?></th>
-                    <td><?= $this->Number->format($author->member_number) ?></td>
+                    <td><?= h($author->member_number) ?></td>
                 </tr>
                 <tr>
                     <th><?= __('Account Balance') ?></th>
-                    <td><?= $this->Number->format($author->account_balance) ?></td>
+                    <td><?= h($author->account_balance) ?></td>
                 </tr>
                 <tr>
                     <th><?= __('Created') ?></th>

--- a/tests/comparisons/Template/testBakeView.php
+++ b/tests/comparisons/Template/testBakeView.php
@@ -36,11 +36,11 @@
                 </tr>
                 <tr>
                     <th><?= __('Member Number') ?></th>
-                    <td><?= h($author->member_number) ?></td>
+                    <td><?= $author->member_number === null ? '' : $this->Number->format($author->member_number) ?></td>
                 </tr>
                 <tr>
                     <th><?= __('Account Balance') ?></th>
-                    <td><?= h($author->account_balance) ?></td>
+                    <td><?= $author->account_balance === null ? '' : $this->Number->format($author->account_balance) ?></td>
                 </tr>
                 <tr>
                     <th><?= __('Created') ?></th>


### PR DESCRIPTION
Fixes #807 

This will prevent the bake command to use the Number helper `$this->Number->format()` from being used if the given field is nullable.