### PR TITLE
Update regex for finding bake template files.

### DIFF
--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -203,7 +203,7 @@ class PluginCommand extends BakeCommand
             $templatesPath = array_shift($paths) . BakeView::BAKE_TEMPLATE_FOLDER . '/Plugin';
             if (is_dir($templatesPath)) {
                 $templates = array_keys(iterator_to_array(
-                    $fs->findRecursive($templatesPath, '/.*\.(twig|php)/')
+                    $fs->findRecursive($templatesPath, '/\.twig$/')
                 ));
             }
         } while (!$templates);


### PR DESCRIPTION
Support for old style php templates was dropped in 4.x.