### PR TITLE
Add parser to find existing class details for non-destructive baking

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "cakephp/cakephp": "5.x-dev",
         "cakephp/twig-view": "dev-cake5",
-        "brick/varexporter": "^0.3.5"
+        "brick/varexporter": "^0.3.5",
+        "nikic/php-parser": "^4.13.2"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "5.x-dev",

--- a/src/Parse/CodeParser.php
+++ b/src/Parse/CodeParser.php
@@ -1,0 +1,205 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Parse;
+
+use PhpParser\Lexer\Emulative;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\Stmt\UseUse;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+
+/**
+ * @internal
+ */
+final class CodeParser extends NodeVisitorAbstract
+{
+    protected Parser $parser;
+
+    protected NodeTraverser $traverser;
+
+    protected string $code = '';
+
+    protected array $parsed = [];
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->parser = (new ParserFactory())->create(
+            ParserFactory::PREFER_PHP7,
+            new Emulative([
+                'usedAttributes' => ['comments', 'startLine', 'endLine', 'startFilePos', 'endFilePos'],
+            ]),
+        );
+        $this->traverser = new NodeTraverser();
+        $this->traverser->addVisitor($this);
+    }
+
+    /**
+     * @param string $code Code to parse
+     * @param string $className Class name expected in file
+     * @return \Bake\Parse\ParsedClass
+     * @throws \Bake\Parse\ParseException
+     */
+    public function parseClass(string $code, ?string $className = null): ParsedClass
+    {
+        $this->code = $code;
+        $this->traverser->traverse($this->parser->parse($code));
+
+        return new ParsedClass(...$this->parsed);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function beforeTraverse(array $nodes)
+    {
+        $this->parsed = [
+            'namespace' => null,
+            'name' => null,
+            'uses' => [
+                'classes' => [],
+                'funtions' => [],
+                'constants' => [],
+            ],
+            'methods' => [],
+        ];
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Namespace_) {
+            if (isset($this->parsed['namespace'])) {
+                throw new ParseException('Multiple namespaces in a file is not supported.');
+            }
+            $this->parsed['namespace'] = (string)$node->name;
+
+            return null;
+        }
+
+        if ($node instanceof Use_) {
+            foreach ($node->uses as $use) {
+                switch ($node->type) {
+                    case Use_::TYPE_NORMAL:
+                        $this->parsed['uses']['classes'] += $this->normalizeUse($use);
+                        break;
+                    case Use_::TYPE_FUNCTION:
+                        $this->parsed['uses']['functions'] += $this->normalizeUse($use);
+                        break;
+                    case Use_::TYPE_CONSTANT:
+                        $this->parsed['uses']['constants'] += $this->normalizeUse($use);
+                        break;
+                }
+            }
+
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+
+        if ($node instanceof GroupUse) {
+            $prefix = (string)$node->prefix;
+            foreach ($node->uses as $use) {
+                switch ($use->type) {
+                    case Use_::TYPE_NORMAL:
+                        $this->parsed['uses']['classes'] += $this->normalizeUse($use, $prefix);
+                        break;
+                    case Use_::TYPE_FUNCTION:
+                        $this->parsed['uses']['functions'] += $this->normalizeUse($use, $prefix);
+                        break;
+                    case Use_::TYPE_CONSTANT:
+                        $this->parsed['uses']['constants'] += $this->normalizeUse($use, $prefix);
+                        break;
+                }
+            }
+
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+
+        if ($node instanceof Class_) {
+            $this->parsed['name'] = (string)$node->name;
+
+            foreach ($node->getMethods() as $method) {
+                $startPos = $method->getStartFilePos();
+                $endPos = $method->getEndFilePos();
+                $code = '    ' . substr($this->code, $startPos, $endPos - $startPos + 1);
+
+                $doc = $method->getDocComment()?->getText();
+                $doc = $doc ? '    ' . $doc : null;
+
+                $name = (string)$method->name;
+                $this->parsed['methods'][$name] = new ParsedMethod(
+                    $name,
+                    $code,
+                    $doc,
+                    []
+                );
+            }
+
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function afterTraverse(array $nodes)
+    {
+        if (!isset($this->parsed['namespace'], $this->parsed['name'])) {
+            throw new ParseException('Could not find namespaced class.');
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\UseUse $use Use node
+     * @param string|null $prefix Group use prefix
+     * @return array<string, string>
+     */
+    protected function normalizeUse(UseUse $use, ?string $prefix = null): array
+    {
+        $name = (string)$use->name;
+        if ($prefix) {
+            $name = $prefix . '\\' . $name;
+        }
+
+        $alias = $use->alias;
+        if (!$alias) {
+            $last = strrpos($name, '\\', -1);
+            if ($last !== false) {
+                $alias = substr($name, strrpos($name, '\\', -1) + 1);
+            } else {
+                $alias = $name;
+            }
+        }
+
+        return [$name => (string)$alias];
+    }
+}

--- a/src/Parse/ParseException.php
+++ b/src/Parse/ParseException.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Parse;
+
+use Cake\Core\Exception\CakeException;
+
+class ParseException extends CakeException
+{
+}

--- a/src/Parse/ParsedClass.php
+++ b/src/Parse/ParsedClass.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Parse;
+
+/**
+ * @internal
+ */
+final class ParsedClass
+{
+    /**
+     * @param string $namespace Namespace
+     * @param string $name Class name
+     * @param array $uses Use statements
+     * @param array<string, \Bake\Parse\ParsedMethod> $methods Class methods
+     */
+    public function __construct(
+        public readonly string $namespace,
+        public readonly string $name,
+        public readonly array $uses,
+        public readonly array $methods
+    ) {
+    }
+}

--- a/src/Parse/ParsedMethod.php
+++ b/src/Parse/ParsedMethod.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Parse;
+
+/**
+ * @internal
+ */
+final class ParsedMethod
+{
+    /**
+     * @param string $name name
+     * @param string $code Code block
+     * @param string|null $docblock Docblock
+     * @param array $attributes Attributes
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $code,
+        public readonly ?string $docblock,
+        public readonly array $attributes
+    ) {
+    }
+}

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -175,7 +175,8 @@ class TestCommandTest extends TestCase
         $this->assertOutputContains('3. BakeArticlesTable');
         $this->assertOutputContains('4. CategoryThreadsTable');
         $this->assertOutputContains('5. HiddenFieldsTable');
-        $this->assertOutputContains('6. TemplateTaskCommentsTable');
+        $this->assertOutputContains('6. ParseTestTable');
+        $this->assertOutputContains('7. TemplateTaskCommentsTable');
         $this->assertOutputContains('Re-run your command as `cake bake Table <classname>`');
     }
 

--- a/tests/TestCase/Parse/CodeParserTest.php
+++ b/tests/TestCase/Parse/CodeParserTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\TestCase\Parse;
+
+use Bake\Parse\CodeParser;
+use Bake\Parse\ParseException;
+use Bake\Test\TestCase\TestCase;
+
+class CodeParserTest extends TestCase
+{
+    public function testParseClass(): void
+    {
+        $parser = new CodeParser();
+        $class = $parser->parseClass(file_get_contents(APP . DS . 'Model' . DS . 'Table' . DS . 'ParseTestTable.php'));
+
+        $this->assertSame('Bake\Test\App\Model\Table', $class->namespace);
+        $this->assertSame('ParseTestTable', $class->name);
+        $this->assertSame(
+            [
+                'Cake\ORM\Query' => 'Query',
+                'Cake\ORM\RulesChecker' => 'RulesChecker',
+                'Cake\ORM\Table' => 'Table',
+                'Cake\Validation\Validator' => 'Validator',
+            ],
+            $class->uses['classes']
+        );
+        $this->assertSame(
+            [
+                'initialize',
+                'buildRules',
+                'validationDefault',
+                'defaultConnectionName',
+                'findTest',
+            ],
+            array_keys($class->methods)
+        );
+
+        $code = <<<'CODEMARKER'
+            public function initialize(array $config): void
+            {
+                parent::initialize($config);
+
+                $this->setTable('test');
+                $this->setDisplayField('id');
+                $this->setPrimaryKey('id');
+            }
+        CODEMARKER;
+        $this->assertSame($code, $class->methods['initialize']->code);
+
+        $doc = <<<'DOCMARKER'
+            /**
+             * Initialize method
+             *
+             * @param array $config The configuration for the Table.
+             * @return void
+             */
+        DOCMARKER;
+        $this->assertSame($doc, $class->methods['initialize']->docblock);
+    }
+
+    public function testParseMissingNamespace(): void
+    {
+        $parser = new CodeParser();
+
+        $this->expectException(ParseException::class);
+        $class = $parser->parseClass(<<<'PARSE'
+        <?php
+
+        class TestTable{}
+        PARSE);
+    }
+
+    public function testParseMissingClass(): void
+    {
+        $parser = new CodeParser();
+
+        $this->expectException(ParseException::class);
+        $class = $parser->parseClass(<<<'PARSE'
+        <?php
+
+        namespace Bake\Test;
+        PARSE);
+    }
+
+    public function testParseMultipleNamespaces(): void
+    {
+        $parser = new CodeParser();
+
+        $this->expectException(ParseException::class);
+        $class = $parser->parseClass(<<<'PARSE'
+        <?php
+
+        namespace Bake\Test;
+
+        class TestTable{}
+
+        namespace Bake\Test2;
+
+        class Test2Table{}
+        PARSE);
+    }
+}

--- a/tests/test_app/App/Model/Table/ParseTestTable.php
+++ b/tests/test_app/App/Model/Table/ParseTestTable.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+/**
+ * ParseTestTable Model
+ *
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable newEmptyEntity()
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable newEntity(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[] newEntities(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable get($primaryKey, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ */
+class ParseTestTable extends Table
+{
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('test');
+        $this->setDisplayField('id');
+        $this->setPrimaryKey('id');
+    }
+
+    /**
+     * Returns a rules checker object that will be used for validating
+     * application integrity.
+     *
+     * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
+     * @return \Cake\ORM\RulesChecker
+     */
+    public function buildRules(RulesChecker $rules): RulesChecker
+    {
+        $rules->add($rules->isUnique(['username']), ['errorField' => 'username']);
+
+        return $rules;
+    }
+
+    /**
+     * Default validation rules.
+     *
+     * @param \Cake\Validation\Validator $validator Validator instance.
+     * @return \Cake\Validation\Validator
+     */
+    public function validationDefault(Validator $validator): Validator
+    {
+        $validator
+            ->numeric('id')
+            ->allowEmptyString('id', 'create');
+
+        $validator
+            ->scalar('username')
+            ->maxLength('username', 100, 'Name must be shorter than 100 characters.')
+            ->requirePresence('username', 'create')
+            ->allowEmptyString('username', null, false);
+
+        return $validator;
+    }
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName(): string
+    {
+        return 'test';
+    }
+
+    /**
+     * @param \Cake\ORM\Query $query Finder query
+     * @param array $options Finder options
+     * @return \Cake\ORM\Query
+     */
+    public function findTest(Query $query, array $options): Query
+    {
+        return $query;
+    }
+}


### PR DESCRIPTION
This doesn't populate the attributes array until I decide what we need from them.

The code and docblocks remain indented. The expected indent size is 4 spaces. We can add more validation to the file formatting as needed.