### PR TITLE
Add support for non-destructive baking to table and entity classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "php": ">=7.2",
         "cakephp/cakephp": "^4.3.0",
         "cakephp/twig-view": "^1.0.2",
-        "brick/varexporter": "^0.3.5"
+        "brick/varexporter": "^0.3.5",
+        "nikic/php-parser": "^4.13.2"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^4.0",

--- a/src/CodeGen/ClassBuilder.php
+++ b/src/CodeGen/ClassBuilder.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.8.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\CodeGen;
+
+class ClassBuilder
+{
+    /**
+     * @var \Bake\CodeGen\ParsedClass|null
+     */
+    protected $parsedClass;
+
+    /**
+     * @param \Bake\CodeGen\ParsedClass $parsedClass Parsed class it already exists
+     */
+    public function __construct(?ParsedClass $parsedClass = null)
+    {
+        $this->parsedClass = $parsedClass;
+    }
+
+    /**
+     * Returns the user functions from existing file.
+     *
+     * @param array<string> $generated Constants that are generated
+     * @return array<string, string>
+     */
+    public function getUserConstants(array $generated = []): array
+    {
+        if ($this->parsedClass === null) {
+            return [];
+        }
+
+        return array_diff_key($this->parsedClass->constants, array_flip($generated));
+    }
+
+    /**
+     * Returns the user functions from existing file.
+     *
+     * @param array<string> $generated Proeprties that are generated
+     * @return array<string, string>
+     */
+    public function getUserProperties(array $generated = []): array
+    {
+        if ($this->parsedClass === null) {
+            return [];
+        }
+
+        return array_diff_key($this->parsedClass->properties, array_flip($generated));
+    }
+
+    /**
+     * Returns the user functions from existing file.
+     *
+     * @param array<string> $generated Methods that are generated
+     * @return array<string, string>
+     */
+    public function getUserFunctions(array $generated = []): array
+    {
+        if ($this->parsedClass === null) {
+            return [];
+        }
+
+        return array_diff_key($this->parsedClass->methods, array_flip($generated));
+    }
+}

--- a/src/CodeGen/CodeParser.php
+++ b/src/CodeGen/CodeParser.php
@@ -1,0 +1,236 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.8.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\CodeGen;
+
+use PhpParser\Error;
+use PhpParser\Lexer\Emulative;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\Stmt\UseUse;
+use PhpParser\NodeAbstract;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+
+/**
+ * @internal
+ */
+class CodeParser extends NodeVisitorAbstract
+{
+    /**
+     * @var \PhpParser\Parser
+     */
+    protected $parser;
+
+    /**
+     * @var \PhpParser\NodeTraverser
+     */
+    protected $traverser;
+
+    /**
+     * @var string
+     */
+    protected $fileText = '';
+
+    /**
+     * @var array
+     */
+    protected $parsed = [];
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->parser = (new ParserFactory())->create(
+            ParserFactory::PREFER_PHP7,
+            new Emulative([
+                'usedAttributes' => ['comments', 'startLine', 'endLine', 'startFilePos', 'endFilePos'],
+            ])
+        );
+        $this->traverser = new NodeTraverser();
+        $this->traverser->addVisitor($this);
+    }
+
+    /**
+     * @param string $code Code to parse
+     * @return \Bake\CodeGen\ParsedFile|null
+     * @throws \Bake\CodeGen\ParseException
+     */
+    public function parseFile(string $code): ?ParsedFile
+    {
+        $this->fileText = $code;
+        try {
+            $this->traverser->traverse($this->parser->parse($code));
+        } catch (Error $e) {
+            throw new ParseException($e->getMessage(), null, $e);
+        }
+
+        if (!isset($this->parsed['namespace'], $this->parsed['class'])) {
+            return null;
+        }
+
+        return new ParsedFile(
+            $this->parsed['namespace'],
+            $this->parsed['imports'],
+            $this->parsed['class']
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function beforeTraverse(array $nodes)
+    {
+        $this->parsed = [
+            'imports' => [
+                'class' => [],
+                'function' => [],
+                'const' => [],
+            ],
+        ];
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Namespace_) {
+            if (isset($this->parsed['namespace'])) {
+                throw new ParseException('Multiple namespaces are not not supported, update your file');
+            }
+            $this->parsed['namespace'] = (string)$node->name;
+
+            return null;
+        }
+
+        if ($node instanceof Use_) {
+            if (count($node->uses) > 1) {
+                throw new ParseException('Multiple use statements per line are not supported, update your file');
+            }
+
+            [$alias, $target] = $this->normalizeUse(current($node->uses));
+            switch ($node->type) {
+                case Use_::TYPE_NORMAL:
+                    $this->parsed['imports']['class'][$alias] = $target;
+                    break;
+                case Use_::TYPE_FUNCTION:
+                    $this->parsed['imports']['function'][$alias] = $target;
+                    break;
+                case Use_::TYPE_CONSTANT:
+                    $this->parsed['imports']['const'][$alias] = $target;
+                    break;
+            }
+
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+
+        if ($node instanceof GroupUse) {
+            throw new ParseException('Group use statements are not supported, update your file');
+        }
+
+        if ($node instanceof Class_) {
+            if (!isset($this->parsed['namespace'])) {
+                throw new ParseException('Classes defined in the global namespace is not supported, update your file');
+            }
+            if (isset($this->parsed['class'])) {
+                throw new ParseException('Multiple classes are not supported, update your file');
+            }
+
+            $constants = [];
+            foreach ($node->getConstants() as $constant) {
+                if (count($constant->consts) > 1) {
+                    throw new ParseException('Multiple constants per line are not supported, update your file');
+                }
+
+                $name = (string)current($constant->consts)->name;
+                $constants[$name] = $this->getNodeCode($constant);
+            }
+
+            $properties = [];
+            foreach ($node->getProperties() as $property) {
+                if (count($property->props) > 1) {
+                    throw new ParseException('Multiple properties per line are not supported, update your file');
+                }
+
+                $name = (string)current($property->props)->name;
+                $properties[$name] = $this->getNodeCode($property);
+            }
+
+            $methods = [];
+            foreach ($node->getMethods() as $method) {
+                $name = (string)$method->name;
+                $methods[$name] = $this->getNodeCode($method);
+            }
+
+            $this->parsed['class'] = new ParsedClass((string)$node->name, $constants, $properties, $methods);
+
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \PhpParser\NodeAbstract $node Parser node
+     * @return string
+     */
+    protected function getNodeCode(NodeAbstract $node): string
+    {
+        $startPos = $node->getStartFilePos();
+        $endPos = $node->getEndFilePos();
+        $code = '    ' . substr($this->fileText, $startPos, $endPos - $startPos + 1);
+
+        $doc = $node->getDocComment() ? $node->getDocComment()->getText() : null;
+        if ($doc) {
+            $code = sprintf("    %s\n%s", $doc, $code);
+        }
+
+        return $code;
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\UseUse $use Use node
+     * @param string|null $prefix Group use prefix
+     * @return array{string, string}
+     */
+    protected function normalizeUse(UseUse $use, ?string $prefix = null): array
+    {
+        $name = (string)$use->name;
+        if ($prefix) {
+            $name = $prefix . '\\' . $name;
+        }
+
+        $alias = $use->alias;
+        if (!$alias) {
+            $last = strrpos($name, '\\', -1);
+            if ($last !== false) {
+                $alias = substr($name, strrpos($name, '\\', -1) + 1);
+            } else {
+                $alias = $name;
+            }
+        }
+
+        return [(string)$alias, $name];
+    }
+}

--- a/src/CodeGen/FileBuilder.php
+++ b/src/CodeGen/FileBuilder.php
@@ -1,0 +1,206 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.8.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\CodeGen;
+
+use Cake\Log\Log;
+use InvalidArgumentException;
+
+class FileBuilder
+{
+    /**
+     * @var string
+     */
+    protected $namespace;
+
+    /**
+     * @var \Bake\CodeGen\ParsedFile|null
+     */
+    protected $parsedFile;
+
+    /**
+     * @var \Bake\CodeGen\ClassBuilder
+     */
+    protected $classBuilder;
+
+    /**
+     * @param string $namespace File namespace
+     * @param \Bake\CodeGen\ParsedFile $parsedFile Parsed file it already exists
+     */
+    public function __construct(string $namespace, ?ParsedFile $parsedFile = null)
+    {
+        if ($parsedFile && $parsedFile->namespace !== $namespace) {
+            throw new ParseException(sprintf(
+                'Existing namespace `%s` does not match expected namespace `%s`, cannot update existing file',
+                $parsedFile->namespace,
+                $namespace
+            ));
+        }
+
+        $this->namespace = $namespace;
+        $this->parsedFile = $parsedFile;
+        $this->classBuilder = new ClassBuilder($parsedFile->class ?? null);
+    }
+
+    /**
+     * Returns the file namespace.
+     *
+     * @return string
+     */
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * @return \Bake\CodeGen\ClassBuilder
+     */
+    public function classBuilder(): ClassBuilder
+    {
+        return $this->classBuilder;
+    }
+
+    /**
+     * Returns sorted list of class imports to include in generated file.
+     *
+     * @param array<string|int, string> $generatedClasses Generated class imports
+     * @param array<string|int, string> $generatedFunctions Generated function imports
+     * @param array<string|int, string> $generatedConsts Generated const imports
+     * @return array<string, array<string>>
+     */
+    public function getUses(
+        array $generatedClasses = [],
+        array $generatedFunctions = [],
+        array $generatedConsts = []
+    ): array {
+        $uses = [];
+
+        $imports = $this->mergeUserImports($generatedClasses, $this->parsedFile->imports['class'] ?? []);
+        foreach ($imports as $alias => $type) {
+            $uses['class'][] = $this->getUse('class', $alias, $type);
+        }
+
+        $imports = $this->mergeUserImports($generatedFunctions, $this->parsedFile->imports['function'] ?? []);
+        foreach ($imports as $alias => $type) {
+            $uses['function'][] = $this->getUse('function', $alias, $type);
+        }
+
+        $imports = $this->mergeUserImports($generatedConsts, $this->parsedFile->imports['const'] ?? []);
+        foreach ($imports as $alias => $type) {
+            $uses['const'][] = $this->getUse('const', $alias, $type);
+        }
+
+        return $uses;
+    }
+
+    /**
+     * Builds a use statement.
+     *
+     * @param string $section Use section "class', 'function' or 'const
+     * @param string $alias Import alias
+     * @param string $type Import type
+     * @return string
+     */
+    protected function getUse(string $section, string $alias, string $type): string
+    {
+        $prefix = '';
+        switch ($section) {
+            case 'class':
+                $prefix = 'use';
+                break;
+            case 'function':
+                $prefix = 'use function';
+                break;
+            case 'const':
+                $prefix = 'use const';
+                break;
+        }
+
+        if ($type == $alias || substr($type, -strlen("\\{$alias}")) === "\\{$alias}") {
+            return "{$prefix} {$type};";
+        }
+
+        return "{$prefix} {$type} as {$alias};";
+    }
+
+    /**
+     * Normalizes imports included from generated code into [alias => name] format.
+     *
+     * @param array<string|int, string> $imports Imports
+     * @return array<string, string>
+     */
+    protected function normalizeIncludes(array $imports): array
+    {
+        $normalized = [];
+        foreach ($imports as $alias => $class) {
+            if (is_int($alias)) {
+                $last = strrpos($class, '\\', -1);
+                if ($last !== false) {
+                    $alias = substr($class, strrpos($class, '\\', -1) + 1);
+                } else {
+                    $alias = $class;
+                }
+            }
+
+            if (array_search($class, $normalized, true) !== false) {
+                throw new InvalidArgumentException(sprintf(
+                    'Cannot specify duplicate import for `%s`',
+                    $class
+                ));
+            }
+
+            $normalized[$alias] = $class;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<string|int, string> $generated Generated imports to merge into
+     * @param array<string, string> $user User imports to merge
+     * @return array<string, string>
+     */
+    protected function mergeUserImports(array $generated, array $user): array
+    {
+        $generated = $this->normalizeIncludes($generated);
+
+        $imports = $generated;
+        foreach ($user as $alias => $class) {
+            if (isset($generated[$alias]) && $generated[$alias] !== $class) {
+                Log::warning(sprintf(
+                    'User import `%s` conflicts with generated import, discarding',
+                    $class
+                ));
+                continue;
+            }
+
+            $generatedAlias = array_search($class, $generated, true);
+            if ($generatedAlias !== false && $generatedAlias != $alias) {
+                Log::warning(sprintf(
+                    'User import `%s` conflicts with generated import, discarding',
+                    $class
+                ));
+                continue;
+            }
+
+            $imports[$alias] = $class;
+        }
+
+        asort($imports, SORT_STRING | SORT_FLAG_CASE);
+
+        return $imports;
+    }
+}

--- a/src/CodeGen/ParseException.php
+++ b/src/CodeGen/ParseException.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.8.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\CodeGen;
+
+use Cake\Core\Exception\CakeException;
+
+class ParseException extends CakeException
+{
+}

--- a/src/CodeGen/ParsedClass.php
+++ b/src/CodeGen/ParsedClass.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.8.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\CodeGen;
+
+/**
+ * @internal
+ */
+class ParsedClass
+{
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var array<string, string>
+     */
+    public $constants;
+
+    /**
+     * @var array<string, string>
+     */
+    public $properties;
+
+    /**
+     * @var array<string, string>
+     */
+    public $methods;
+
+    /**
+     * @param string $name Class name
+     * @param array<string, string> $constants Class constants
+     * @param array<string, string> $properties Class properties
+     * @param array<string, string> $methods Class methods
+     */
+    public function __construct(string $name, array $constants, array $properties, array $methods)
+    {
+        $this->name = $name;
+        $this->constants = $constants;
+        $this->properties = $properties;
+        $this->methods = $methods;
+    }
+}

--- a/src/CodeGen/ParsedFile.php
+++ b/src/CodeGen/ParsedFile.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.8.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\CodeGen;
+
+/**
+ * @internal
+ */
+class ParsedFile
+{
+    /**
+     * @var string
+     */
+    public $namespace;
+
+    /**
+     * @var array{class: array<string, string>, function: array<string, string>, const: array<string, string>}
+     */
+    public $imports;
+
+    /**
+     * @var \Bake\CodeGen\ParsedClass
+     */
+    public $class;
+
+    /**
+     * @param string $namespace Namespace
+     * @param array{class: array<string, string>, function: array<string, string>, const: array<string, string>} $imports File imports
+     * @param \Bake\CodeGen\ParsedClass $class Parsed class
+     */
+    public function __construct(
+        string $namespace,
+        array $imports,
+        ParsedClass $class
+    ) {
+        $this->namespace = $namespace;
+        $this->imports = $imports;
+        $this->class = $class;
+    }
+}

--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Bake\Command;
 
+use Bake\CodeGen\CodeParser;
+use Bake\CodeGen\ParsedFile;
 use Bake\Utility\CommonOptionsTrait;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
@@ -178,5 +180,20 @@ abstract class BakeCommand extends Command
     protected function isValidColumnName(string $name): bool
     {
         return (bool)preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $name);
+    }
+
+    /**
+     * Parses a file if it exists.
+     *
+     * @param string $path File path
+     * @return \Bake\CodeGen\ParsedFile|null
+     */
+    protected function parseFile(string $path): ?ParsedFile
+    {
+        if (file_exists($path)) {
+            return (new CodeParser())->parseFile(file_get_contents($path));
+        }
+
+        return null;
     }
 }

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Bake\Command;
 
+use Bake\CodeGen\FileBuilder;
 use Bake\Utility\TableScanner;
 use Bake\Utility\TemplateRenderer;
 use Cake\Console\Arguments;
@@ -1100,7 +1101,9 @@ class ModelCommand extends BakeCommand
         if ($args->getOption('no-entity')) {
             return;
         }
+
         $name = $this->_entityName($model->getAlias());
+        $io->out("\n" . sprintf('Baking entity class for %s...', $name), 1, ConsoleIo::NORMAL);
 
         $namespace = Configure::read('App.namespace');
         $pluginPath = '';
@@ -1109,21 +1112,27 @@ class ModelCommand extends BakeCommand
             $pluginPath = $this->plugin . '.';
         }
 
+        $path = $this->getPath($args);
+        $filename = $path . 'Entity' . DS . $name . '.php';
+
+        $parsedFile = null;
+        if ($args->getOption('update')) {
+            $parsedFile = $this->parseFile($filename);
+        }
+
         $data += [
             'name' => $name,
             'namespace' => $namespace,
             'plugin' => $this->plugin,
             'pluginPath' => $pluginPath,
             'primaryKey' => [],
+            'fileBuilder' => new FileBuilder("{$namespace}\Model\Entity", $parsedFile),
         ];
 
         $renderer = new TemplateRenderer($this->theme);
         $renderer->set($data);
         $out = $renderer->generate('Bake.Model/entity');
 
-        $path = $this->getPath($args);
-        $filename = $path . 'Entity' . DS . $name . '.php';
-        $io->out("\n" . sprintf('Baking entity class for %s...', $name), 1, ConsoleIo::NORMAL);
         $io->createFile($filename, $out, $args->getOption('force'));
 
         $emptyFile = $path . 'Entity' . DS . '.gitkeep';
@@ -1145,13 +1154,23 @@ class ModelCommand extends BakeCommand
             return;
         }
 
+        $name = $model->getAlias();
+        $io->out("\n" . sprintf('Baking table class for %s...', $name), 1, ConsoleIo::NORMAL);
+
         $namespace = Configure::read('App.namespace');
         $pluginPath = '';
         if ($this->plugin) {
             $namespace = $this->_pluginNamespace($this->plugin);
         }
 
-        $name = $model->getAlias();
+        $path = $this->getPath($args);
+        $filename = $path . 'Table' . DS . $name . 'Table.php';
+
+        $parsedFile = null;
+        if ($args->getOption('update')) {
+            $parsedFile = $this->parseFile($filename);
+        }
+
         $entity = $this->_entityName($model->getAlias());
         $data += [
             'plugin' => $this->plugin,
@@ -1167,15 +1186,13 @@ class ModelCommand extends BakeCommand
             'rulesChecker' => [],
             'behaviors' => [],
             'connection' => $this->connection,
+            'fileBuilder' => new FileBuilder("{$namespace}\Model\Table", $parsedFile),
         ];
 
         $renderer = new TemplateRenderer($this->theme);
         $renderer->set($data);
         $out = $renderer->generate('Bake.Model/table');
 
-        $path = $this->getPath($args);
-        $filename = $path . 'Table' . DS . $name . 'Table.php';
-        $io->out("\n" . sprintf('Baking table class for %s...', $name), 1, ConsoleIo::NORMAL);
         $io->createFile($filename, $out, $args->getOption('force'));
 
         // Work around composer caching that classes/files do not exist.
@@ -1255,6 +1272,9 @@ class ModelCommand extends BakeCommand
         )->addArgument('name', [
             'help' => 'Name of the model to bake (without the Table suffix). ' .
                 'You can use Plugin.name to bake plugin models.',
+        ])->addOption('update', [
+            'boolean' => true,
+            'help' => 'Update generated methods in existing files. If the file doesn\'t exist it will be created.',
         ])->addOption('table', [
             'help' => 'The table name to use if you have non-conventional table names.',
         ])->addOption('no-entity', [

--- a/src/View/BakeView.php
+++ b/src/View/BakeView.php
@@ -45,8 +45,9 @@ class BakeView extends TwigView
     public function initialize(): void
     {
         $this->setConfig('environment', [
-          'cache' => false,
-          'strict_variables' => Configure::read('Bake.twigStrictVariables', false),
+            'autoescape' => false,
+            'cache' => false,
+            'strict_variables' => Configure::read('Bake.twigStrictVariables', false),
         ]);
 
         parent::initialize();

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -457,6 +457,42 @@ class BakeHelper extends Helper
     }
 
     /**
+     * Concats strings together.
+     *
+     * @param string $delimiter Delimiter to separate strings
+     * @param array<array<string>|string> $strings Strings to concatenate
+     * @param string $prefix Code to prepend if final output is not empty
+     * @param string $suffix Code to append if final output is not empty
+     * @return string
+     */
+    public function concat(
+        string $delimiter,
+        array $strings,
+        string $prefix = '',
+        string $suffix = ''
+    ): string {
+        $output = implode(
+            $delimiter,
+            array_map(function ($string) use ($delimiter) {
+                if (is_string($string)) {
+                    return $string;
+                }
+
+                return implode($delimiter, array_filter($string));
+            }, array_filter($strings))
+        );
+
+        if ($prefix && !empty($output)) {
+            $output = $prefix . $output;
+        }
+        if ($suffix && !empty($output)) {
+            $output .= $suffix;
+        }
+
+        return $output;
+    }
+
+    /**
      * To be mocked elsewhere...
      *
      * @param \Cake\ORM\Table $table Table

--- a/templates/bake/Model/entity.twig
+++ b/templates/bake/Model/entity.twig
@@ -23,17 +23,21 @@
 {% endif %}
 
 {%- set accessible = Bake.getFieldAccessibility(fields, primaryKey) %}
-<?php
-declare(strict_types=1);
 
-namespace {{ namespace }}\Model\Entity;
-
-use Cake\ORM\Entity;
+{%- set generatedProperties = [] %}
+{%- set uses = fileBuilder.uses(['Cake\\ORM\\Entity']) %}
+{{ element('Bake.file_header', {namespace: fileBuilder.namespace, uses: uses}) }}
 
 {{ DocBlock.classDescription(name, 'Entity', annotations)|raw }}
 class {{ name }} extends Entity
 {
+{% set userConstants = fileBuilder.classBuilder.userConstants([]) %}
+{% if userConstants %}
+    {{~ Bake.concat('\n\n', userConstants) }}
+
+{% endif %}
 {% if accessible %}
+{%- set generatedProperties = generatedProperties|merge(['_accessible']) %}
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().
      *
@@ -49,11 +53,22 @@ class {{ name }} extends Entity
 
 {% endif %}
 {%- if hidden %}
+{%- set generatedProperties = generatedProperties|merge(['_hidden']) %}
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
      * @var array<string>
      */
     protected $_hidden = {{ Bake.exportVar(hidden, 1)|raw }};
+{% endif %}
+{% set userProperties = fileBuilder.classBuilder.userProperties(generatedProperties) %}
+{% if userProperties %}
+
+    {{~ Bake.concat('\n\n', userProperties) }}
+{% endif %}
+{% set userFunctions = fileBuilder.classBuilder.userFunctions([]) %}
+{% if userFunctions %}
+
+    {{~ Bake.concat('\n\n', userFunctions) }}
 {% endif %}
 }

--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -14,17 +14,23 @@
  */
 #}
 {% set annotations = DocBlock.buildTableAnnotations(associations, associationInfo, behaviors, entity, namespace) %}
-<?php
-declare(strict_types=1);
-
-namespace {{ namespace }}\Model\Table;
-
-{% set uses = ['use Cake\\ORM\\Query;', 'use Cake\\ORM\\RulesChecker;', 'use Cake\\ORM\\Table;', 'use Cake\\Validation\\Validator;'] %}
-{{ uses|join('\n')|raw }}
+{% set generatedFunctions = ['initialize'] %}
+{% set uses = fileBuilder.uses(['Cake\\ORM\\Query', 'Cake\\ORM\\RulesChecker', 'Cake\\ORM\\Table', 'Cake\\Validation\\Validator'], [], []) %}
+{{ element('Bake.file_header', {namespace: fileBuilder.namespace, uses: uses}) }}
 
 {{ DocBlock.classDescription(name, 'Model', annotations)|raw }}
 class {{ name }}Table extends Table
 {
+{% set userConstants = fileBuilder.classBuilder.userConstants([]) %}
+{% if userConstants %}
+    {{~ Bake.concat('\n\n', userConstants) }}
+
+{% endif %}
+{% set userProperties = fileBuilder.classBuilder.userProperties([]) %}
+{% if userProperties %}
+    {{~ Bake.concat('\n\n', userProperties) }}
+
+{% endif %}
     /**
      * Initialize method
      *
@@ -81,6 +87,7 @@ class {{ name }}Table extends Table
 {{- "\n" }}
 
 {%- if validation %}
+{% set generatedFunctions = generatedFunctions|merge(['validationDefault']) %}
 
     /**
      * Default validation rules.
@@ -108,6 +115,7 @@ class {{ name }}Table extends Table
 {% endif %}
 
 {%- if rulesChecker %}
+{% set generatedFunctions = generatedFunctions|merge(['buildRules']) %}
 
     /**
      * Returns a rules checker object that will be used for validating
@@ -132,6 +140,7 @@ class {{ name }}Table extends Table
 {% endif %}
 
 {%- if connection is not same as('default') %}
+{% set generatedFunctions = generatedFunctions|merge(['defaultConnectionName']) %}
 
     /**
      * Returns the database connection name to use by default.
@@ -142,5 +151,10 @@ class {{ name }}Table extends Table
     {
         return '{{ connection }}';
     }
+{% endif %}
+{% set userFunctions = fileBuilder.classBuilder.userFunctions(generatedFunctions) %}
+{% if userFunctions %}
+
+    {{~ Bake.concat('\n\n', userFunctions) }}
 {% endif %}
 }

--- a/templates/bake/element/file_header.twig
+++ b/templates/bake/element/file_header.twig
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+
+namespace {{ namespace }};
+{{-  Bake.concat('\n', [uses.class ?? [], uses.function ?? [], uses.const ?? []], '\n\n') }}

--- a/tests/TestCase/CodeGen/ClassBuilderTest.php
+++ b/tests/TestCase/CodeGen/ClassBuilderTest.php
@@ -1,0 +1,124 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.8.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\TestCase\CodeGen;
+
+use Bake\CodeGen\CodeParser;
+use Bake\CodeGen\FileBuilder;
+use Bake\Test\TestCase\TestCase;
+
+class ClassBuilderTest extends TestCase
+{
+    public function testUserConstants(): void
+    {
+        $parser = new CodeParser();
+        $file = $parser->parseFile(
+            <<<'PARSE'
+<?php
+
+namespace MyApp\Model;
+
+class TestTable
+{
+    /**
+     * @var string
+     */
+    const GENERATED_CONST = 'string';
+
+    /**
+     * @var string
+     */
+    const MY_CONST = 3;
+
+    /**
+     * @param \Cake\ORM\Query $query Query
+     * @return \Cake\ORM\Query
+     */
+    public function findSomething(Query $query): Query
+    {
+    }
+}
+PARSE
+        );
+
+        $builder = new FileBuilder('MyApp\Model', $file);
+        $constants = $builder->classBuilder()->getUserConstants(['GENERATED_CONST']);
+        $this->assertSame(
+            [
+                'MY_CONST',
+            ],
+            array_keys($constants)
+        );
+    }
+
+    public function testUserFunctions(): void
+    {
+        $parser = new CodeParser();
+        $file = $parser->parseFile(
+            <<<'PARSE'
+<?php
+
+namespace MyApp\Model;
+
+use Cake\ORM\Query;
+use Cake\ORM\Table;
+
+class TestTable
+{
+    /**
+     * Returns a rules checker object that will be used for validating
+     * application integrity.
+     *
+     * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
+     * @return \Cake\ORM\RulesChecker
+     */
+    public function buildRules(RulesChecker $rules): RulesChecker
+    {
+        $rules->add($rules->isUnique(['username']), ['errorField' => 'username']);
+
+        return $rules;
+    }
+
+    /**
+     * @param \Cake\ORM\Query $query Query
+     * @return \Cake\ORM\Query
+     */
+    public function findSomething(Query $query): Query
+    {
+    }
+
+    /**
+     * @param \Cake\ORM\Query $query Query
+     * @return \Cake\ORM\Query
+     */
+    public function findSomethingElse(Query $query): Query
+    {
+    }
+}
+PARSE
+        );
+
+        $builder = new FileBuilder('MyApp\Model', $file);
+        $methods = $builder->classBuilder()->getUserFunctions(['buildRules']);
+        $this->assertSame(
+            [
+                'findSomething',
+                'findSomethingElse',
+            ],
+            array_keys($methods)
+        );
+    }
+}

--- a/tests/TestCase/CodeGen/CodeParserTest.php
+++ b/tests/TestCase/CodeGen/CodeParserTest.php
@@ -1,0 +1,226 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.8.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\TestCase\CodeGen;
+
+use Bake\CodeGen\CodeParser;
+use Bake\CodeGen\ParseException;
+use Bake\Test\TestCase\TestCase;
+
+class CodeParserTest extends TestCase
+{
+    public function testParseFile(): void
+    {
+        $parser = new CodeParser();
+        $file = $parser->parseFile(file_get_contents(APP . DS . 'Model' . DS . 'Table' . DS . 'ParseTestTable.php'));
+
+        $this->assertSame('Bake\Test\App\Model\Table', $file->namespace);
+        $this->assertSame('ParseTestTable', $file->class->name);
+        $this->assertSame(
+            [
+                'Query' => 'Cake\ORM\Query',
+                'RulesChecker' => 'Cake\ORM\RulesChecker',
+                'Table' => 'Cake\ORM\Table',
+                'Validator' => 'Cake\Validation\Validator',
+            ],
+            $file->imports['class']
+        );
+        $this->assertSame(
+            [
+                'SOME_CONST',
+            ],
+            array_keys($file->class->constants)
+        );
+        $this->assertSame(
+            [
+                'withDocProperty',
+                'withoutDocProperty',
+            ],
+            array_keys($file->class->properties)
+        );
+        $this->assertSame(
+            [
+                'initialize',
+                'buildRules',
+                'validationDefault',
+                'defaultConnectionName',
+                'findTest',
+            ],
+            array_keys($file->class->methods)
+        );
+
+        $code = <<<'PARSE'
+    /**
+     * @var int
+     */
+    protected const SOME_CONST = 1;
+PARSE;
+        $this->assertSame($code, $file->class->constants['SOME_CONST']);
+
+        $code = <<<'PARSE'
+    /**
+     * @var string
+     */
+    protected $withDocProperty = <<<'TEXT'
+    BLOCK OF TEXT
+TEXT;
+PARSE;
+        $this->assertSame($code, $file->class->properties['withDocProperty']);
+
+        $code = <<<'PARSE'
+    protected $withoutDocProperty = 1;
+PARSE;
+        $this->assertSame($code, $file->class->properties['withoutDocProperty']);
+
+        $code = <<<'PARSE'
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('test');
+        $this->setDisplayField('id');
+        $this->setPrimaryKey('id');
+    }
+PARSE;
+        $this->assertSame($code, $file->class->methods['initialize']);
+    }
+
+    public function testUseStatements(): void
+    {
+        $parser = new CodeParser();
+        $file = $parser->parseFile(<<<'PARSE'
+<?php
+
+namespace Test;
+
+use Test\Another\ClassA;
+use Test\Another\ClassC as C;
+
+use function Test\Another\test_func;
+use function Test\Another\test_func2 as new_func;
+
+use const Test\Another\TEST_CONSTANT;
+use const Test\Another\TEST_CONSTANT2 as NEW_CONSTANT;
+
+class TestTable{}
+PARSE
+        );
+
+        $this->assertSame(
+            [
+                'class' => [
+                    'ClassA' => 'Test\Another\ClassA',
+                    'C' => 'Test\Another\ClassC',
+                ],
+                'function' => [
+                    'test_func' => 'Test\Another\test_func',
+                    'new_func' => 'Test\Another\test_func2',
+
+                ],
+                'const' => [
+                    'TEST_CONSTANT' => 'Test\Another\TEST_CONSTANT',
+                    'NEW_CONSTANT' => 'Test\Another\TEST_CONSTANT2',
+                ],
+            ],
+            $file->imports
+        );
+    }
+
+    public function testParseMissingClass(): void
+    {
+        $parser = new CodeParser();
+
+        $file = $parser->parseFile(<<<'PARSE'
+<?php
+
+namespace Bake\Test;
+PARSE
+        );
+        $this->assertNull($file);
+    }
+
+    public function testParseMissingNamespace(): void
+    {
+        $parser = new CodeParser();
+
+        $this->expectException(ParseException::class);
+        $parser->parseFile(<<<'PARSE'
+<?php
+
+class TestTable{}
+PARSE
+        );
+    }
+
+    public function testParseMultipleNamespaces(): void
+    {
+        $parser = new CodeParser();
+
+        $this->expectException(ParseException::class);
+        $parser->parseFile(<<<'PARSE'
+<?php
+
+namespace Bake\Test;
+
+class TestTable{}
+
+namespace Bake\Test2;
+
+class Test2Table{}
+PARSE
+        );
+    }
+
+    public function testParseMultipleUses(): void
+    {
+        $parser = new CodeParser();
+
+        $this->expectException(ParseException::class);
+        $parser->parseFile(<<<'PARSE'
+<?php
+
+namespace Bake\Test;
+
+use Cake\ORM\Query, Cake\ORM\Table;
+
+class TestTable{}
+PARSE
+        );
+    }
+
+    public function testParseGroupUses(): void
+    {
+        $parser = new CodeParser();
+
+        $this->expectException(ParseException::class);
+        $parser->parseFile(<<<'PARSE'
+<?php
+
+namespace Bake\Test;
+
+use Cake\ORM\{Query, Table};
+
+class TestTable{}
+PARSE
+        );
+    }
+}

--- a/tests/TestCase/CodeGen/FileBuilderTest.php
+++ b/tests/TestCase/CodeGen/FileBuilderTest.php
@@ -1,0 +1,168 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         2.8.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\TestCase\CodeGen;
+
+use Bake\CodeGen\CodeParser;
+use Bake\CodeGen\FileBuilder;
+use Bake\CodeGen\ParseException;
+use Bake\Test\TestCase\TestCase;
+use Cake\Log\Log;
+
+class FileBuilderTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Log::drop('parser');
+    }
+
+    public function testMismatchedNamespace(): void
+    {
+        $parser = new CodeParser();
+        $file = $parser->parseFile(<<<'PARSE'
+<?php
+
+namespace MyApp\Model;
+
+class TestTable{}
+PARSE
+        );
+
+        $this->expectException(ParseException::class);
+        $builder = new FileBuilder('MyOtherApp\Model', $file);
+    }
+
+    public function testUses(): void
+    {
+        $parser = new CodeParser();
+        $file = $parser->parseFile(<<<'PARSE'
+<?php
+
+namespace MyApp\Model;
+
+use Cake\ORM\Table;
+use MyApp\Expression\MyExpression;
+use RuntimeException as MyException;
+use function MyApp\my_function;
+use function implode as custom_implode;
+use const MyApp\MY_CONSTANT;
+use const DATE_ATOM as CUSTOM_DATE;
+
+class TestTable{}
+PARSE
+        );
+
+        $builder = new FileBuilder('MyApp\Model', $file);
+
+        // Pass required imports out of order
+        $uses = $builder->getUses(['Table' => 'Cake\ORM\Table', 'Cake\ORM\Query']);
+        $this->assertSame(
+            [
+                'class' => [
+                    'use Cake\ORM\Query;',
+                    'use Cake\ORM\Table;',
+                    'use MyApp\Expression\MyExpression;',
+                    'use RuntimeException as MyException;',
+                ],
+                'function' => [
+                    'use function implode as custom_implode;',
+                    'use function MyApp\my_function;',
+                ],
+                'const' => [
+                    'use const DATE_ATOM as CUSTOM_DATE;',
+                    'use const MyApp\MY_CONSTANT;',
+                ],
+            ],
+            $uses
+        );
+
+        // Build without existing file
+        $builder = new FileBuilder('MyApp\Model');
+        $uses = $builder->getUses(['Cake\ORM\Table', 'Cake\ORM\Query'], ['implode'], ['DATE_ATOM']);
+        $this->assertSame(
+            [
+                'class' => [
+                    'use Cake\ORM\Query;',
+                    'use Cake\ORM\Table;',
+                ],
+                'function' => [
+                    'use function implode;',
+                ],
+                'const' => [
+                    'use const DATE_ATOM;',
+                ],
+            ],
+            $uses
+        );
+    }
+
+    public function testImportConflictUserClass(): void
+    {
+        Log::setConfig('parser', [
+            'className' => 'Array',
+            'levels' => ['warning'],
+        ]);
+
+        $parser = new CodeParser();
+        $file = $parser->parseFile(<<<'PARSE'
+<?php
+
+namespace MyApp\Model;
+
+use Cake\ORM\Query as MyQuery;
+
+class TestTable{}
+PARSE
+        );
+
+        $builder = new FileBuilder('MyApp\Model', $file);
+
+        $builder->getUses(['Cake\ORM\Query']);
+        $this->assertSame(
+            ['warning: User import `Cake\ORM\Query` conflicts with generated import, discarding'],
+            Log::engine('parser')->read()
+        );
+    }
+
+    public function testImportConflictUserAlias(): void
+    {
+        Log::setConfig('parser', [
+            'className' => 'Array',
+            'levels' => ['warning'],
+        ]);
+
+        $parser = new CodeParser();
+        $file = $parser->parseFile(<<<'PARSE'
+<?php
+
+namespace MyApp\Model;
+
+use MyApp\Query as Query;
+
+class TestTable{}
+PARSE
+        );
+
+        $builder = new FileBuilder('MyApp\Model', $file);
+
+        $builder->getUses(['Cake\ORM\Query']);
+        $this->assertSame(
+            ['warning: User import `MyApp\Query` conflicts with generated import, discarding'],
+            Log::engine('parser')->read()
+        );
+    }
+}

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -177,7 +177,8 @@ class TestCommandTest extends TestCase
         $this->assertOutputContains('3. BakeArticlesTable');
         $this->assertOutputContains('4. CategoryThreadsTable');
         $this->assertOutputContains('5. HiddenFieldsTable');
-        $this->assertOutputContains('6. TemplateTaskCommentsTable');
+        $this->assertOutputContains('6. ParseTestTable');
+        $this->assertOutputContains('7. TemplateTaskCommentsTable');
         $this->assertOutputContains('Re-run your command as `cake bake Table <classname>`');
     }
 

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -250,4 +250,34 @@ class BakeHelperTest extends TestCase
         ];
         $this->assertSame($expected, $result);
     }
+
+    public function testConcat(): void
+    {
+        $statements = [
+            'use Cake\ORM\Query;',
+            'use RuntimeException as MyException;',
+            '',
+        ];
+        $code = $this->BakeHelper->concat("\n", $statements);
+        $this->assertSame(
+            <<<'PARSE'
+use Cake\ORM\Query;
+use RuntimeException as MyException;
+PARSE
+            ,
+            $code
+        );
+
+        $code = $this->BakeHelper->concat("\n", $statements, "\n", "\n");
+        $this->assertSame(
+            <<<'PARSE'
+
+use Cake\ORM\Query;
+use RuntimeException as MyException;
+
+PARSE
+            ,
+            $code
+        );
+    }
 }

--- a/tests/comparisons/Model/testBakeUpdateEntity.php
+++ b/tests/comparisons/Model/testBakeUpdateEntity.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Model\Entity;
+
+use Cake\ORM\Entity;
+use MyApp\Test;
+
+/**
+ * TodoItem Entity
+ *
+ * @property int $id
+ * @property int $user_id
+ * @property string $title
+ * @property string|null $body
+ * @property string $effort
+ * @property bool $completed
+ * @property int $todo_task_count
+ * @property \Cake\I18n\FrozenTime|null $created
+ * @property \Cake\I18n\FrozenTime|null $updated
+ *
+ * @property \Bake\Test\App\Model\Entity\User $user
+ * @property \Bake\Test\App\Model\Entity\TodoReminder $todo_reminder
+ * @property \Bake\Test\App\Model\Entity\TodoTask[] $todo_tasks
+ * @property \Bake\Test\App\Model\Entity\TodoLabel[] $todo_labels
+ */
+class TodoItem extends Entity
+{
+    /**
+     * @var int
+     */
+    protected const MY_CONST = 1;
+
+    /**
+     * Fields that are excluded from JSON versions of the entity.
+     *
+     * @var array<string>
+     */
+    protected $_hidden = [
+        'user_id',
+    ];
+
+    protected $_accessible = [
+        // should not overwritten
+    ];
+
+    /**
+     * @var string
+     */
+    protected $myProperty = 'string';
+
+    protected function _getName(): string
+    {
+        return 'name';
+    }
+}

--- a/tests/comparisons/Model/testBakeUpdateTable.php
+++ b/tests/comparisons/Model/testBakeUpdateTable.php
@@ -1,0 +1,140 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+use RuntimeException as CustomException;
+
+/**
+ * TodoItems Model
+ *
+ * @property \Bake\Test\App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
+ * @property \Bake\Test\App\Model\Table\TodoRemindersTable&\Cake\ORM\Association\HasOne $TodoReminders
+ * @property \Bake\Test\App\Model\Table\TodoTasksTable&\Cake\ORM\Association\HasMany $TodoTasks
+ * @property \Bake\Test\App\Model\Table\TodoLabelsTable&\Cake\ORM\Association\BelongsToMany $TodoLabels
+ *
+ * @method \Bake\Test\App\Model\Entity\TodoItem newEmptyEntity()
+ * @method \Bake\Test\App\Model\Entity\TodoItem newEntity(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[] newEntities(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem get($primaryKey, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ *
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ */
+class TodoItemsTable extends Table
+{
+    /**
+     * @var int
+     */
+    protected const MY_CONST = 1;
+
+    /**
+     * @var string
+     */
+    protected $myProperty = 'string';
+
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('todo_items');
+        $this->setDisplayField('title');
+        $this->setPrimaryKey('id');
+
+        $this->addBehavior('Timestamp');
+
+        $this->belongsTo('Users', [
+            'foreignKey' => 'user_id',
+            'joinType' => 'INNER',
+        ]);
+        $this->hasOne('TodoReminders', [
+            'foreignKey' => 'todo_item_id',
+        ]);
+        $this->hasMany('TodoTasks', [
+            'foreignKey' => 'todo_item_id',
+        ]);
+        $this->belongsToMany('TodoLabels', [
+            'foreignKey' => 'todo_item_id',
+            'targetForeignKey' => 'todo_label_id',
+            'joinTable' => 'todo_items_todo_labels',
+        ]);
+    }
+
+    /**
+     * Default validation rules.
+     *
+     * @param \Cake\Validation\Validator $validator Validator instance.
+     * @return \Cake\Validation\Validator
+     */
+    public function validationDefault(Validator $validator): Validator
+    {
+        $validator
+            ->integer('user_id')
+            ->notEmptyString('user_id');
+
+        $validator
+            ->scalar('title')
+            ->maxLength('title', 50)
+            ->requirePresence('title', 'create')
+            ->notEmptyString('title');
+
+        $validator
+            ->scalar('body')
+            ->allowEmptyString('body');
+
+        $validator
+            ->decimal('effort')
+            ->notEmptyString('effort');
+
+        $validator
+            ->boolean('completed')
+            ->notEmptyString('completed');
+
+        $validator
+            ->integer('todo_task_count')
+            ->notEmptyString('todo_task_count');
+
+        return $validator;
+    }
+
+    /**
+     * Returns a rules checker object that will be used for validating
+     * application integrity.
+     *
+     * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
+     * @return \Cake\ORM\RulesChecker
+     */
+    public function buildRules(RulesChecker $rules): RulesChecker
+    {
+        // generation of this function is disabled by --no-rules and should stay
+
+        return $rules;
+    }
+
+    /**
+     */
+    public function findByPriority(Query $query): Query
+    {
+        throw new CustomException();
+
+        return $query;
+    }
+}

--- a/tests/comparisons/Model/testBakeUpdateTableNoFile.php
+++ b/tests/comparisons/Model/testBakeUpdateTableNoFile.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+/**
+ * TodoItems Model
+ *
+ * @property \Bake\Test\App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
+ * @property \Bake\Test\App\Model\Table\TodoRemindersTable&\Cake\ORM\Association\HasOne $TodoReminders
+ * @property \Bake\Test\App\Model\Table\TodoTasksTable&\Cake\ORM\Association\HasMany $TodoTasks
+ * @property \Bake\Test\App\Model\Table\TodoLabelsTable&\Cake\ORM\Association\BelongsToMany $TodoLabels
+ *
+ * @method \Bake\Test\App\Model\Entity\TodoItem newEmptyEntity()
+ * @method \Bake\Test\App\Model\Entity\TodoItem newEntity(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[] newEntities(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem get($primaryKey, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\TodoItem[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ *
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ */
+class TodoItemsTable extends Table
+{
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('todo_items');
+        $this->setDisplayField('title');
+        $this->setPrimaryKey('id');
+
+        $this->addBehavior('Timestamp');
+
+        $this->belongsTo('Users', [
+            'foreignKey' => 'user_id',
+            'joinType' => 'INNER',
+        ]);
+        $this->hasOne('TodoReminders', [
+            'foreignKey' => 'todo_item_id',
+        ]);
+        $this->hasMany('TodoTasks', [
+            'foreignKey' => 'todo_item_id',
+        ]);
+        $this->belongsToMany('TodoLabels', [
+            'foreignKey' => 'todo_item_id',
+            'targetForeignKey' => 'todo_label_id',
+            'joinTable' => 'todo_items_todo_labels',
+        ]);
+    }
+
+    /**
+     * Default validation rules.
+     *
+     * @param \Cake\Validation\Validator $validator Validator instance.
+     * @return \Cake\Validation\Validator
+     */
+    public function validationDefault(Validator $validator): Validator
+    {
+        $validator
+            ->integer('user_id')
+            ->notEmptyString('user_id');
+
+        $validator
+            ->scalar('title')
+            ->maxLength('title', 50)
+            ->requirePresence('title', 'create')
+            ->notEmptyString('title');
+
+        $validator
+            ->scalar('body')
+            ->allowEmptyString('body');
+
+        $validator
+            ->decimal('effort')
+            ->notEmptyString('effort');
+
+        $validator
+            ->boolean('completed')
+            ->notEmptyString('completed');
+
+        $validator
+            ->integer('todo_task_count')
+            ->notEmptyString('todo_task_count');
+
+        return $validator;
+    }
+
+    /**
+     * Returns a rules checker object that will be used for validating
+     * application integrity.
+     *
+     * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
+     * @return \Cake\ORM\RulesChecker
+     */
+    public function buildRules(RulesChecker $rules): RulesChecker
+    {
+        $rules->add($rules->existsIn('user_id', 'Users'), ['errorField' => 'user_id']);
+
+        return $rules;
+    }
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName(): string
+    {
+        return 'test';
+    }
+}

--- a/tests/test_app/App/Model/Table/ParseTestTable.php
+++ b/tests/test_app/App/Model/Table/ParseTestTable.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+/**
+ * ParseTestTable Model
+ *
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable newEmptyEntity()
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable newEntity(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[] newEntities(array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable get($primaryKey, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \Bake\Test\App\Model\Entity\ParseTestTable[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ */
+class ParseTestTable extends Table
+{
+    /**
+     * @var int
+     */
+    protected const SOME_CONST = 1;
+
+    /**
+     * @var string
+     */
+    protected $withDocProperty = <<<'TEXT'
+    BLOCK OF TEXT
+TEXT;
+
+    protected $withoutDocProperty = 1;
+
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('test');
+        $this->setDisplayField('id');
+        $this->setPrimaryKey('id');
+    }
+
+    /**
+     * Returns a rules checker object that will be used for validating
+     * application integrity.
+     *
+     * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
+     * @return \Cake\ORM\RulesChecker
+     */
+    public function buildRules(RulesChecker $rules): RulesChecker
+    {
+        $rules->add($rules->isUnique(['username']), ['errorField' => 'username']);
+
+        return $rules;
+    }
+
+    /**
+     * Default validation rules.
+     *
+     * @param \Cake\Validation\Validator $validator Validator instance.
+     * @return \Cake\Validation\Validator
+     */
+    public function validationDefault(Validator $validator): Validator
+    {
+        $validator
+            ->numeric('id')
+            ->allowEmptyString('id', 'create');
+
+        $validator
+            ->scalar('username')
+            ->maxLength('username', 100, 'Name must be shorter than 100 characters.')
+            ->requirePresence('username', 'create')
+            ->allowEmptyString('username', null, false);
+
+        return $validator;
+    }
+
+    /**
+     * Returns the database connection name to use by default.
+     *
+     * @return string
+     */
+    public static function defaultConnectionName(): string
+    {
+        return 'test';
+    }
+
+    /**
+     * @param \Cake\ORM\Query $query Finder query
+     * @param array $options Finder options
+     * @return \Cake\ORM\Query
+     */
+    public function findTest(Query $query, array $options): Query
+    {
+        return $query;
+    }
+}


### PR DESCRIPTION
Closes https://github.com/cakephp/bake/issues/709 https://github.com/cakephp/bake/issues/651

This adds a new option `--update` to ModelCommand which enables updating existing files with generated code.

Features:

- User defined code is kept in the generated file
  - Use statements
  - Class constants
  - Class properties
  - Class methods
- Use statements will be merged and sorted correctly
- Users can customize the file header to include project file comments using the new `Bake.file_header` template

Caveats: 

- All generated code will be overwritten
  - Some generated code can be disabled in which case the user-version will be kept
- Existing files must not use group use statements or multiple declarations per line (properties, constants)
  - This would result in re-writing the lines anyway so just requiring users to do it first
- User code will be appended after the generated code (constants after constants, properties after properties, etc)

This does not update tests generated for models.

This does not update behaviors as we only generate an empty template not specific to the model.