### PR TITLE
fix tests not using reference to command code constant via the interface

### DIFF
--- a/tests/TestCase/Command/AllCommandTest.php
+++ b/tests/TestCase/Command/AllCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
 use Bake\Utility\SubsetSchemaCollection;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Datasource\ConnectionManager;
 
 /**
@@ -95,7 +95,7 @@ class AllCommandTest extends TestCase
         ];
         $this->exec('bake all --connection test Products', ['y']);
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertOutputContains('Bake All complete');
     }
@@ -136,7 +136,7 @@ class AllCommandTest extends TestCase
         ];
         $this->exec('bake all --connection test --everything', ['y']);
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertOutputContains('Bake All complete');
     }
@@ -166,7 +166,7 @@ class AllCommandTest extends TestCase
         ];
         $this->exec('bake all --connection test --prefix admin Products', ['y']);
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains(
             'namespace Bake\Test\App\Controller\Admin;',
@@ -212,7 +212,7 @@ class AllCommandTest extends TestCase
         ];
         $this->exec('bake all --connection test Products', ['y', 'y', 'y', 'y']);
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains(
             '@uses \Bake\Test\App\Controller\ProductsController::index()',
             $testsPath . 'TestCase/Controller/ProductsControllerTest.php'

--- a/tests/TestCase/Command/CellCommandTest.php
+++ b/tests/TestCase/Command/CellCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 
 /**
@@ -53,7 +53,7 @@ class CellCommandTest extends TestCase
         ];
         $this->exec('bake cell Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains('class ExampleCell extends Cell', $this->generatedFiles[0]);
     }
@@ -75,7 +75,7 @@ class CellCommandTest extends TestCase
         ];
         $this->exec('bake cell TestBake.Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains('namespace TestBake\View\Cell;', $this->generatedFiles[0]);
         $this->assertFileContains('class ExampleCell extends Cell', $this->generatedFiles[0]);
     }
@@ -115,7 +115,7 @@ class CellCommandTest extends TestCase
         ];
         $this->exec('bake cell --prefix Admin Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains('namespace Bake\Test\App\View\Cell\Admin;', $this->generatedFiles[0]);
         $this->assertFileContains('class ExampleCell extends Cell', $this->generatedFiles[0]);
@@ -138,7 +138,7 @@ class CellCommandTest extends TestCase
         ];
         $this->exec('bake cell --prefix Admin TestBake.Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains('namespace TestBake\View\Cell\Admin;', $this->generatedFiles[0]);
         $this->assertFileContains('class ExampleCell extends Cell', $this->generatedFiles[0]);
     }

--- a/tests/TestCase/Command/CommandCommandTest.php
+++ b/tests/TestCase/Command/CommandCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 
 /**
@@ -51,7 +51,7 @@ class CommandCommandTest extends TestCase
         ];
         $this->exec('bake command Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains('class ExampleCommand extends Command', $this->generatedFiles[0]);
     }
@@ -72,7 +72,7 @@ class CommandCommandTest extends TestCase
         ];
         $this->exec('bake command TestBake.Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains('namespace TestBake\Command;', $this->generatedFiles[0]);
         $this->assertFileContains('class ExampleCommand extends Command', $this->generatedFiles[0]);
     }
@@ -112,7 +112,7 @@ class CommandCommandTest extends TestCase
         ];
         $this->exec('bake command Docblock', ['y', 'y']);
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains(
             '@uses \Bake\Test\App\Command\DocblockCommand::buildOptionParser()',
             $testsPath . 'TestCase/Command/DocblockCommandTest.php'
@@ -141,7 +141,7 @@ class CommandCommandTest extends TestCase
 
         $this->exec('bake command Docblock --plugin BakeTest', ['y', 'y']);
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains(
             '@uses \BakeTest\Command\DocblockCommand::buildOptionParser()',
             $testsPath . 'TestCase/Command/DocblockCommandTest.php'

--- a/tests/TestCase/Command/CommandHelperTest.php
+++ b/tests/TestCase/Command/CommandHelperTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 
 /**
@@ -51,7 +51,7 @@ class CommandHelperTest extends TestCase
         ];
         $this->exec('bake command_helper Error');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
 
@@ -75,7 +75,7 @@ class CommandHelperTest extends TestCase
         ];
         $this->exec('bake command_helper TestBake.Error');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }

--- a/tests/TestCase/Command/ControllerAllCommandTest.php
+++ b/tests/TestCase/Command/ControllerAllCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\App\Model\Table\BakeArticlesTable;
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
 
@@ -84,7 +84,7 @@ class ControllerAllCommandTest extends TestCase
         }
         $this->exec('bake controller all --connection test --no-test --quiet');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
 
         $this->assertFileDoesNotExist(

--- a/tests/TestCase/Command/ControllerCommandTest.php
+++ b/tests/TestCase/Command/ControllerCommandTest.php
@@ -19,8 +19,8 @@ namespace Bake\Test\TestCase\Command;
 use Bake\Command\ControllerCommand;
 use Bake\Test\App\Model\Table\BakeArticlesTable;
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
 use Cake\Console\Arguments;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 
 /**
@@ -79,7 +79,7 @@ class ControllerCommandTest extends TestCase
     {
         $this->exec('bake controller');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('- BakeArticles');
         $this->assertOutputContains('- BakeArticlesBakeTags');
         $this->assertOutputContains('- BakeComments');
@@ -134,7 +134,7 @@ class ControllerCommandTest extends TestCase
             'BakeArticles'
         );
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }
@@ -153,7 +153,7 @@ class ControllerCommandTest extends TestCase
             '--actions login,logout BakeArticles'
         );
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }
@@ -171,7 +171,7 @@ class ControllerCommandTest extends TestCase
             '--helpers Html,Time --components RequestHandler,Auth --no-actions BakeArticles'
         );
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }
@@ -189,7 +189,7 @@ class ControllerCommandTest extends TestCase
             '--helpers Html,Time --components "RequestHandler, Auth" BakeArticles'
         );
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }
@@ -268,7 +268,7 @@ class ControllerCommandTest extends TestCase
         ];
         $this->exec('bake controller --connection test BakeArticles');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains(
             'class BakeArticlesControllerTest extends TestCase',
@@ -290,7 +290,7 @@ class ControllerCommandTest extends TestCase
         $this->generatedFile = APP . 'Controller/BakeArticlesController.php';
         $this->exec('bake controller --connection test --no-test BakeArticles');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileDoesNotExist(ROOT . 'tests/TestCase/Controller/BakeArticlesControllerTest.php');
         $this->assertFileExists($this->generatedFile);
     }
@@ -304,7 +304,7 @@ class ControllerCommandTest extends TestCase
     {
         $this->exec('bake controller');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('Possible controllers based on your current database');
         $this->assertOutputContains('- BakeArticles');
     }
@@ -331,7 +331,7 @@ class ControllerCommandTest extends TestCase
     {
         $this->generatedFile = APP . 'Controller/BakeArticlesController.php';
         $this->exec("bake controller --connection test --no-test {$name}");
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $this->assertFileExists($this->generatedFile);
         $this->assertFileContains('BakeArticlesController extends AppController', $this->generatedFile);
@@ -350,7 +350,7 @@ class ControllerCommandTest extends TestCase
         $this->generatedFile = $path . 'src/Controller/BakeArticlesController.php';
 
         $this->exec('bake controller --connection test --no-test Company/Pastry.BakeArticles');
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $this->assertFileExists($this->generatedFile);
         $this->assertFileContains('namespace Company\Pastry\Controller;', $this->generatedFile);
@@ -371,7 +371,7 @@ class ControllerCommandTest extends TestCase
         $this->generatedFile = $path . 'src/Controller/BakeArticlesController.php';
 
         $this->exec('bake controller --connection test --no-test --plugin Company/Pastry bake_articles');
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $this->assertFileExists($this->generatedFile);
         $this->assertFileContains('namespace Company\Pastry\Controller;', $this->generatedFile);

--- a/tests/TestCase/Command/EntryCommandTest.php
+++ b/tests/TestCase/Command/EntryCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 
 /**
  * EntryCommand Test
@@ -57,7 +57,7 @@ class EntryCommandTest extends TestCase
     {
         $this->exec('bake --help');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('Available Commands');
         $this->assertOutputContains('bake controller');
         $this->assertOutputContains('bake controller all');
@@ -73,7 +73,7 @@ class EntryCommandTest extends TestCase
     public function testExecuteAppTask()
     {
         $this->exec('bake app_policy');
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('App Policy Generated');
     }
 
@@ -86,7 +86,7 @@ class EntryCommandTest extends TestCase
     {
         $this->exec('bake app_policy --help');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('bake app_policy');
         $this->assertOutputContains('Options');
     }
@@ -102,7 +102,7 @@ class EntryCommandTest extends TestCase
 
         $this->exec('bake zerg --verbose');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('Zerg generated');
         $this->assertOutputContains('Loud noises');
     }
@@ -116,7 +116,7 @@ class EntryCommandTest extends TestCase
     {
         $this->exec('bake nope');
 
-        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertExitCode(CommandInterface::CODE_ERROR);
         $this->assertErrorContains('Could not find');
     }
 }

--- a/tests/TestCase/Command/FixtureAllCommandTest.php
+++ b/tests/TestCase/Command/FixtureAllCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
 use Bake\Utility\SubsetSchemaCollection;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 
@@ -85,7 +85,7 @@ class FixtureAllCommandTest extends TestCase
         ];
         $this->exec('bake fixture all --connection test');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains('class ArticlesFixture', $this->generatedFiles[0]);
         $this->assertFileContains('class CommentsFixture', $this->generatedFiles[1]);
@@ -104,7 +104,7 @@ class FixtureAllCommandTest extends TestCase
         ];
         $this->exec('bake fixture all --connection test --count 10 --records');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains("'title' => 'Third Article'", $this->generatedFiles[0]);
         $this->assertFileContains(
@@ -126,7 +126,7 @@ class FixtureAllCommandTest extends TestCase
         ];
         $this->exec('bake fixture all --connection test --schema');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains(
             "public \$import = ['table' => 'articles'",

--- a/tests/TestCase/Command/FormCommandTest.php
+++ b/tests/TestCase/Command/FormCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 
 /**
  * FormCommandTest class
@@ -49,7 +49,7 @@ class FormCommandTest extends TestCase
         ];
         $this->exec('bake form Test', ['y']);
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains('class TestForm extends Form', $this->generatedFiles[0]);
     }

--- a/tests/TestCase/Command/MailerCommandTest.php
+++ b/tests/TestCase/Command/MailerCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 
 /**
@@ -51,7 +51,7 @@ class MailerCommandTest extends TestCase
         ];
         $this->exec('bake mailer Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles, 'files should be created');
         $this->assertFileContains('class ExampleMailer extends Mailer', $this->generatedFiles[0]);
     }
@@ -73,7 +73,7 @@ class MailerCommandTest extends TestCase
         ];
         $this->exec('bake mailer TestBake.Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles, 'files should be created');
         $this->assertFileContains('namespace TestBake\Mailer;', $this->generatedFiles[0]);
         $this->assertFileContains('class ExampleMailer extends Mailer', $this->generatedFiles[0]);
@@ -98,7 +98,7 @@ class MailerCommandTest extends TestCase
         ];
         $this->exec('bake mailer TestBake.Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
 }

--- a/tests/TestCase/Command/MiddlewareCommandTest.php
+++ b/tests/TestCase/Command/MiddlewareCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 
 /**
@@ -48,7 +48,7 @@ class MiddlewareCommandTest extends TestCase
         $this->generatedFile = APP . 'Middleware/ExampleMiddleware.php';
         $this->exec('bake middleware example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains('class ExampleMiddleware', $this->generatedFile);
     }
 
@@ -65,7 +65,7 @@ class MiddlewareCommandTest extends TestCase
         $this->generatedFile = $path . 'src/Middleware/ExampleMiddleware.php';
         $this->exec('bake middleware TestBake.example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains('class ExampleMiddleware', $this->generatedFile);
     }
 
@@ -82,7 +82,7 @@ class MiddlewareCommandTest extends TestCase
         $this->generatedFile = $path . 'src/Middleware/ExampleMiddleware.php';
         $this->exec('bake middleware TestBake.example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFile));
     }
 }

--- a/tests/TestCase/Command/ModelAllCommandTest.php
+++ b/tests/TestCase/Command/ModelAllCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
 use Bake\Utility\SubsetSchemaCollection;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Inflector;
 
@@ -88,7 +88,7 @@ class ModelAllCommandTest extends TestCase
         }
         $this->exec('bake model all --connection test --no-table --no-test');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
 
         $this->assertFileDoesNotExist(

--- a/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
+++ b/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Postgres;
@@ -84,7 +84,7 @@ class ModelCommandAssociationDetectionTest extends TestCase
         ];
         $this->exec("bake model --no-entity --no-fixture --no-test --connection test {$name}");
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $contents = file_get_contents($this->generatedFiles[0]);
         $this->assertSameAsFile($comparisonFile . '.php', $contents);
     }

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -18,8 +18,8 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Command\ModelCommand;
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
 use Cake\Console\Arguments;
+use Cake\Console\CommandInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
@@ -93,7 +93,7 @@ class ModelCommandTest extends TestCase
     {
         $this->exec('bake model --connection test');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('- TodoItems');
         $this->assertOutputContains('- TodoTasks');
         $this->assertOutputContains('- TodoLabels');
@@ -1263,7 +1263,7 @@ class ModelCommandTest extends TestCase
         ];
         $this->exec('bake model --no-test todo_items');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileDoesNotExist(ROOT . 'tests/TestCase/Model/Table/TodoItemsTableTest.php');
     }
@@ -1281,7 +1281,7 @@ class ModelCommandTest extends TestCase
         ];
         $this->exec('bake model --no-test --no-fixture todo_items');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileDoesNotExist(ROOT . 'tests/Fixture/TodoItemsFixture.php');
         $this->assertFileDoesNotExist(ROOT . 'tests/TestCase/Model/Table/TodoItemsTableTest.php');
@@ -1301,7 +1301,7 @@ class ModelCommandTest extends TestCase
         ];
         $this->exec('bake model --no-fixture todo_items');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileDoesNotExist(ROOT . 'tests/Fixture/TodoItemsFixture.php');
     }
@@ -1476,7 +1476,7 @@ class ModelCommandTest extends TestCase
         ];
         $this->exec('bake model --no-test --no-fixture --connection test --table todo_items Items');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $result = file_get_contents($this->generatedFiles[0]);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -1492,7 +1492,7 @@ class ModelCommandTest extends TestCase
         $this->generatedFile = APP . 'Model/Entity/User.php';
         $this->exec('bake model --no-test --no-fixture --no-table --no-fields --no-hidden users');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -1508,7 +1508,7 @@ class ModelCommandTest extends TestCase
         $this->generatedFile = APP . 'Model/Entity/User.php';
         $this->exec('bake model --no-test --no-fixture --no-table users');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -1537,7 +1537,7 @@ class ModelCommandTest extends TestCase
         $this->generatedFile = APP . 'Model/Entity/TodoItem.php';
         $this->exec('bake model --no-test --no-fixture --no-table --no-fields todo_items');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -1555,7 +1555,7 @@ class ModelCommandTest extends TestCase
         ];
         $this->exec('bake model --no-test --no-table --no-fixture TodoItems');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $result = file_get_contents($this->generatedFiles[0]);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -1571,7 +1571,7 @@ class ModelCommandTest extends TestCase
         $this->generatedFile = APP . 'Model/Entity/TodoItem.php';
         $this->exec('bake model --no-test --no-fixture --no-table --no-fields todo_items');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -1587,7 +1587,7 @@ class ModelCommandTest extends TestCase
         $this->generatedFile = APP . 'Model/Entity/TodoItem.php';
         $this->exec('bake model --no-test --no-fixture --no-table --fields id,title,body,completed todo_items');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -1603,7 +1603,7 @@ class ModelCommandTest extends TestCase
         $this->generatedFile = APP . 'Model/Entity/User.php';
         $this->exec('bake model --no-test --no-fixture --no-table --no-fields --hidden password users');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -1619,7 +1619,7 @@ class ModelCommandTest extends TestCase
         $this->generatedFile = APP . 'Model/Entity/User.php';
         $this->exec('bake model --no-test --no-fixture --no-table --no-fields --hidden foo,bar users');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -1639,7 +1639,7 @@ class ModelCommandTest extends TestCase
 
         $this->exec('bake model --no-validation --no-test --no-fixture --no-entity BakeTest.Users');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -1656,7 +1656,7 @@ class ModelCommandTest extends TestCase
 
         $this->exec('bake model --no-validation --no-test --no-fixture --no-entity TodoTasks');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $result = file_get_contents($this->generatedFile);
         $this->assertStringContainsString('CounterCache', $result);
@@ -1677,7 +1677,7 @@ class ModelCommandTest extends TestCase
 
         $this->exec('bake model --no-validation --no-test --no-fixture --no-entity -p BakeTest Users');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
@@ -1695,7 +1695,7 @@ class ModelCommandTest extends TestCase
         ];
         $this->exec('bake model --no-test --no-fixture --no-entity Users');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
 
         $result = file_get_contents($this->generatedFiles[0]);
@@ -1711,7 +1711,7 @@ class ModelCommandTest extends TestCase
     {
         $this->exec('bake model');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('Choose a model to bake from the following:');
     }
 
@@ -1730,7 +1730,7 @@ class ModelCommandTest extends TestCase
         ];
         $this->exec('bake model --connection test users');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
     }
 
@@ -1762,7 +1762,7 @@ class ModelCommandTest extends TestCase
         ];
         $this->exec("bake model --connection test {$name}");
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
     }
 

--- a/tests/TestCase/Command/PluginCommandTest.php
+++ b/tests/TestCase/Command/PluginCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Command\PluginCommand;
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\StopException;
 use Cake\Core\App;
@@ -85,7 +85,7 @@ class PluginCommandTest extends TestCase
     public function testMainBakePluginContents()
     {
         $this->exec('bake plugin SimpleExample', ['y', 'n']);
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertPluginContents('SimpleExample');
     }
 
@@ -97,7 +97,7 @@ class PluginCommandTest extends TestCase
     public function testMainCustomAppNamespace()
     {
         $this->exec('bake plugin Simple', ['y', 'n']);
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $bakedRoot = App::path('plugins')[0];
         $appController = $bakedRoot . 'Simple/src/Controller/AppController.php';
@@ -112,7 +112,7 @@ class PluginCommandTest extends TestCase
     public function testMainVendorName()
     {
         $this->exec('bake plugin Company/Example', ['y', 'n']);
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertPluginContents('Company/Example');
     }
 
@@ -124,7 +124,7 @@ class PluginCommandTest extends TestCase
     public function testMainVendorNameCasingFix()
     {
         $this->exec('bake plugin company/example', ['y', 'n']);
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertPluginContents('Company/Example');
     }
 
@@ -137,7 +137,7 @@ class PluginCommandTest extends TestCase
     {
         $this->exec('bake plugin');
 
-        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertExitCode(CommandInterface::CODE_ERROR);
         $this->assertErrorContains('You must');
     }
 
@@ -164,7 +164,7 @@ class PluginCommandTest extends TestCase
 
         $this->exec("bake plugin --composer '{$composerPath}' composer_example", ['y', 'y']);
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $result = json_decode(file_get_contents(ROOT . 'composer.json'), true);
         $this->assertArrayHasKey('autoload', $result);

--- a/tests/TestCase/Command/SimpleBakeCommandTest.php
+++ b/tests/TestCase/Command/SimpleBakeCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 
 /**
@@ -52,7 +52,7 @@ class SimpleBakeCommandTest extends TestCase
         ];
         $this->exec('bake behavior Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains('class ExampleBehavior extends Behavior', $this->generatedFiles[0]);
     }
@@ -70,7 +70,7 @@ class SimpleBakeCommandTest extends TestCase
         ];
         $this->exec('bake behavior Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
 
         $result = file_get_contents($this->generatedFiles[0]);
@@ -87,7 +87,7 @@ class SimpleBakeCommandTest extends TestCase
         $this->generatedFile = APP . 'Model/Behavior/ExampleBehavior.php';
         $this->exec('bake behavior --no-test Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileDoesNotExist(ROOT . 'tests/TestCase/Model/Behavior/ExampleBehaviorTest.php');
         $this->assertFileContains('class ExampleBehavior extends Behavior', $this->generatedFile);
     }
@@ -99,7 +99,7 @@ class SimpleBakeCommandTest extends TestCase
         $this->generatedFile = APP . 'Model/Behavior/FooBarBehavior.php';
         $this->exec('bake behavior --no-test --theme TestBakeTheme FooBar');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains('This file was generated using TestBakeTheme theme', $this->generatedFile);
     }
 
@@ -119,7 +119,7 @@ class SimpleBakeCommandTest extends TestCase
         ];
         $this->exec('bake behavior TestBake.Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
 
         $result = file_get_contents($this->generatedFiles[0]);

--- a/tests/TestCase/Command/TemplateAllCommandTest.php
+++ b/tests/TestCase/Command/TemplateAllCommandTest.php
@@ -18,7 +18,7 @@ namespace Bake\Test\TestCase\Command;
 
 use Bake\Test\TestCase\TestCase;
 use Bake\Utility\SubsetSchemaCollection;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 
@@ -95,7 +95,7 @@ class TemplateAllCommandTest extends TestCase
         ];
         $this->exec('bake template all');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
     }
 
@@ -118,7 +118,7 @@ class TemplateAllCommandTest extends TestCase
         ];
         $this->exec('bake template all --index-columns 3');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains('title', $this->generatedFiles[0]);
         $this->assertFileNotContains('published', $this->generatedFiles[0]);

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -19,8 +19,8 @@ namespace Bake\Test\TestCase\Command;
 use Bake\Command\TemplateCommand;
 use Bake\Test\App\Model\Table\BakeArticlesTable;
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
 use Cake\Console\Arguments;
+use Cake\Console\CommandInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\StopException;
 use Cake\Core\Configure;
@@ -443,7 +443,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = ROOT . 'templates/Authors/view.php';
         $this->exec('bake template authors view');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
 
         $result = file_get_contents($this->generatedFile);
@@ -460,7 +460,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = ROOT . 'templates/HiddenFields/view.php';
         $this->exec('bake template HiddenFields view');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
 
         $result = file_get_contents($this->generatedFile);
@@ -477,7 +477,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = ROOT . 'templates/Authors/edit.php';
         $this->exec('bake template authors edit');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
 
         $result = file_get_contents($this->generatedFile);
@@ -494,7 +494,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = ROOT . 'templates/Articles/edit.php';
         $this->exec('bake template articles edit');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
 
         $result = file_get_contents($this->generatedFile);
@@ -511,7 +511,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = ROOT . 'templates/TemplateTaskComments/index.php';
         $this->exec('bake template template_task_comments index');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
 
         $result = file_get_contents($this->generatedFile);
@@ -528,7 +528,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = ROOT . 'templates/HiddenFields/index.php';
         $this->exec('bake template HiddenFields index');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
 
         $result = file_get_contents($this->generatedFile);
@@ -545,7 +545,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = ROOT . 'templates/TemplateTaskComments/index.php';
         $this->exec('bake template template_task_comments --index-columns 3 index');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
 
         $result = file_get_contents($this->generatedFile);
@@ -569,7 +569,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = $path . 'Comments/index.php';
         $this->exec('bake template BakeTest.comments index');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $this->assertFileContains('$comment->article->id', $this->generatedFile);
     }
@@ -586,10 +586,10 @@ class TemplateCommandTest extends TestCase
             APP . '../templates/CategoryThreads/index.php',
         ];
         $this->exec('bake template CategoryThreads index');
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $this->exec('bake template CategoryThreads add');
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileNotContains('rght', $this->generatedFiles[0]);
@@ -612,7 +612,7 @@ class TemplateCommandTest extends TestCase
         ];
         $this->exec('bake template CategoryThreads index');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileNotContains('New Parent Category', $this->generatedFiles[0]);
         $this->assertFileNotContains('List Parent Category', $this->generatedFiles[0]);
@@ -629,7 +629,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = ROOT . 'templates/CategoryThreads/view.php';
         $this->exec('bake template category_threads view');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
 
         $this->assertFileContains('Related Category Threads', $this->generatedFile);
@@ -657,7 +657,7 @@ class TemplateCommandTest extends TestCase
     {
         $this->exec('bake template');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('Possible tables to bake view templates for based on your current database:');
         $this->assertOutputContains('- Comments');
         $this->assertOutputContains('- Articles');
@@ -673,7 +673,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = ROOT . 'templates/TemplateTaskComments/view.php';
         $this->exec('bake template TemplateTaskComments view');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $this->assertFileDoesNotExist(
             ROOT . 'templates/TemplateTaskComments/edit.php',
@@ -699,7 +699,7 @@ class TemplateCommandTest extends TestCase
         ];
         $this->exec('bake template TemplateTaskComments');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileDoesNotExist(
             ROOT . 'templates/TemplateTaskComments/edit.php',
@@ -724,7 +724,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = $path . 'Comments/index.php';
         $this->exec('bake template --connection test TestBake.Comments index');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $this->assertFileDoesNotExist(
             $path . 'Comments/view.php',
@@ -757,7 +757,7 @@ class TemplateCommandTest extends TestCase
         ];
         $this->exec('bake template --controller Blog Posts');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertOutputNotContains('No bake template found');
         $this->assertErrorEmpty();
@@ -776,7 +776,7 @@ class TemplateCommandTest extends TestCase
         ];
         $this->exec('bake template --prefix Admin Posts');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
     }
 
@@ -790,7 +790,7 @@ class TemplateCommandTest extends TestCase
         $this->generatedFile = ROOT . 'templates/TemplateTaskComments/list.php';
         $this->exec('bake template TemplateTaskComments index list');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);
         $this->assertFileContains('Template Task Comments', $this->generatedFile);
     }
@@ -804,6 +804,6 @@ class TemplateCommandTest extends TestCase
     {
         $this->exec('bake template MissingTableClass');
 
-        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertExitCode(CommandInterface::CODE_ERROR);
     }
 }

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -21,7 +21,7 @@ use Bake\Test\App\Controller\PostsController;
 use Bake\Test\App\Model\Table\ArticlesTable;
 use Bake\Test\App\Model\Table\CategoryThreadsTable;
 use Bake\Test\TestCase\TestCase;
-use Cake\Command\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Plugin;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest as Request;
@@ -77,7 +77,7 @@ class TestCommandTest extends TestCase
         $this->assertOutputContains('1. Entity');
         $this->assertOutputContains('2. Table');
         $this->assertOutputContains('3. Controller');
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
     }
 
     /**
@@ -90,7 +90,7 @@ class TestCommandTest extends TestCase
     {
         $this->exec('bake test entity');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('You must provide a class to bake');
     }
 
@@ -106,7 +106,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test Table TestTaskTag');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains(
             'class TestTaskTagTableTest extends TestCase',
@@ -128,7 +128,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test table TestBake.BakeArticles');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains(
             'class BakeArticlesTableTest extends TestCase',
@@ -157,7 +157,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test table --all');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
     }
 
@@ -170,7 +170,7 @@ class TestCommandTest extends TestCase
     {
         $this->exec('bake test table');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('You must provide a class to bake a test for. Some possible options are:');
         $this->assertOutputContains('1. ArticlesTable');
         $this->assertOutputContains('2. AuthorsTable');
@@ -191,7 +191,7 @@ class TestCommandTest extends TestCase
         $this->loadPlugins(['BakeTest' => ['path' => ROOT . 'Plugin' . DS . 'BakeTest' . DS]]);
         $this->exec('bake test table --plugin BakeTest');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('You must provide a class to bake a test for. Some possible options are:');
         $this->assertOutputContains('1. AuthorsTable');
         $this->assertOutputContains('2. BakeArticlesTable');
@@ -351,7 +351,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test table Authors --fixtures app.Posts,app.Comments,app.Users');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -368,7 +368,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test table Authors --no-fixture');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -385,7 +385,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test cell Articles');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -402,7 +402,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test command OtherExample');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -419,7 +419,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test table Articles');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -436,7 +436,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test controller PostsController');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -453,7 +453,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test controller NoModelController');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -470,7 +470,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test controller Admin\PostsController');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -487,7 +487,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test controller --prefix Admin PostsController');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -504,7 +504,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test component Apple');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -521,7 +521,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test behavior Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -538,7 +538,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test helper Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -555,7 +555,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test shell Articles');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -572,7 +572,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test task Articles');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -589,7 +589,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test shell_helper Example');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
     }
@@ -603,7 +603,7 @@ class TestCommandTest extends TestCase
     {
         $this->exec('bake test Foo Example');
 
-        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertExitCode(CommandInterface::CODE_ERROR);
     }
 
     /**
@@ -780,7 +780,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test entity --plugin TestTest Article');
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
     }
 
@@ -825,7 +825,7 @@ class TestCommandTest extends TestCase
 
         $this->exec('bake test --connection test controller Products', ['y']);
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains(
             '@uses \Bake\Test\App\Controller\ProductsController::index()',
             $testsPath . 'TestCase/Controller/ProductsControllerTest.php'
@@ -847,7 +847,7 @@ class TestCommandTest extends TestCase
         ];
         $this->exec('bake test --connection test table Products', ['y']);
 
-        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains(
             '@uses \Bake\Test\App\Model\Table\ProductsTable::validationDefault()',
             $testsPath . 'TestCase/Model/Table/ProductsTableTest.php'


### PR DESCRIPTION
fixes the following "warning"

<img width="816" alt="image" src="https://user-images.githubusercontent.com/9105243/155884802-6ead532f-d497-4b9e-9d5a-f78e452057ac.png">