### PR TITLE
Add @phpcsSuppress to `Command::execute`

### DIFF
--- a/templates/bake/Command/command.twig
+++ b/templates/bake/Command/command.twig
@@ -48,6 +48,7 @@ class {{ name }}Command extends Command
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return null|void|int The exit code or null for success
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {

--- a/tests/comparisons/Command/testBakePlugin.php
+++ b/tests/comparisons/Command/testBakePlugin.php
@@ -33,6 +33,7 @@ class ExampleCommand extends Command
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return null|void|int The exit code or null for success
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {


### PR DESCRIPTION
PHPCS will complain about missing return-type hints when you bake your first command. 

```php
Method \App\Command\AppCommand::execute() does not have native return type hint for its return value but it should be possible to add it based on @return
    |       |     annotation "int|null|void".
```

PHPCBF then adds `: int|null|null` 🤔 