### PR TITLE
3.x: narrow down baked controller return types

### DIFF
--- a/templates/bake/Controller/controller.twig
+++ b/templates/bake/Controller/controller.twig
@@ -17,9 +17,12 @@
  * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 #}
+{%- set uses = ['Cake\\Http\\Response'] -%}
+{%- set uses = (plugin or prefix) ? uses|merge(["#{baseNamespace}\\Controller\\AppController"]) : uses -%}
+
 {{ element('Bake.file_header', {
     namespace: "#{namespace}\\Controller#{prefix}",
-    classImports: (plugin or prefix) ? ["#{baseNamespace}\\Controller\\AppController"] : [],
+    classImports: uses,
 }) }}
 
 /**

--- a/templates/bake/element/Controller/delete.twig
+++ b/templates/bake/element/Controller/delete.twig
@@ -20,7 +20,7 @@
      * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete($id = null)
+    public function delete($id = null): ?Response
     {
         $this->request->allowMethod(['post', 'delete']);
         ${{ singularName }} = $this->{{ currentModelName }}->get($id);

--- a/templates/bake/element/Controller/index.twig
+++ b/templates/bake/element/Controller/index.twig
@@ -16,9 +16,9 @@
     /**
      * Index method
      *
-     * @return \Cake\Http\Response|null|void Renders view
+     * @return void Renders view
      */
-    public function index()
+    public function index(): void
     {
 {% set belongsTo = Bake.aliasExtractor(modelObj, 'BelongsTo') %}
 {% if belongsTo %}

--- a/templates/bake/element/Controller/view.twig
+++ b/templates/bake/element/Controller/view.twig
@@ -21,10 +21,10 @@
      * View method
      *
      * @param string|null $id {{ singularHumanName }} id.
-     * @return \Cake\Http\Response|null|void Renders view
+     * @return void Renders view
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function view($id = null)
+    public function view($id = null): void
     {
         ${{ singularName }} = $this->{{ currentModelName }}->get($id, [
             'contain' => {{ Bake.exportArray(allAssociations)|raw }},

--- a/tests/comparisons/Controller/testBakeActions.php
+++ b/tests/comparisons/Controller/testBakeActions.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Controller;
 
+use Cake\Http\Response;
+
 /**
  * BakeArticles Controller
  *
@@ -29,9 +31,9 @@ class BakeArticlesController extends AppController
     /**
      * Index method
      *
-     * @return \Cake\Http\Response|null|void Renders view
+     * @return void Renders view
      */
-    public function index()
+    public function index(): void
     {
         $query = $this->BakeArticles->find()
             ->contain(['BakeUsers']);
@@ -44,10 +46,10 @@ class BakeArticlesController extends AppController
      * View method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null|void Renders view
+     * @return void Renders view
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function view($id = null)
+    public function view($id = null): void
     {
         $bakeArticle = $this->BakeArticles->get($id, [
             'contain' => ['BakeUsers', 'BakeTags', 'BakeComments'],
@@ -111,7 +113,7 @@ class BakeArticlesController extends AppController
      * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete($id = null)
+    public function delete($id = null): ?Response
     {
         $this->request->allowMethod(['post', 'delete']);
         $bakeArticle = $this->BakeArticles->get($id);

--- a/tests/comparisons/Controller/testBakeActionsContent.php
+++ b/tests/comparisons/Controller/testBakeActionsContent.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Controller;
 
+use Cake\Http\Response;
+
 /**
  * BakeArticles Controller
  *
@@ -13,9 +15,9 @@ class BakeArticlesController extends AppController
     /**
      * Index method
      *
-     * @return \Cake\Http\Response|null|void Renders view
+     * @return void Renders view
      */
-    public function index()
+    public function index(): void
     {
         $query = $this->BakeArticles->find()
             ->contain(['BakeUsers']);
@@ -28,10 +30,10 @@ class BakeArticlesController extends AppController
      * View method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null|void Renders view
+     * @return void Renders view
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function view($id = null)
+    public function view($id = null): void
     {
         $bakeArticle = $this->BakeArticles->get($id, [
             'contain' => ['BakeUsers', 'BakeTags', 'BakeComments'],
@@ -95,7 +97,7 @@ class BakeArticlesController extends AppController
      * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete($id = null)
+    public function delete($id = null): ?Response
     {
         $this->request->allowMethod(['post', 'delete']);
         $bakeArticle = $this->BakeArticles->get($id);

--- a/tests/comparisons/Controller/testBakeActionsOption.php
+++ b/tests/comparisons/Controller/testBakeActionsOption.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Controller;
 
+use Cake\Http\Response;
+
 /**
  * BakeArticles Controller
  *

--- a/tests/comparisons/Controller/testBakeComponents.php
+++ b/tests/comparisons/Controller/testBakeComponents.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Controller;
 
+use Cake\Http\Response;
+
 /**
  * BakeArticles Controller
  *

--- a/tests/comparisons/Controller/testBakeNoActions.php
+++ b/tests/comparisons/Controller/testBakeNoActions.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Bake\Test\App\Controller;
 
+use Cake\Http\Response;
+
 /**
  * BakeArticles Controller
  *

--- a/tests/comparisons/Controller/testBakeWithPlugin.php
+++ b/tests/comparisons/Controller/testBakeWithPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace BakeTest\Controller;
 
 use Bake\Test\App\Controller\AppController;
+use Cake\Http\Response;
 
 /**
  * BakeArticles Controller
@@ -15,9 +16,9 @@ class BakeArticlesController extends AppController
     /**
      * Index method
      *
-     * @return \Cake\Http\Response|null|void Renders view
+     * @return void Renders view
      */
-    public function index()
+    public function index(): void
     {
         $query = $this->BakeArticles->find()
             ->contain(['BakeUsers']);
@@ -30,10 +31,10 @@ class BakeArticlesController extends AppController
      * View method
      *
      * @param string|null $id Bake Article id.
-     * @return \Cake\Http\Response|null|void Renders view
+     * @return void Renders view
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function view($id = null)
+    public function view($id = null): void
     {
         $bakeArticle = $this->BakeArticles->get($id, [
             'contain' => ['BakeUsers', 'BakeTags', 'BakeComments'],
@@ -97,7 +98,7 @@ class BakeArticlesController extends AppController
      * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete($id = null)
+    public function delete($id = null): ?Response
     {
         $this->request->allowMethod(['post', 'delete']);
         $bakeArticle = $this->BakeArticles->get($id);


### PR DESCRIPTION
This PR adds return types to baked controllers `index`, `view` and `delete` methods since they can be defined as such.

`add` and `edit` need to stay as they are (unless we want to change that)

Also: We shouldn't generate PHPDoc's if the generated code doesn't represent that.
