### PR TITLE
Remove access to impossible array offset

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -494,7 +494,7 @@ class ModelCommand extends BakeCommand
                         'foreignKey' => $fieldName,
                     ];
                 }
-                if ($assoc && $this->plugin && empty($assoc['className'])) {
+                if ($assoc && $this->plugin) {
                     $assoc['className'] = $this->plugin . '.' . $assoc['alias'];
                 }
                 if ($assoc) {


### PR DESCRIPTION
This fixes a psalm error since `$assoc['className']` can never exist.