### PR TITLE
3.x: change baked index method to use query instance instead of table

### DIFF
--- a/templates/bake/element/Controller/index.twig
+++ b/templates/bake/element/Controller/index.twig
@@ -22,11 +22,12 @@
     {
 {% set belongsTo = Bake.aliasExtractor(modelObj, 'BelongsTo') %}
 {% if belongsTo %}
-        $this->paginate = [
-            'contain' => {{ Bake.exportArray(belongsTo)|raw }},
-        ];
+        $query = $this->{{ currentModelName }}->find()
+            ->contain({{ Bake.exportArray(belongsTo)|raw }});
+{% else %}
+        $query = $this->{{ currentModelName }}->find();
 {% endif %}
-        ${{ pluralName }} = $this->paginate($this->{{ currentModelName }});
+        ${{ pluralName }} = $this->paginate($query);
 
         $this->set(compact('{{ pluralName }}'));
     }

--- a/tests/comparisons/Controller/testBakeActions.php
+++ b/tests/comparisons/Controller/testBakeActions.php
@@ -34,10 +34,9 @@ class BakeArticlesController extends AppController
      */
     public function index()
     {
-        $this->paginate = [
-            'contain' => ['BakeUsers'],
-        ];
-        $bakeArticles = $this->paginate($this->BakeArticles);
+        $query = $this->BakeArticles->find()
+            ->contain(['BakeUsers']);
+        $bakeArticles = $this->paginate($query);
 
         $this->set(compact('bakeArticles'));
     }

--- a/tests/comparisons/Controller/testBakeActionsContent.php
+++ b/tests/comparisons/Controller/testBakeActionsContent.php
@@ -18,10 +18,9 @@ class BakeArticlesController extends AppController
      */
     public function index()
     {
-        $this->paginate = [
-            'contain' => ['BakeUsers'],
-        ];
-        $bakeArticles = $this->paginate($this->BakeArticles);
+        $query = $this->BakeArticles->find()
+            ->contain(['BakeUsers']);
+        $bakeArticles = $this->paginate($query);
 
         $this->set(compact('bakeArticles'));
     }

--- a/tests/comparisons/Controller/testBakeWithPlugin.php
+++ b/tests/comparisons/Controller/testBakeWithPlugin.php
@@ -20,10 +20,9 @@ class BakeArticlesController extends AppController
      */
     public function index()
     {
-        $this->paginate = [
-            'contain' => ['BakeUsers'],
-        ];
-        $bakeArticles = $this->paginate($this->BakeArticles);
+        $query = $this->BakeArticles->find()
+            ->contain(['BakeUsers']);
+        $bakeArticles = $this->paginate($query);
 
         $this->set(compact('bakeArticles'));
     }


### PR DESCRIPTION
This is my proposal to change the default generated `paginate()` method to use a query instance instead of the table instance.

I never really used that approach because in the end I always created a query instance which then gets adjusted/modified/extended by other typical query methods (`where()`, `contain()`, `orderDesc()` etc.) and therefore this would just be a little more clearer for newbies as well instead of the "magic" that `paginate()` just uses the table instance and the `paginate` property of the current controller.

Sure one can easily create their own bake template where they can overwrite pretty much everything but that will only happen after spending quite some time with the framework.

Curious what you guys have to say about that 😄 