### PR TITLE
Fix up closing of queries.

### DIFF
--- a/templates/bake/element/Controller/add.twig
+++ b/templates/bake/element/Controller/add.twig
@@ -37,7 +37,7 @@
 {%- for assoc in associations %}
     {%- set otherName = Bake.getAssociatedTableAlias(modelObj, assoc) %}
     {%- set otherPlural = otherName|variable %}
-        ${{ otherPlural }} = $this->{{ currentModelName }}->{{ otherName }}->find('list', ['limit' => 200])->all();
+        ${{ otherPlural }} = $this->{{ currentModelName }}->{{ otherName }}->find('list', ['limit' => 200])->toArray();
         {{- "\n" }}
     {%- set compact = compact|merge(["'#{otherPlural}'"]) %}
 {% endfor %}

--- a/templates/bake/element/Controller/edit.twig
+++ b/templates/bake/element/Controller/edit.twig
@@ -40,7 +40,7 @@
 {% for assoc in belongsTo|merge(belongsToMany) %}
     {%- set otherName = Bake.getAssociatedTableAlias(modelObj, assoc) %}
     {%- set otherPlural = otherName|variable %}
-        ${{ otherPlural }} = $this->{{ currentModelName }}->{{ otherName }}->find('list', ['limit' => 200])->all();
+        ${{ otherPlural }} = $this->{{ currentModelName }}->{{ otherName }}->find('list', ['limit' => 200])->toArray();
         {{- "\n" }}
     {%- set compact = compact|merge(["'#{otherPlural}'"]) %}
 {% endfor %}

--- a/tests/comparisons/Controller/testBakeActions.php
+++ b/tests/comparisons/Controller/testBakeActions.php
@@ -75,8 +75,8 @@ class BakeArticlesController extends AppController
             }
             $this->Flash->error(__('The bake article could not be saved. Please, try again.'));
         }
-        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->all();
-        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->all();
+        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->toArray();
+        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->toArray();
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
     }
 
@@ -101,8 +101,8 @@ class BakeArticlesController extends AppController
             }
             $this->Flash->error(__('The bake article could not be saved. Please, try again.'));
         }
-        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->all();
-        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->all();
+        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->toArray();
+        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->toArray();
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
     }
 

--- a/tests/comparisons/Controller/testBakeActionsContent.php
+++ b/tests/comparisons/Controller/testBakeActionsContent.php
@@ -59,8 +59,8 @@ class BakeArticlesController extends AppController
             }
             $this->Flash->error(__('The bake article could not be saved. Please, try again.'));
         }
-        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->all();
-        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->all();
+        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->toArray();
+        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->toArray();
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
     }
 
@@ -85,8 +85,8 @@ class BakeArticlesController extends AppController
             }
             $this->Flash->error(__('The bake article could not be saved. Please, try again.'));
         }
-        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->all();
-        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->all();
+        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->toArray();
+        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->toArray();
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
     }
 

--- a/tests/comparisons/Controller/testBakeWithPlugin.php
+++ b/tests/comparisons/Controller/testBakeWithPlugin.php
@@ -61,8 +61,8 @@ class BakeArticlesController extends AppController
             }
             $this->Flash->error(__('The bake article could not be saved. Please, try again.'));
         }
-        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->all();
-        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->all();
+        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->toArray();
+        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->toArray();
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
     }
 
@@ -87,8 +87,8 @@ class BakeArticlesController extends AppController
             }
             $this->Flash->error(__('The bake article could not be saved. Please, try again.'));
         }
-        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->all();
-        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->all();
+        $bakeUsers = $this->BakeArticles->BakeUsers->find('list', ['limit' => 200])->toArray();
+        $bakeTags = $this->BakeArticles->BakeTags->find('list', ['limit' => 200])->toArray();
         $this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
     }
 


### PR DESCRIPTION
I dont see the point in using all() for those array lists if it doesnt solve the issue of it being handled afterwards

> Cannot use object of type Cake\Datasource\ResultSetDecorator as array

Using toArray() is IMO expected here to close this instead to have an array to work with and easily append or prepend elements for the list.