### PR TITLE
Fix config array type.

### DIFF
--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -36,7 +36,7 @@ class {{ name }}Table extends Table{{ fileBuilder.classBuilder.implements ? ' im
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/TestCase/CodeGen/CodeParserTest.php
+++ b/tests/TestCase/CodeGen/CodeParserTest.php
@@ -92,7 +92,7 @@ PARSE;
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
@@ -33,7 +33,7 @@ class CategoriesProductsTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
@@ -34,7 +34,7 @@ class CategoriesTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
@@ -34,7 +34,7 @@ class CategoriesTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
@@ -32,7 +32,7 @@ class OldProductsTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTableSigned.php
@@ -32,7 +32,7 @@ class OldProductsTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
@@ -32,7 +32,7 @@ class ProductVersionsTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
@@ -32,7 +32,7 @@ class ProductVersionsTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -37,7 +37,7 @@ class ItemsTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeTableNullableForeignKey.php
+++ b/tests/comparisons/Model/testBakeTableNullableForeignKey.php
@@ -32,7 +32,7 @@ class TestBakeArticlesTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeTableRules.php
+++ b/tests/comparisons/Model/testBakeTableRules.php
@@ -30,7 +30,7 @@ class UniqueFieldsTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeTableValidation.php
+++ b/tests/comparisons/Model/testBakeTableValidation.php
@@ -32,7 +32,7 @@ class TestBakeArticlesTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeTableWithCounterCache.php
+++ b/tests/comparisons/Model/testBakeTableWithCounterCache.php
@@ -35,7 +35,7 @@ class TodoTasksTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeTableWithPlugin.php
+++ b/tests/comparisons/Model/testBakeTableWithPlugin.php
@@ -35,7 +35,7 @@ class UsersTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeUpdateTable.php
+++ b/tests/comparisons/Model/testBakeUpdateTable.php
@@ -49,7 +49,7 @@ class TodoItemsTable extends Table implements SomeInterface
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeUpdateTableNoFile.php
+++ b/tests/comparisons/Model/testBakeUpdateTableNoFile.php
@@ -37,7 +37,7 @@ class TodoItemsTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/comparisons/Model/testBakeWithRulesUnique.php
+++ b/tests/comparisons/Model/testBakeWithRulesUnique.php
@@ -35,7 +35,7 @@ class UsersTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/test_app/App/Model/Table/AuthorsTable.php
+++ b/tests/test_app/App/Model/Table/AuthorsTable.php
@@ -23,7 +23,7 @@ use Cake\ORM\Table;
 class AuthorsTable extends Table
 {
     /**
-     * @param array $config
+     * @param array<string, mixed> $config
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/test_app/App/Model/Table/ParseTestTable.php
+++ b/tests/test_app/App/Model/Table/ParseTestTable.php
@@ -46,7 +46,7 @@ TEXT;
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param array<string, mixed> $config The configuration for the Table.
      * @return void
      */
     public function initialize(array $config): void

--- a/tests/test_app/Plugin/BakeTest/src/Model/Table/BakeArticlesTable.php
+++ b/tests/test_app/Plugin/BakeTest/src/Model/Table/BakeArticlesTable.php
@@ -24,7 +24,7 @@ use Cake\ORM\Table;
 class BakeArticlesTable extends Table
 {
     /**
-     * @param array $config
+     * @param array<string, mixed> $config
      * @return void
      */
     public function initialize(array $config): void


### PR DESCRIPTION
Freshly baked tables fail in PHPStan due to the config array docblock
```
  Line   src/Model/Table/ApplesTable.php                                                                                              
 ------ ----------------------------------------------------------------------------------------------------------------------------- 
  38     Method App\Model\Table\ApplesTable::initialize() has parameter $config with no value type specified in iterable type array.  
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                    
 ------ ----------------------------------------------------------------------------------------------------------------------------- 

```

This fixes it