### PR TITLE
3.next - Fix unique constraints getting lost.

### DIFF
--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -128,13 +128,13 @@ class {{ name }}Table extends Table{{ fileBuilder.classBuilder.implements ? ' im
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-{% for field, rule in rulesChecker %}
-{% set fields = rule.fields is defined ? Bake.exportArray(rule.fields) : Bake.exportVar(field) %}
+{% for rule in rulesChecker %}
+{% set fields = Bake.exportArray(rule.fields) %}
 {% set options = '' %}
 {% for optionName, optionValue in rule.options %}
     {%~ set options = (loop.first ? '[' : options) ~ "'#{optionName}' => " ~ Bake.exportVar(optionValue) ~ (loop.last ? ']' : ', ') %}
 {% endfor %}
-        $rules->add($rules->{{ rule.name }}({{ fields|raw }}{{ (rule.extra|default ? ", '#{rule.extra}'" : '')|raw }}{{ (options ? ', ' ~ options : '')|raw }}), ['errorField' => '{{ field }}']);
+        $rules->add($rules->{{ rule.name }}({{ fields|raw }}{{ (rule.extra|default ? ", '#{rule.extra}'" : '')|raw }}{{ (options ? ', ' ~ options : '')|raw }}), ['errorField' => '{{ rule.fields[0] }}']);
 {% endfor %}
 
         return $rules;

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
@@ -63,8 +63,8 @@ class CategoriesProductsTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->existsIn('category_id', 'Categories'), ['errorField' => 'category_id']);
-        $rules->add($rules->existsIn('product_id', 'Products'), ['errorField' => 'product_id']);
+        $rules->add($rules->existsIn(['category_id'], 'Categories'), ['errorField' => 'category_id']);
+        $rules->add($rules->existsIn(['product_id'], 'Products'), ['errorField' => 'product_id']);
 
         return $rules;
     }

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
@@ -78,7 +78,7 @@ class ProductVersionsTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->existsIn('product_id', 'Products'), ['errorField' => 'product_id']);
+        $rules->add($rules->existsIn(['product_id'], 'Products'), ['errorField' => 'product_id']);
 
         return $rules;
     }

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
@@ -78,7 +78,7 @@ class ProductVersionsTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->existsIn('product_id', 'Products'), ['errorField' => 'product_id']);
+        $rules->add($rules->existsIn(['product_id'], 'Products'), ['errorField' => 'product_id']);
 
         return $rules;
     }

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -113,7 +113,7 @@ class ItemsTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->existsIn('user_id', 'Users'), ['errorField' => 'user_id']);
+        $rules->add($rules->existsIn(['user_id'], 'Users'), ['errorField' => 'user_id']);
 
         return $rules;
     }

--- a/tests/comparisons/Model/testBakeTableWithCounterCache.php
+++ b/tests/comparisons/Model/testBakeTableWithCounterCache.php
@@ -66,7 +66,7 @@ class TodoTasksTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->existsIn('todo_item_id', 'TodoItems'), ['errorField' => 'todo_item_id']);
+        $rules->add($rules->existsIn(['todo_item_id'], 'TodoItems'), ['errorField' => 'todo_item_id']);
 
         return $rules;
     }

--- a/tests/comparisons/Model/testBakeUpdateTableNoFile.php
+++ b/tests/comparisons/Model/testBakeUpdateTableNoFile.php
@@ -113,7 +113,7 @@ class TodoItemsTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->existsIn('user_id', 'Users'), ['errorField' => 'user_id']);
+        $rules->add($rules->existsIn(['user_id'], 'Users'), ['errorField' => 'user_id']);
 
         return $rules;
     }


### PR DESCRIPTION
When using the first column of the constraints and foreign keys to index the rules array, constraints and foreign keys that share the same first column in the composite constraint will overwrite previously set rules.

Now that is kind of a breaking change for people that are using custom table templates and/or custom model commands, but I don't really see a good way to fix this in a backwards compatible manner without awkward workarounds that will eventually still have pitfalls. Maybe this should rather go in a not yet existent 3.next?

Ideally there would be support for multiple error fields, as setting the error on the first field only is kinda awkward. Any opinions on that?

refs #957