### PR TITLE
Use generic syntax

### DIFF
--- a/templates/bake/Template/index.twig
+++ b/templates/bake/Template/index.twig
@@ -16,7 +16,7 @@
 <?php
 /**
  * @var \{{ namespace }}\View\AppView $this
- * @var array<\{{ entityClass }}>|\Cake\Collection\CollectionInterface<\{{ entityClass }}> ${{ pluralVar }}
+ * @var iterable<\{{ entityClass }}> ${{ pluralVar }}
  */
 ?>
 <div class="{{ pluralVar }} index content">

--- a/templates/bake/Template/index.twig
+++ b/templates/bake/Template/index.twig
@@ -16,7 +16,7 @@
 <?php
 /**
  * @var \{{ namespace }}\View\AppView $this
- * @var \{{ entityClass }}[]|\Cake\Collection\CollectionInterface ${{ pluralVar }}
+ * @var array<\{{ entityClass }}>|\Cake\Collection\CollectionInterface<\{{ entityClass }}> ${{ pluralVar }}
  */
 ?>
 <div class="{{ pluralVar }} index content">

--- a/tests/comparisons/Template/testBakeIndex.php
+++ b/tests/comparisons/Template/testBakeIndex.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @var \Bake\Test\App\View\AppView $this
- * @var \Cake\Datasource\EntityInterface[]|\Cake\Collection\CollectionInterface $templateTaskComments
+ * @var iterable<\Cake\Datasource\EntityInterface> $templateTaskComments
  */
 ?>
 <div class="templateTaskComments index content">

--- a/tests/comparisons/Template/testBakeIndexHiddenFields.php
+++ b/tests/comparisons/Template/testBakeIndexHiddenFields.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @var \Bake\Test\App\View\AppView $this
- * @var \Bake\Test\App\Model\Entity\HiddenField[]|\Cake\Collection\CollectionInterface $hiddenFields
+ * @var iterable<\Bake\Test\App\Model\Entity\HiddenField> $hiddenFields
  */
 ?>
 <div class="hiddenFields index content">

--- a/tests/comparisons/Template/testBakeIndexWithIndexLimit.php
+++ b/tests/comparisons/Template/testBakeIndexWithIndexLimit.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @var \Bake\Test\App\View\AppView $this
- * @var \Cake\Datasource\EntityInterface[]|\Cake\Collection\CollectionInterface $templateTaskComments
+ * @var iterable<\Cake\Datasource\EntityInterface> $templateTaskComments
  */
 ?>
 <div class="templateTaskComments index content">


### PR DESCRIPTION
Should we start adapting the newer syntax also in template files that are baked?
They would reflect it better

Also, the current syntax by some tools (e.g. code sniffer) could be changed to
```
array<\{{ entityClass }}>|\Cake\Collection\CollectionInterface
```
which would be wrong, as the object is now not part of the collection anymore.
Only the legacy syntax supported this understanding (as per legacy fallback interpretation).

Follows https://github.com/cakephp/cakephp/pull/16651