### PR TITLE
Add `allow-alias-relations` option to bake model command

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -363,7 +363,7 @@ class ModelCommand extends BakeCommand
                     get_class($associationTable) === Table::class &&
                     !in_array(Inflector::tableize($tmpModelName), $tables, true)
                 ) {
-                    $allowAliasRelations = $args && $args->getOption('allow-alias-relations');
+                    $allowAliasRelations = $args && $args->getOption('skip-relation-check');
                     $found = $this->findTableReferencedBy($schema, $fieldName);
                     if ($found) {
                         $tmpModelName = Inflector::camelize($found);
@@ -1322,9 +1322,10 @@ class ModelCommand extends BakeCommand
         ])->addOption('no-fixture', [
             'boolean' => true,
             'help' => 'Do not generate a test fixture skeleton.',
-        ])->addOption('allow-alias-relations', [
+        ])->addOption('skip-relation-check', [
             'boolean' => true,
-            'help' => 'Skip checks for existing tables of has one relations, e.g. for an example_id field.',
+            'help' => 'Generate relations for all "example_id" fields'
+            . ' without checking the database if a table "examples" exists.',
         ])->setEpilog(
             'Omitting all arguments and options will list the table names you can generate models for.'
         );

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -329,7 +329,7 @@ class ModelCommand extends BakeCommand
      *
      * @param \Cake\ORM\Table $model Database\Table instance of table being generated.
      * @param array $associations Array of in progress associations
-     * @param Arguments|null $args
+     * @param \Cake\Console\Arguments|null $args CLI arguments
      * @return array Associations with belongsTo added in.
      */
     public function findBelongsTo(Table $model, array $associations, ?Arguments $args = null): array

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -492,7 +492,7 @@ class ModelCommandTest extends TestCase
 
     /**
      * Test that association generation adds `Anythings` association for `anything_id` field
-     * when using `--allow-alias-relations` option, even if no db table exists
+     * when using `--skip-relation-check` option, even if no db table exists
      *
      * @return void
      */
@@ -504,7 +504,7 @@ class ModelCommandTest extends TestCase
         $command = new ModelCommand();
         $command->connection = 'test';
 
-        $args = new Arguments([], ['allow-alias-relations' => true], []);
+        $args = new Arguments([], ['skip-relation-check' => true], []);
         $io = $this->createMock(ConsoleIo::class);
         $result = $command->getAssociations($items, $args, $io);
         $expected = [

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -491,6 +491,59 @@ class ModelCommandTest extends TestCase
     }
 
     /**
+     * Test that association generation adds `Anythings` association for `anything_id` field
+     * when using `--allow-alias-relations` option, even if no db table exists
+     *
+     * @return void
+     */
+    public function testGetAssociationsAddAssociationIfNoTableExistButAliasIsAllowed()
+    {
+        $items = $this->getTableLocator()->get('TodoItems');
+
+        $items->setSchema($items->getSchema()->addColumn('anything_id', ['type' => 'integer']));
+        $command = new ModelCommand();
+        $command->connection = 'test';
+
+        $args = new Arguments([], ['allow-alias-relations' => true], []);
+        $io = $this->createMock(ConsoleIo::class);
+        $result = $command->getAssociations($items, $args, $io);
+        $expected = [
+            'belongsTo' => [
+                [
+                    'alias' => 'Users',
+                    'foreignKey' => 'user_id',
+                    'joinType' => 'INNER',
+                ],
+                [
+                    'alias' => 'Anythings',
+                    'foreignKey' => 'anything_id',
+                ],
+            ],
+            'hasMany' => [
+                [
+                    'alias' => 'TodoTasks',
+                    'foreignKey' => 'todo_item_id',
+                ],
+            ],
+            'belongsToMany' => [
+                [
+                    'alias' => 'TodoLabels',
+                    'foreignKey' => 'todo_item_id',
+                    'joinTable' => 'todo_items_todo_labels',
+                    'targetForeignKey' => 'todo_label_id',
+                ],
+            ],
+            'hasOne' => [
+                [
+                    'alias' => 'TodoReminders',
+                    'foreignKey' => 'todo_item_id',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test that association generation ignores `_id` fields
      *
      * @return void


### PR DESCRIPTION
Since PR https://github.com/cakephp/bake/pull/842 which was merged into [2.7.1](https://github.com/cakephp/bake/releases/tag/2.7.1), the bake model command skips the generation of relation-code, if the table does not actually exist in the database. 

This might be unwanted behaviour for some more edge-case scenarios, e.g. when one table is used for multiple alias relations. 

E.g., if you have an `addresses` table, you might want to have a field `delivery_address_id` and `invoice_address_id` on your `customers` table, while using the same table and `Address` entity for both of them. You would just have to set the `className` option for the two relations, so that they both point to a field `addresses.id`. 

Since `2.7.1`, the relations are not baked anymore, because there is no actual `delivery_addresses` table in the database.

This PR introduces a new option `--allow-alias-relations` to skip the check for an existing table and to bake the relation code anyway. 

Related issue: 
https://github.com/cakephp/bake/issues/912 