### PR TITLE
3.x: remove composer.json adjustments while baking a plugin

### DIFF
--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -115,9 +115,25 @@ class PluginCommand extends BakeCommand
         }
 
         $this->_generateFiles($plugin, $this->path, $args, $io);
-
-        $this->_modifyAutoloader($plugin, $this->path, $args, $io);
         $this->_modifyApplication($plugin, $io);
+
+        $composer = $this->findComposer($args, $io);
+
+        try {
+            $cwd = getcwd();
+
+            // Windows makes running multiple commands at once hard.
+            chdir(dirname($this->_rootComposerFilePath()));
+            $command = 'php ' . escapeshellarg($composer) . ' dump-autoload';
+            $process = new Process($io);
+            $io->out($process->call($command));
+
+            chdir($cwd);
+        } catch (RuntimeException $e) {
+            $error = $e->getMessage();
+            $io->error(sprintf('Could not run `composer dump-autoload`: %s', $error));
+            $this->abort();
+        }
 
         $io->hr();
         $io->out(sprintf('<success>Created:</success> %s in %s', $plugin, $this->path . $plugin), 2);
@@ -165,7 +181,7 @@ class PluginCommand extends BakeCommand
 
         $name = $pluginName;
         $vendor = 'your-name-here';
-        if (strpos($pluginName, '/') !== false) {
+        if (str_contains($pluginName, '/')) {
             [$vendor, $name] = explode('/', $pluginName);
         }
         $package = Inflector::dasherize($vendor) . '/' . Inflector::dasherize($name);
@@ -241,69 +257,6 @@ class PluginCommand extends BakeCommand
         $io->out(sprintf('Generating %s file...', $template));
         $out = $renderer->generate('Bake.Plugin/' . $template);
         $io->createFile($root . $filename, $out);
-    }
-
-    /**
-     * Modifies App's composer.json to include the plugin and tries to call
-     * composer dump-autoload to refresh the autoloader cache
-     *
-     * @param string $plugin Name of plugin
-     * @param string $path The path to save the phpunit.xml file to.
-     * @param \Cake\Console\Arguments $args The Arguments instance.
-     * @param \Cake\Console\ConsoleIo $io The io instance.
-     * @return bool True if composer could be modified correctly
-     */
-    protected function _modifyAutoloader(
-        string $plugin,
-        string $path,
-        Arguments $args,
-        ConsoleIo $io
-    ): bool {
-        $file = $this->_rootComposerFilePath();
-
-        if (!file_exists($file)) {
-            $io->out(sprintf('<info>Main composer file %s not found</info>', $file));
-
-            return false;
-        }
-
-        $autoloadPath = str_replace(ROOT . DS, '', $this->path);
-        $autoloadPath = str_replace('\\', '/', $autoloadPath);
-        $namespace = str_replace('/', '\\', $plugin);
-
-        $config = json_decode(file_get_contents($file), true);
-        $config['autoload']['psr-4'][$namespace . '\\'] = $autoloadPath . $plugin . '/src/';
-        $config['autoload-dev']['psr-4'][$namespace . '\\Test\\'] = $autoloadPath . $plugin . '/tests/';
-
-        $io->out('<info>Modifying composer autoloader</info>');
-
-        $out = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n";
-        $io->createFile($file, $out, $this->force);
-
-        $composer = $this->findComposer($args, $io);
-
-        if (!$composer) {
-            $io->error('Could not locate composer. Add composer to your PATH, or use the --composer option.');
-            $this->abort();
-        }
-
-        try {
-            $cwd = getcwd();
-
-            // Windows makes running multiple commands at once hard.
-            chdir(dirname($this->_rootComposerFilePath()));
-            $command = 'php ' . escapeshellarg($composer) . ' dump-autoload';
-            $process = new Process($io);
-            $io->out($process->call($command));
-
-            chdir($cwd);
-        } catch (RuntimeException $e) {
-            $error = $e->getMessage();
-            $io->error(sprintf('Could not run `composer dump-autoload`: %s', $error));
-            $this->abort();
-        }
-
-        return true;
     }
 
     /**

--- a/templates/bake/Plugin/composer.json.twig
+++ b/templates/bake/Plugin/composer.json.twig
@@ -24,7 +24,7 @@
         "cakephp/cakephp": "{{ cakeVersion|raw }}"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.19"
+        "phpunit/phpunit": "^10.1"
     },
     "autoload": {
         "psr-4": {

--- a/tests/TestCase/Command/PluginCommandTest.php
+++ b/tests/TestCase/Command/PluginCommandTest.php
@@ -178,25 +178,6 @@ class PluginCommandTest extends TestCase
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
-        $result = json_decode(file_get_contents(ROOT . 'composer.json'), true);
-        $this->assertArrayHasKey('autoload', $result);
-        $this->assertArrayHasKey('psr-4', $result['autoload']);
-        $this->assertArrayHasKey('ComposerExample\\', $result['autoload']['psr-4']);
-
-        $this->assertArrayHasKey('autoload-dev', $result);
-        $this->assertArrayHasKey('psr-4', $result['autoload-dev']);
-        $this->assertArrayHasKey('ComposerExample\\Test\\', $result['autoload-dev']['psr-4']);
-
-        $pluginPath = App::path('plugins')[0];
-        $this->assertSame(
-            $pluginPath . 'ComposerExample' . DS . 'src' . DS,
-            $result['autoload']['psr-4']['ComposerExample\\']
-        );
-        $this->assertSame(
-            $pluginPath . 'ComposerExample' . DS . 'tests' . DS,
-            $result['autoload-dev']['psr-4']['ComposerExample\\Test\\']
-        );
-
         // Restore
         copy(ROOT . 'composer.json.bak', $composerConfig);
         unlink(ROOT . 'composer.json.bak');

--- a/tests/comparisons/Plugin/Company/Example/composer.json
+++ b/tests/comparisons/Plugin/Company/Example/composer.json
@@ -8,7 +8,7 @@
         "cakephp/cakephp": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.19"
+        "phpunit/phpunit": "^10.1"
     },
     "autoload": {
         "psr-4": {

--- a/tests/comparisons/Plugin/SimpleExample/composer.json
+++ b/tests/comparisons/Plugin/SimpleExample/composer.json
@@ -8,7 +8,7 @@
         "cakephp/cakephp": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.19"
+        "phpunit/phpunit": "^10.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
We don't need to adjust the root composer.json any more.