### PR TITLE
Added `Middleware` to `TestCommand::classTypes`

### DIFF
--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -57,6 +57,7 @@ class TestCommand extends BakeCommand
         'Mailer' => 'Mailer',
         'Command' => 'Command',
         'CommandHelper' => 'Command\Helper',
+        'Middleware' => 'Middleware',
     ];
 
     /**
@@ -79,6 +80,7 @@ class TestCommand extends BakeCommand
         'Mailer' => 'Mailer',
         'Command' => 'Command',
         'CommandHelper' => 'Helper',
+        'Middleware' => 'Middleware',
     ];
 
     /**

--- a/tests/TestCase/Command/MiddlewareCommandTest.php
+++ b/tests/TestCase/Command/MiddlewareCommandTest.php
@@ -39,14 +39,14 @@ class MiddlewareCommandTest extends TestCase
     }
 
     /**
-     * Test the excute method.
+     * Test the execute method.
      *
      * @return void
      */
     public function testMain()
     {
         $this->generatedFile = APP . 'Middleware/ExampleMiddleware.php';
-        $this->exec('bake middleware example');
+        $this->exec('bake middleware example', ['y']);
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains('class ExampleMiddleware', $this->generatedFile);
@@ -63,7 +63,7 @@ class MiddlewareCommandTest extends TestCase
         $path = Plugin::path('TestBake');
 
         $this->generatedFile = $path . 'src/Middleware/ExampleMiddleware.php';
-        $this->exec('bake middleware TestBake.example');
+        $this->exec('bake middleware TestBake.example', ['y']);
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains('class ExampleMiddleware', $this->generatedFile);
@@ -80,7 +80,7 @@ class MiddlewareCommandTest extends TestCase
         $path = Plugin::path('TestBake');
 
         $this->generatedFile = $path . 'src/Middleware/ExampleMiddleware.php';
-        $this->exec('bake middleware TestBake.example');
+        $this->exec('bake middleware TestBake.example', ['y']);
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFile));

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -292,8 +292,6 @@ class TestCommandTest extends TestCase
             ['Task', 'ExampleTask', 'App\Shell\Task\ExampleTask'],
             ['Cell', 'Example', 'App\View\Cell\ExampleCell'],
             ['Cell', 'ExampleCell', 'App\View\Cell\ExampleCell'],
-            ['Middleware', 'Example', 'App\Middleware\ExampleMiddleware'],
-            ['Middleware', 'ExampleMiddleware', 'App\Middleware\ExampleMiddleware'],
         ];
     }
 
@@ -598,23 +596,6 @@ class TestCommandTest extends TestCase
     }
 
     /**
-     * test baking middleware test files
-     *
-     * @return void
-     */
-    public function testBakeMiddlewareTest()
-    {
-        $this->generatedFiles = [
-            ROOT . 'tests/TestCase/Middleware/ExampleMiddlewareTest.php',
-        ];
-        $this->exec('bake test Middleware ExampleMiddleware');
-
-        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
-        $this->assertFilesExist($this->generatedFiles);
-        $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
-    }
-
-    /**
      * Test baking an unknown class type.
      *
      * @return void
@@ -765,8 +746,6 @@ class TestCommandTest extends TestCase
             ],
             ['Shell', 'App\Shell\ExampleShell', 'TestCase/Shell/ExampleShellTest.php'],
             ['shell', 'App\Shell\ExampleShell', 'TestCase/Shell/ExampleShellTest.php'],
-            ['Middleware', 'App\Middleware\ExampleMiddleware', 'TestCase/Middleware/ExampleMiddlewareTest.php'],
-            ['middleware', 'App\Middleware\ExampleMiddleware', 'TestCase/Middleware/ExampleMiddlewareTest.php'],
         ];
     }
 
@@ -821,7 +800,6 @@ class TestCommandTest extends TestCase
             ['Behavior', 'Model\Behavior'],
             ['Helper', 'View\Helper'],
             ['ShellHelper', 'Shell\Helper'],
-            ['Middleware', 'Middleware'],
         ];
     }
 

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -292,6 +292,8 @@ class TestCommandTest extends TestCase
             ['Task', 'ExampleTask', 'App\Shell\Task\ExampleTask'],
             ['Cell', 'Example', 'App\View\Cell\ExampleCell'],
             ['Cell', 'ExampleCell', 'App\View\Cell\ExampleCell'],
+            ['Middleware', 'Example', 'App\Middleware\ExampleMiddleware'],
+            ['Middleware', 'ExampleMiddleware', 'App\Middleware\ExampleMiddleware'],
         ];
     }
 
@@ -589,6 +591,23 @@ class TestCommandTest extends TestCase
             ROOT . 'tests/TestCase/Shell/Helper/ExampleHelperTest.php',
         ];
         $this->exec('bake test shell_helper Example');
+
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+        $this->assertFilesExist($this->generatedFiles);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', file_get_contents($this->generatedFiles[0]));
+    }
+
+    /**
+     * test baking middleware test files
+     *
+     * @return void
+     */
+    public function testBakeMiddlewareTest()
+    {
+        $this->generatedFiles = [
+            ROOT . 'tests/TestCase/Middleware/ExampleMiddlewareTest.php',
+        ];
+        $this->exec('bake test Middleware ExampleMiddleware');
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -765,6 +765,8 @@ class TestCommandTest extends TestCase
             ],
             ['Shell', 'App\Shell\ExampleShell', 'TestCase/Shell/ExampleShellTest.php'],
             ['shell', 'App\Shell\ExampleShell', 'TestCase/Shell/ExampleShellTest.php'],
+            ['Middleware', 'App\Middleware\ExampleMiddleware', 'TestCase/Middleware/ExampleMiddlewareTest.php'],
+            ['middleware', 'App\Middleware\ExampleMiddleware', 'TestCase/Middleware/ExampleMiddlewareTest.php'],
         ];
     }
 
@@ -819,6 +821,7 @@ class TestCommandTest extends TestCase
             ['Behavior', 'Model\Behavior'],
             ['Helper', 'View\Helper'],
             ['ShellHelper', 'Shell\Helper'],
+            ['Middleware', 'Middleware'],
         ];
     }
 


### PR DESCRIPTION
resolves #875 

with this PR we can do
```shell
./bin/cake bake test middleware Sample1
```
Also, when baking a middleware, the test will automatically be generated
