### PR TITLE
Update annotation order

### DIFF
--- a/docs/en/development.rst
+++ b/docs/en/development.rst
@@ -145,7 +145,7 @@ looks like this::
         *
         * @param \Cake\Console\Arguments $args The command arguments.
         * @param \Cake\Console\ConsoleIo $io The console io
-        * @return null|void|int The exit code or null for success
+        * @return int|null|void The exit code or null for success
         */
         public function execute(Arguments $args, ConsoleIo $io)
         {
@@ -188,7 +188,7 @@ And the resultant baked class (**src/Command/FooCommand.php**) looks like this::
         *
         * @param \Cake\Console\Arguments $args The command arguments.
         * @param \Cake\Console\ConsoleIo $io The console io
-        * @return null|void|int The exit code or null for success
+        * @return int|null|void The exit code or null for success
         */
         public function execute(Arguments $args, ConsoleIo $io)
         {

--- a/docs/fr/development.rst
+++ b/docs/fr/development.rst
@@ -153,7 +153,7 @@ ressemble à ceci::
         *
         * @param \Cake\Console\Arguments $args Les arguments de la commande.
         * @param \Cake\Console\ConsoleIo $io La console il
-        * @return null|void|int Le code de sortie ou null pour un succès
+        * @return int|null|void Le code de sortie ou null pour un succès
         */
         public function execute(Arguments $args, ConsoleIo $io)
         {
@@ -197,7 +197,7 @@ ressemble à ceci::
         *
         * @param \Cake\Console\Arguments $args Les arguments de la commande.
         * @param \Cake\Console\ConsoleIo $io La console io
-        * @return null|void|int Le code de sortie ou null pour un succès
+        * @return int|null|void Le code de sortie ou null pour un succès
         */
         public function execute(Arguments $args, ConsoleIo $io)
         {

--- a/templates/bake/Command/command.twig
+++ b/templates/bake/Command/command.twig
@@ -47,7 +47,7 @@ class {{ name }}Command extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|void|int The exit code or null for success
+     * @return int|null|void The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {

--- a/tests/comparisons/Command/testBakePlugin.php
+++ b/tests/comparisons/Command/testBakePlugin.php
@@ -32,7 +32,7 @@ class ExampleCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|void|int The exit code or null for success
+     * @return int|null|void The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {


### PR DESCRIPTION
PHPCS expects `@return int|null|void`.

```php
@return type hint is not formatted properly, expected "int|null|void"
```