### PR TITLE
2.x: make sure the configured plugin directory exists before baking a plugin

### DIFF
--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -102,6 +102,9 @@ class PluginCommand extends BakeCommand
         if (count($pathOptions) > 1) {
             $this->findPath($pathOptions, $io);
         }
+        if (!is_dir($this->path)) {
+            mkdir($this->path);
+        }
         $io->out(sprintf('<info>Plugin Name:</info> %s', $plugin));
         $io->out(sprintf('<info>Plugin Directory:</info> %s', $this->path . $plugin));
         $io->hr();


### PR DESCRIPTION
Closes #909 