### PR TITLE
Update DocBlockHelper.php allow different date and time classes

### DIFF
--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -226,8 +226,8 @@ class DocBlockHelper extends Helper
 
             case 'time':
                 $dbType = TypeFactory::build($type);
-                if (method_exists($dbType, 'getDateTimeClassName')) {
-                    return '\\' . $dbType->getDateTimeClassName();
+                if (method_exists($dbType, 'getTimeClassName')) {
+                    return '\\' . $dbType->getTimeClassName();
                 }
 
                 return '\Cake\I18n\Time';

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -204,6 +204,8 @@ class DocBlockHelper extends Helper
                 $dbType = TypeFactory::build($type);
                 if (method_exists($dbType, 'getDateClassName')) {
                     return '\\' . $dbType->getDateClassName();
+                } elseif (method_exists($dbType, 'getDateTimeClassName')) {
+                    return '\\' . $dbType->getDateTimeClassName();
                 }
 
                 return '\Cake\I18n\Date';
@@ -214,7 +216,9 @@ class DocBlockHelper extends Helper
             case 'timestampfractional':
             case 'timestamptimezone':
                 $dbType = TypeFactory::build($type);
-                if (method_exists($dbType, 'getDateTimeClassName')) {
+                if (method_exists($dbType, 'getDateClassName')) {
+                    return '\\' . $dbType->getDateClassName();
+                } elseif (method_exists($dbType, 'getDateTimeClassName')) {
                     return '\\' . $dbType->getDateTimeClassName();
                 }
 

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -5,6 +5,7 @@ namespace Bake\View\Helper;
 
 use Cake\Collection\Collection;
 use Cake\Core\App;
+use Cake\Database\TypeFactory;
 use Cake\ORM\Association;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
@@ -200,6 +201,13 @@ class DocBlockHelper extends Helper
                 return 'string|resource';
 
             case 'date':
+                $dbType = TypeFactory::build($type);
+                if (method_exists($dbType, 'getDateClassName')) {
+                    return '\\' . $dbType->getDateClassName();
+                } elseif (method_exists($dbType, 'getDateTimeClassName')) {
+                    return '\\' . $dbType->getDateTimeClassName();
+                }
+
                 return '\Cake\I18n\Date';
 
             case 'datetime':
@@ -207,9 +215,19 @@ class DocBlockHelper extends Helper
             case 'timestamp':
             case 'timestampfractional':
             case 'timestamptimezone':
+                $dbType = TypeFactory::build($type);
+                if (method_exists($dbType, 'getDateTimeClassName')) {
+                    return '\\' . $dbType->getDateTimeClassName();
+                }
+
                 return '\Cake\I18n\DateTime';
 
             case 'time':
+                $dbType = TypeFactory::build($type);
+                if (method_exists($dbType, 'getDateTimeClassName')) {
+                    return '\\' . $dbType->getDateTimeClassName();
+                }
+
                 return '\Cake\I18n\Time';
         }
 

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -203,6 +203,7 @@ class DocBlockHelper extends Helper
             case 'date':
                 $dbType = TypeFactory::build($type);
                 if (method_exists($dbType, 'getDateClassName')) {
+                    // allow custom Date class which should extend \Cake\I18n\Date
                     return '\\' . $dbType->getDateClassName();
                 }
 
@@ -215,6 +216,7 @@ class DocBlockHelper extends Helper
             case 'timestamptimezone':
                 $dbType = TypeFactory::build($type);
                 if (method_exists($dbType, 'getDateTimeClassName')) {
+                    // allow custom DateTime class which should extend \Cake\I18n\DateTime
                     return '\\' . $dbType->getDateTimeClassName();
                 }
 
@@ -223,6 +225,7 @@ class DocBlockHelper extends Helper
             case 'time':
                 $dbType = TypeFactory::build($type);
                 if (method_exists($dbType, 'getTimeClassName')) {
+                    // allow custom Time class which should extend \Cake\I18n\Time
                     return '\\' . $dbType->getTimeClassName();
                 }
 

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -204,8 +204,6 @@ class DocBlockHelper extends Helper
                 $dbType = TypeFactory::build($type);
                 if (method_exists($dbType, 'getDateClassName')) {
                     return '\\' . $dbType->getDateClassName();
-                } elseif (method_exists($dbType, 'getDateTimeClassName')) {
-                    return '\\' . $dbType->getDateTimeClassName();
                 }
 
                 return '\Cake\I18n\Date';
@@ -216,9 +214,7 @@ class DocBlockHelper extends Helper
             case 'timestampfractional':
             case 'timestamptimezone':
                 $dbType = TypeFactory::build($type);
-                if (method_exists($dbType, 'getDateClassName')) {
-                    return '\\' . $dbType->getDateClassName();
-                } elseif (method_exists($dbType, 'getDateTimeClassName')) {
+                if (method_exists($dbType, 'getDateTimeClassName')) {
                     return '\\' . $dbType->getDateTimeClassName();
                 }
 

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -204,8 +204,6 @@ class DocBlockHelper extends Helper
                 $dbType = TypeFactory::build($type);
                 if (method_exists($dbType, 'getDateClassName')) {
                     return '\\' . $dbType->getDateClassName();
-                } elseif (method_exists($dbType, 'getDateTimeClassName')) {
-                    return '\\' . $dbType->getDateTimeClassName();
                 }
 
                 return '\Cake\I18n\Date';


### PR DESCRIPTION
since CakePHP 5.0 the overwritten DateTime or Date class is not used anymore for annotation.
I can't get Checks to pass, but I think it is clear what I want to achieve. It worked in the previous major version.