### PR TITLE
Revert template override path change.

### DIFF
--- a/docs/en/development.rst
+++ b/docs/en/development.rst
@@ -226,7 +226,7 @@ dependencies in your templates you can include template overrides in your
 application templates. These overrides work similar to overriding other plugin
 templates.
 
-#. Create a new directory **/templates/plugin/Bake/bake/**.
+#. Create a new directory **/templates/plugin/Bake/**.
 #. Copy any templates you want to override from
    **vendor/cakephp/bake/templates/bake/** to matching files in your
    application.


### PR DESCRIPTION
Application overrides do not use the `/bake` subdirectory.

https://github.com/cakephp/bake/blob/e310c84265cd015feba6e702c3ec1b80c3cc0670/src/View/BakeView.php#L130-L133

Reverts #915