### PR TITLE
Add createTemplateRenderer() to BakeCommand

### DIFF
--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -19,11 +19,14 @@ namespace Bake\Command;
 use Bake\CodeGen\CodeParser;
 use Bake\CodeGen\ParsedFile;
 use Bake\Utility\CommonOptionsTrait;
+use Bake\Utility\TemplateRenderer;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Core\ConventionsTrait;
+use Cake\Event\Event;
+use Cake\Event\EventManager;
 use InvalidArgumentException;
 
 /**
@@ -150,6 +153,19 @@ abstract class BakeCommand extends Command
         }
 
         return str_replace('/', DIRECTORY_SEPARATOR, $path);
+    }
+
+    /**
+     * Creates a new instance of TemplateRenderer with theme set.
+     *
+     * @return \Bake\Utility\TemplateRenderer
+     */
+    public function createTemplateRenderer(): TemplateRenderer
+    {
+        $renderer = new TemplateRenderer($this->theme);
+        EventManager::instance()->dispatch(new Event('Bake.renderer', $renderer));
+
+        return $renderer;
     }
 
     /**

--- a/src/Command/ControllerCommand.php
+++ b/src/Command/ControllerCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Bake\Command;
 
 use Bake\Utility\TableScanner;
-use Bake\Utility\TemplateRenderer;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
@@ -177,10 +176,9 @@ class ControllerCommand extends BakeCommand
             'pluginPath' => null,
         ];
 
-        $renderer = new TemplateRenderer($this->theme);
-        $renderer->set($data);
-
-        $contents = $renderer->generate('Bake.Controller/controller');
+        $contents = $this->createTemplateRenderer()
+            ->set($data)
+            ->generate('Bake.Controller/controller');
 
         $path = $this->getPath($args);
         $filename = $path . $controllerName . 'Controller.php';

--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Bake\Command;
 
 use Bake\Utility\TableScanner;
-use Bake\Utility\TemplateRenderer;
 use Brick\VarExporter\VarExporter;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
@@ -261,13 +260,13 @@ class FixtureCommand extends BakeCommand
         $path = $this->getPath($args);
         $filename = $vars['name'] . 'Fixture.php';
 
-        $renderer = new TemplateRenderer($args->getOption('theme'));
-        $renderer->set('model', $model);
-        $renderer->set($vars);
-        $content = $renderer->generate('Bake.tests/fixture');
+        $contents = $this->createTemplateRenderer()
+            ->set('model', $model)
+            ->set($vars)
+            ->generate('Bake.tests/fixture');
 
         $io->out("\n" . sprintf('Baking test fixture for %s...', $model), 1, ConsoleIo::NORMAL);
-        $io->createFile($path . $filename, $content, $args->getOption('force'));
+        $io->createFile($path . $filename, $contents, $args->getOption('force'));
         $emptyFile = $path . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);
     }

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -18,7 +18,6 @@ namespace Bake\Command;
 
 use Bake\CodeGen\FileBuilder;
 use Bake\Utility\TableScanner;
-use Bake\Utility\TemplateRenderer;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
@@ -1129,11 +1128,11 @@ class ModelCommand extends BakeCommand
             'fileBuilder' => new FileBuilder("{$namespace}\Model\Entity", $parsedFile),
         ];
 
-        $renderer = new TemplateRenderer($this->theme);
-        $renderer->set($data);
-        $out = $renderer->generate('Bake.Model/entity');
+        $contents = $this->createTemplateRenderer()
+            ->set($data)
+            ->generate('Bake.Model/entity');
 
-        $io->createFile($filename, $out, $args->getOption('force'));
+        $io->createFile($filename, $contents, $args->getOption('force'));
 
         $emptyFile = $path . 'Entity' . DS . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);
@@ -1189,11 +1188,11 @@ class ModelCommand extends BakeCommand
             'fileBuilder' => new FileBuilder("{$namespace}\Model\Table", $parsedFile),
         ];
 
-        $renderer = new TemplateRenderer($this->theme);
-        $renderer->set($data);
-        $out = $renderer->generate('Bake.Model/table');
+        $contents = $this->createTemplateRenderer()
+            ->set($data)
+            ->generate('Bake.Model/table');
 
-        $io->createFile($filename, $out, $args->getOption('force'));
+        $io->createFile($filename, $contents, $args->getOption('force'));
 
         // Work around composer caching that classes/files do not exist.
         // Check for the file as it might not exist in tests.

--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -174,18 +174,18 @@ class PluginCommand extends BakeCommand
             true
         );
 
-        $renderer = new TemplateRenderer($args->getOption('theme'));
-        $renderer->set([
-            'name' => $name,
-            'package' => $package,
-            'namespace' => $namespace,
-            'baseNamespace' => $baseNamespace,
-            'plugin' => $pluginName,
-            'routePath' => Inflector::dasherize($pluginName),
-            'path' => $path,
-            'root' => ROOT,
-            'cakeVersion' => $composerConfig['require']['cakephp/cakephp'],
-        ]);
+        $renderer = $this->createTemplateRenderer()
+            ->set([
+                'name' => $name,
+                'package' => $package,
+                'namespace' => $namespace,
+                'baseNamespace' => $baseNamespace,
+                'plugin' => $pluginName,
+                'routePath' => Inflector::dasherize($pluginName),
+                'path' => $path,
+                'root' => ROOT,
+                'cakeVersion' => $composerConfig['require']['cakephp/cakephp'],
+            ]);
 
         $root = $path . $pluginName . DS;
 

--- a/src/Command/SimpleBakeCommand.php
+++ b/src/Command/SimpleBakeCommand.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Bake\Command;
 
-use Bake\Utility\TemplateRenderer;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
@@ -100,10 +99,10 @@ abstract class SimpleBakeCommand extends BakeCommand
      */
     protected function bake(string $name, Arguments $args, ConsoleIo $io): void
     {
-        $renderer = new TemplateRenderer($args->getOption('theme'));
-        $renderer->set('name', $name);
-        $renderer->set($this->templateData($args));
-        $contents = $renderer->generate($this->template());
+        $contents = $this->createTemplateRenderer()
+            ->set('name', $name)
+            ->set($this->templateData($args))
+            ->generate($this->template());
 
         $filename = $this->getPath($args) . $this->fileName($name);
         $io->createFile($filename, $contents, (bool)$args->getOption('force'));

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -18,7 +18,6 @@ namespace Bake\Command;
 
 use Bake\Utility\Model\AssociationFilter;
 use Bake\Utility\TableScanner;
-use Bake\Utility\TemplateRenderer;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
@@ -386,10 +385,10 @@ class TemplateCommand extends BakeCommand
             $vars['fields'] = array_diff($vars['fields'], $vars['hidden']);
         }
 
-        $renderer = new TemplateRenderer($args->getOption('theme'));
-        $renderer->set('action', $action);
-        $renderer->set('plugin', $this->plugin);
-        $renderer->set($vars);
+        $renderer = $this->createTemplateRenderer()
+            ->set('action', $action)
+            ->set('plugin', $this->plugin)
+            ->set($vars);
 
         $indexColumns = 0;
         if ($action === 'index' && $args->getOption('index-columns') !== null) {

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Bake\Command;
 
-use Bake\Utility\TemplateRenderer;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
@@ -279,32 +278,32 @@ class TestCommand extends BakeCommand
 
         $io->out("\n" . sprintf('Baking test case for %s ...', $fullClassName), 1, Shell::QUIET);
 
-        $renderer = new TemplateRenderer($this->theme);
-        $renderer->set('fixtures', $this->_fixtures);
-        $renderer->set('plugin', $this->plugin);
-        $renderer->set(compact(
-            'subject',
-            'className',
-            'properties',
-            'methods',
-            'type',
-            'fullClassName',
-            'mock',
-            'preConstruct',
-            'postConstruct',
-            'construction',
-            'uses',
-            'baseNamespace',
-            'subNamespace',
-            'namespace'
-        ));
-        $out = $renderer->generate('Bake.tests/test_case');
+        $contents = $this->createTemplateRenderer()
+            ->set('fixtures', $this->_fixtures)
+            ->set('plugin', $this->plugin)
+            ->set(compact(
+                'subject',
+                'className',
+                'properties',
+                'methods',
+                'type',
+                'fullClassName',
+                'mock',
+                'preConstruct',
+                'postConstruct',
+                'construction',
+                'uses',
+                'baseNamespace',
+                'subNamespace',
+                'namespace'
+            ))
+            ->generate('Bake.tests/test_case');
 
         $filename = $this->testCaseFileName($type, $fullClassName);
         $emptyFile = dirname($filename) . DS . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);
-        if ($io->createFile($filename, $out, $args->getOption('force'))) {
-            return $out;
+        if ($io->createFile($filename, $contents, $args->getOption('force'))) {
+            return $contents;
         }
 
         return false;

--- a/src/Utility/TemplateRenderer.php
+++ b/src/Utility/TemplateRenderer.php
@@ -42,7 +42,7 @@ class TemplateRenderer
     /**
      * Template theme
      *
-     * @var string
+     * @var string|null
      */
     protected $theme;
 
@@ -51,9 +51,9 @@ class TemplateRenderer
      *
      * @param ?string $theme The template theme/plugin to use.
      */
-    public function __construct(?string $theme = '')
+    public function __construct(?string $theme = null)
     {
-        $this->theme = $theme ?? '';
+        $this->theme = $theme;
     }
 
     /**


### PR DESCRIPTION
closes https://github.com/cakephp/bake/issues/721

This allows commands to add custom templates and other ViewBuilder options for each TemplateRenderer used.