### PR TITLE
3.x: use `hasValue()` instead of `has()`

### DIFF
--- a/templates/bake/Template/index.twig
+++ b/templates/bake/Template/index.twig
@@ -43,7 +43,7 @@
 {% for alias, details in associations.BelongsTo %}
 {% if field == details.foreignKey %}
 {% set isKey = true %}
-                    <td><?= ${{ singularVar }}->has('{{ details.property }}') ? $this->Html->link(${{ singularVar }}->{{ details.property }}->{{ details.displayField }}, ['controller' => '{{ details.controller }}', 'action' => 'view', ${{ singularVar }}->{{ details.property }}->{{ details.primaryKey[0] }}]) : '' ?></td>
+                    <td><?= ${{ singularVar }}->hasValue('{{ details.property }}') ? $this->Html->link(${{ singularVar }}->{{ details.property }}->{{ details.displayField }}, ['controller' => '{{ details.controller }}', 'action' => 'view', ${{ singularVar }}->{{ details.property }}->{{ details.primaryKey[0] }}]) : '' ?></td>
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/templates/bake/Template/view.twig
+++ b/templates/bake/Template/view.twig
@@ -45,7 +45,7 @@
 {% set details = associationFields[field] %}
                 <tr>
                     <th><?= __('{{ details.property|humanize }}') ?></th>
-                    <td><?= ${{ singularVar }}->has('{{ details.property }}') ? $this->Html->link(${{ singularVar }}->{{ details.property }}->{{ details.displayField }}, ['controller' => '{{ details.controller }}', 'action' => 'view', ${{ singularVar }}->{{ details.property }}->{{ details.primaryKey[0] }}]) : '' ?></td>
+                    <td><?= ${{ singularVar }}->hasValue('{{ details.property }}') ? $this->Html->link(${{ singularVar }}->{{ details.property }}->{{ details.displayField }}, ['controller' => '{{ details.controller }}', 'action' => 'view', ${{ singularVar }}->{{ details.property }}->{{ details.primaryKey[0] }}]) : '' ?></td>
                 </tr>
 {% else %}
                 <tr>
@@ -59,7 +59,7 @@
 {% for alias, details in associations.HasOne %}
                 <tr>
                     <th><?= __('{{ alias|underscore|singularize|humanize }}') ?></th>
-                    <td><?= ${{ singularVar }}->has('{{ details.property }}') ? $this->Html->link(${{ singularVar }}->{{ details.property }}->{{ details.displayField }}, ['controller' => '{{ details.controller }}', 'action' => 'view', ${{ singularVar }}->{{ details.property }}->{{ details.primaryKey[0] }}]) : '' ?></td>
+                    <td><?= ${{ singularVar }}->hasValue('{{ details.property }}') ? $this->Html->link(${{ singularVar }}->{{ details.property }}->{{ details.displayField }}, ['controller' => '{{ details.controller }}', 'action' => 'view', ${{ singularVar }}->{{ details.property }}->{{ details.primaryKey[0] }}]) : '' ?></td>
                 </tr>
 {% endfor %}
 {% endif %}

--- a/tests/comparisons/Template/testBakeIndex.php
+++ b/tests/comparisons/Template/testBakeIndex.php
@@ -24,7 +24,7 @@
                 <?php foreach ($templateTaskComments as $templateTaskComment): ?>
                 <tr>
                     <td><?= $this->Number->format($templateTaskComment->id) ?></td>
-                    <td><?= $templateTaskComment->has('article') ? $this->Html->link($templateTaskComment->article->title, ['controller' => 'Articles', 'action' => 'view', $templateTaskComment->article->id]) : '' ?></td>
+                    <td><?= $templateTaskComment->hasValue('article') ? $this->Html->link($templateTaskComment->article->title, ['controller' => 'Articles', 'action' => 'view', $templateTaskComment->article->id]) : '' ?></td>
                     <td><?= $this->Number->format($templateTaskComment->user_id) ?></td>
                     <td><?= h($templateTaskComment->published) ?></td>
                     <td><?= h($templateTaskComment->created) ?></td>

--- a/tests/comparisons/Template/testBakeIndexWithIndexLimit.php
+++ b/tests/comparisons/Template/testBakeIndexWithIndexLimit.php
@@ -21,7 +21,7 @@
                 <?php foreach ($templateTaskComments as $templateTaskComment): ?>
                 <tr>
                     <td><?= $this->Number->format($templateTaskComment->id) ?></td>
-                    <td><?= $templateTaskComment->has('article') ? $this->Html->link($templateTaskComment->article->title, ['controller' => 'Articles', 'action' => 'view', $templateTaskComment->article->id]) : '' ?></td>
+                    <td><?= $templateTaskComment->hasValue('article') ? $this->Html->link($templateTaskComment->article->title, ['controller' => 'Articles', 'action' => 'view', $templateTaskComment->article->id]) : '' ?></td>
                     <td><?= $this->Number->format($templateTaskComment->user_id) ?></td>
                     <td class="actions">
                         <?= $this->Html->link(__('View'), ['action' => 'view', $templateTaskComment->id]) ?>

--- a/tests/comparisons/Template/testBakeView.php
+++ b/tests/comparisons/Template/testBakeView.php
@@ -20,7 +20,7 @@
             <table>
                 <tr>
                     <th><?= __('Role') ?></th>
-                    <td><?= $author->has('role') ? $this->Html->link($author->role->name, ['controller' => 'Roles', 'action' => 'view', $author->role->id]) : '' ?></td>
+                    <td><?= $author->hasValue('role') ? $this->Html->link($author->role->name, ['controller' => 'Roles', 'action' => 'view', $author->role->id]) : '' ?></td>
                 </tr>
                 <tr>
                     <th><?= __('Name') ?></th>
@@ -28,7 +28,7 @@
                 </tr>
                 <tr>
                     <th><?= __('Profile') ?></th>
-                    <td><?= $author->has('profile') ? $this->Html->link($author->profile->nick, ['controller' => 'Profiles', 'action' => 'view', $author->profile->id]) : '' ?></td>
+                    <td><?= $author->hasValue('profile') ? $this->Html->link($author->profile->nick, ['controller' => 'Profiles', 'action' => 'view', $author->profile->id]) : '' ?></td>
                 </tr>
                 <tr>
                     <th><?= __('Id') ?></th>


### PR DESCRIPTION
Refs: #931 

As explained in the issue the `EntityTrait::has()` now returns true if a property is `null`.

To keep the already established behaviour in baked code this should now be changed to `hasValue()`