### PR TITLE
update phpstan and psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "cs-check": "phpcs --parallel=16 -p src/ tests/",
         "cs-fix": "phpcbf --parallel=16 -p src/ tests/",
         "stan": "phpstan analyse src/ && psalm.phar",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.5 psalm/phar:~4.22.0 && mv composer.backup composer.json",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.7 psalm/phar:~4.23.0 && mv composer.backup composer.json",
         "test": "phpunit",
         "test-coverage": "phpunit --coverage-clover=clover.xml"
     },

--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -23,7 +23,7 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
-use Cake\Database\Exception;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Inflector;
@@ -160,7 +160,7 @@ class FixtureCommand extends BakeCommand
 
         try {
             $data = $this->readSchema($model, $useTable);
-        } catch (Exception $e) {
+        } catch (DatabaseException $e) {
             $this->getTableLocator()->remove($model);
             $useTable = Inflector::underscore($model);
             $table = $useTable;

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -24,7 +24,7 @@ use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlserver;
-use Cake\Database\Exception;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Schema\CachedCollection;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\Schema\TableSchemaInterface;
@@ -956,7 +956,7 @@ class ModelCommand extends BakeCommand
 
             try {
                 $otherSchema = $otherModel->getSchema();
-            } catch (Exception $e) {
+            } catch (DatabaseException $e) {
                 continue;
             }
 

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -23,7 +23,7 @@ use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Plugin;
 use Cake\Filesystem\Filesystem;
 use Cake\Http\Response;
@@ -399,12 +399,12 @@ class TestCommand extends BakeCommand
      *
      * @param string $type The type of thing having a test generated.
      * @return string
-     * @throws \Cake\Core\Exception\Exception When invalid object types are requested.
+     * @throws \Cake\Core\Exception\CakeException When invalid object types are requested.
      */
     public function mapType(string $type): string
     {
         if (empty($this->classTypes[$type])) {
-            throw new Exception('Invalid object type: ' . $type);
+            throw new CakeException('Invalid object type: ' . $type);
         }
 
         return $this->classTypes[$type];

--- a/src/Utility/CommonOptionsTrait.php
+++ b/src/Utility/CommonOptionsTrait.php
@@ -31,7 +31,7 @@ use InvalidArgumentException;
 trait CommonOptionsTrait
 {
     /**
-     * @var string|null
+     * @var string
      */
     public $plugin;
 

--- a/src/View/BakeView.php
+++ b/src/View/BakeView.php
@@ -69,7 +69,7 @@ class BakeView extends TwigView
      *
      * @param string|null $template Name of view file to use, or a template string to render
      * @param string|false|null $layout Layout to use. Not used, for consistency with other views only
-     * @throws \Cake\Core\Exception\Exception If there is an error in the view.
+     * @throws \Cake\Core\Exception\CakeException If there is an error in the view.
      * @return string Rendered content.
      */
     public function render(?string $template = null, $layout = null): string


### PR DESCRIPTION
The main changes I had to make were related to the fact, that PHPStan doesn't understand our class alias
```
class_alias('Cake\Core\Exception\CakeException', 'Cake\Core\Exception\Exception');
```
same for the DatabaseException.

Therefore I adjusted all usages of these Exceptions to the new ones.