### PR TITLE
Fix error when trying to bake with non-existent plugins directory.

### DIFF
--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -383,7 +383,7 @@ class PluginCommand extends BakeCommand
         ])->addOption('theme', [
             'short' => 't',
             'help' => 'The theme to use when baking code.',
-            'default' => Configure::read('Bake.theme') ?? '',
+            'default' => Configure::read('Bake.theme') ?: null,
             'choices' => $this->_getBakeThemes(),
         ]);
 

--- a/tests/TestCase/Command/PluginCommandTest.php
+++ b/tests/TestCase/Command/PluginCommandTest.php
@@ -34,6 +34,8 @@ class PluginCommandTest extends TestCase
 {
     protected $testAppFile = APP . 'Application.php';
 
+    protected $pluginsPath = TMP . 'plugin_task' . DS;
+
     /**
      * setUp method
      *
@@ -47,11 +49,10 @@ class PluginCommandTest extends TestCase
         $this->useCommandRunner();
 
         // Output into a safe place.
-        $path = TMP . 'plugin_task' . DS;
-        Configure::write('App.paths.plugins', [$path]);
+        Configure::write('App.paths.plugins', [$this->pluginsPath]);
 
         // Create the test output path
-        mkdir($path, 0777, true);
+        mkdir($this->pluginsPath, 0777, true);
 
         if (file_exists(APP . 'Application.php.bak')) {
             rename(APP . 'Application.php.bak', APP . 'Application.php');
@@ -68,7 +69,7 @@ class PluginCommandTest extends TestCase
     public function tearDown(): void
     {
         $fs = new Filesystem();
-        $fs->deleteDir(TMP . 'plugin_task');
+        $fs->deleteDir($this->pluginsPath);
 
         if (file_exists(APP . 'Application.php.bak')) {
             rename(APP . 'Application.php.bak', APP . 'Application.php');
@@ -84,6 +85,16 @@ class PluginCommandTest extends TestCase
      */
     public function testMainBakePluginContents()
     {
+        $this->exec('bake plugin SimpleExample', ['y', 'n']);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+        $this->assertPluginContents('SimpleExample');
+    }
+
+    public function testBakingWithNonExistentPluginsDir()
+    {
+        $fs = new Filesystem();
+        $fs->deleteDir($this->pluginsPath);
+
         $this->exec('bake plugin SimpleExample', ['y', 'n']);
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertPluginContents('SimpleExample');
@@ -211,7 +222,7 @@ class PluginCommandTest extends TestCase
         $result = $command->findPath($paths, $io);
 
         $this->assertNull($result, 'no return');
-        $this->assertSame(TMP . 'plugin_task' . DS, $command->path);
+        $this->assertSame($this->pluginsPath, $command->path);
     }
 
     /**


### PR DESCRIPTION
This was caused due to `Bake.theme` option defaulting to empty string instead of null and hence a plugin with empty name was being searched causing an exception.

Closes #909