### PR TITLE
Fixes application Bake templates path in Document

### DIFF
--- a/docs/en/development.rst
+++ b/docs/en/development.rst
@@ -226,7 +226,7 @@ dependencies in your templates you can include template overrides in your
 application templates. These overrides work similar to overriding other plugin
 templates.
 
-#. Create a new directory **/templates/plugin/Bake/**.
+#. Create a new directory **/templates/plugin/Bake/bake/**.
 #. Copy any templates you want to override from
    **vendor/cakephp/bake/templates/bake/** to matching files in your
    application.


### PR DESCRIPTION
In the documentation, there is a possibility that users may place files incorrectly, because the template path on the application side does not include "bake".