### PR TITLE
Try new dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "cakephp/cakephp": "^5.0.0",
         "cakephp/twig-view": "^2.0.0",
-        "brick/varexporter": "^0.3.5",
+        "brick/varexporter": "^0.4.0",
         "nikic/php-parser": "^4.13.2"
     },
     "require-dev": {


### PR DESCRIPTION
Outdated dependency alert:

  - brick/varexporter (0.3.8) latest is 0.4.0
  
According to https://github.com/brick/varexporter/releases/tag/0.4.0 no real changes...
It was a bit nonsense to release a new major here

Anyway, we should probably also backport this to 2.x as `0.3 || 0.4`