### PR TITLE
Add file_header template

### DIFF
--- a/templates/bake/Model/behavior.twig
+++ b/templates/bake/Model/behavior.twig
@@ -13,10 +13,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 #}
-<?php
-declare(strict_types=1);
-
-namespace {{ namespace }}\Model\Behavior;
+{{ element('Bake.file_header', {'namespace': "#{namespace}\\Model\\Behavior"}) }}
 
 use Cake\ORM\Behavior;
 use Cake\ORM\Table;

--- a/templates/bake/Model/entity.twig
+++ b/templates/bake/Model/entity.twig
@@ -23,10 +23,7 @@
 {% endif %}
 
 {%- set accessible = Bake.getFieldAccessibility(fields, primaryKey) %}
-<?php
-declare(strict_types=1);
-
-namespace {{ namespace }}\Model\Entity;
+{{ element('Bake.file_header', {'namespace': "#{namespace}\\Model\\Entity"}) }}
 
 use Cake\ORM\Entity;
 

--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -14,10 +14,7 @@
  */
 #}
 {% set annotations = DocBlock.buildTableAnnotations(associations, associationInfo, behaviors, entity, namespace) %}
-<?php
-declare(strict_types=1);
-
-namespace {{ namespace }}\Model\Table;
+{{ element('Bake.file_header', {'namespace': "#{namespace}\\Model\\Table"}) }}
 
 {% set uses = ['use Cake\\ORM\\Query;', 'use Cake\\ORM\\RulesChecker;', 'use Cake\\ORM\\Table;', 'use Cake\\Validation\\Validator;'] %}
 {{ uses|join('\n')|raw }}

--- a/templates/bake/element/file_header.twig
+++ b/templates/bake/element/file_header.twig
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=1);
+
+namespace {{ namespace }};


### PR DESCRIPTION
The namespace is included because spacing between namespace and file comment can be custom.

This converts only the Model templates until the format is approved.