### PR TITLE
Don't enforce FKs presence on create to allow e.g. hasMany association save calls to run through

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -794,9 +794,9 @@ class ModelCommand extends BakeCommand
             if (in_array($fieldName, $primaryKey, true)) {
                 continue;
             }
-            $isForeignKey = in_array($fieldName, $foreignKeys, true);
             $field = $schema->getColumn($fieldName);
-            $validation = $this->fieldValidation($schema, $fieldName, $field, $primaryKey, $isForeignKey);
+            $field['isForeignKey'] = in_array($fieldName, $foreignKeys, true);
+            $validation = $this->fieldValidation($schema, $fieldName, $field, $primaryKey);
             if ($validation) {
                 $validate[$fieldName] = $validation;
             }
@@ -811,16 +811,14 @@ class ModelCommand extends BakeCommand
      * @param \Cake\Database\Schema\TableSchemaInterface $schema The table schema for the current field.
      * @param string $fieldName Name of field to be validated.
      * @param array $metaData metadata for field
-     * @param array<string> $primaryKey The primary key field. Unused because PK validation is skipped
-     * @param bool $isForeignKey Indicates if the currently precessed field is a foreign key
+     * @param array<string> $primaryKey The primary key field. Unused because PK validation is skippe
      * @return array Array of validation for the field.
      */
     public function fieldValidation(
         TableSchemaInterface $schema,
         string $fieldName,
         array $metaData,
-        array $primaryKey,
-        bool $isForeignKey = false
+        array $primaryKey
     ): array {
         $ignoreFields = ['lft', 'rght', 'created', 'modified', 'updated'];
         if (in_array($fieldName, $ignoreFields, true)) {
@@ -886,7 +884,7 @@ class ModelCommand extends BakeCommand
             ];
         } else {
             // FKs shouldn't be required on create to allow e.g. save calls with hasMany associations to create entities
-            if (($metaData['default'] === null || $metaData['default'] === false) && !$isForeignKey) {
+            if (($metaData['default'] === null || $metaData['default'] === false) && !$metaData['isForeignKey']) {
                 $validation['requirePresence'] = [
                     'rule' => 'requirePresence',
                     'args' => ['create'],

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -811,7 +811,7 @@ class ModelCommand extends BakeCommand
      * @param \Cake\Database\Schema\TableSchemaInterface $schema The table schema for the current field.
      * @param string $fieldName Name of field to be validated.
      * @param array $metaData metadata for field
-     * @param array<string> $primaryKey The primary key field. Unused because PK validation is skippe
+     * @param array<string> $primaryKey The primary key field. Unused because PK validation is skipped
      * @return array Array of validation for the field.
      */
     public function fieldValidation(

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -783,13 +783,20 @@ class ModelCommand extends BakeCommand
 
         $validate = [];
         $primaryKey = $schema->getPrimaryKey();
+        $foreignKeys = [];
+        if (isset($associations['belongsTo'])) {
+            foreach ($associations['belongsTo'] as $assoc) {
+                $foreignKeys[] = $assoc['foreignKey'];
+            }
+        }
         foreach ($fields as $fieldName) {
             // Skip primary key
             if (in_array($fieldName, $primaryKey, true)) {
                 continue;
             }
+            $isForeignKey = in_array($fieldName, $foreignKeys, true);
             $field = $schema->getColumn($fieldName);
-            $validation = $this->fieldValidation($schema, $fieldName, $field, $primaryKey);
+            $validation = $this->fieldValidation($schema, $fieldName, $field, $isForeignKey);
             if ($validation) {
                 $validate[$fieldName] = $validation;
             }
@@ -804,14 +811,14 @@ class ModelCommand extends BakeCommand
      * @param \Cake\Database\Schema\TableSchemaInterface $schema The table schema for the current field.
      * @param string $fieldName Name of field to be validated.
      * @param array $metaData metadata for field
-     * @param array<string> $primaryKey The primary key field. Unused because PK validation is skipped
+     * @param bool $isForeignKey True if the current is a foreign key
      * @return array Array of validation for the field.
      */
     public function fieldValidation(
         TableSchemaInterface $schema,
         string $fieldName,
         array $metaData,
-        array $primaryKey
+        bool $isForeignKey
     ): array {
         $ignoreFields = ['lft', 'rght', 'created', 'modified', 'updated'];
         if (in_array($fieldName, $ignoreFields, true)) {
@@ -876,7 +883,8 @@ class ModelCommand extends BakeCommand
                 'args' => [],
             ];
         } else {
-            if ($metaData['default'] === null || $metaData['default'] === false) {
+            // FKs shouldn't be required on create to allow e.g. save calls with hasMany associations to create entities
+            if (($metaData['default'] === null || $metaData['default'] === false) && !$isForeignKey) {
                 $validation['requirePresence'] = [
                     'rule' => 'requirePresence',
                     'args' => ['create'],

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -65,7 +65,7 @@ class ModelCommand extends BakeCommand
      *
      * @var bool
      */
-    protected $isForeignKey = false;
+    protected $isCurrentFieldForeignKey = false;
 
     /**
      * Execute the command.
@@ -801,7 +801,7 @@ class ModelCommand extends BakeCommand
             if (in_array($fieldName, $primaryKey, true)) {
                 continue;
             }
-            $this->isForeignKey = in_array($fieldName, $foreignKeys, true);
+            $this->isCurrentFieldForeignKey = in_array($fieldName, $foreignKeys, true);
             $field = $schema->getColumn($fieldName);
             $validation = $this->fieldValidation($schema, $fieldName, $field, $primaryKey);
             if ($validation) {
@@ -891,7 +891,7 @@ class ModelCommand extends BakeCommand
             ];
         } else {
             // FKs shouldn't be required on create to allow e.g. save calls with hasMany associations to create entities
-            if (($metaData['default'] === null || $metaData['default'] === false) && !$this->isForeignKey) {
+            if (($metaData['default'] === null || $metaData['default'] === false) && !$this->isCurrentFieldForeignKey) {
                 $validation['requirePresence'] = [
                     'rule' => 'requirePresence',
                     'args' => ['create'],

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -1167,7 +1167,6 @@ class ModelCommandTest extends TestCase
             ],
             'user_id' => [
                 'integer' => ['rule' => 'integer', 'args' => []],
-                'requirePresence' => ['rule' => 'requirePresence', 'args' => ['create']],
                 'notEmpty' => ['rule' => 'notEmptyString', 'args' => []],
             ],
         ];

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
@@ -59,7 +59,6 @@ class ProductVersionsTable extends Table
     {
         $validator
             ->integer('product_id')
-            ->requirePresence('product_id', 'create')
             ->notEmptyString('product_id');
 
         $validator

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
@@ -59,7 +59,6 @@ class ProductVersionsTable extends Table
     {
         $validator
             ->nonNegativeInteger('product_id')
-            ->requirePresence('product_id', 'create')
             ->notEmptyString('product_id');
 
         $validator

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -77,7 +77,6 @@ class ItemsTable extends Table
     {
         $validator
             ->integer('user_id')
-            ->requirePresence('user_id', 'create')
             ->notEmptyString('user_id');
 
         $validator


### PR DESCRIPTION
Caused by #805 

As just discussed in discord my implementation of requiring not nullable FKs in the validator causes issues when you want to create new entities via an e.g. hasMany association save call.

See https://youtu.be/d499_oCjq1s?t=340

The main cause behind all of this is the `->requirePresence()` which can be removed to allow that functionality again.