### PR TITLE
Make backing type a bool, since it defaults anyway on 1 of 2 options.

### DIFF
--- a/src/Command/EnumCommand.php
+++ b/src/Command/EnumCommand.php
@@ -18,7 +18,6 @@ namespace Bake\Command;
 
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleOptionParser;
-use InvalidArgumentException;
 
 /**
  * Enum code generator.
@@ -66,7 +65,7 @@ class EnumCommand extends SimpleBakeCommand
     public function templateData(Arguments $arguments): array
     {
         $data = parent::templateData($arguments);
-        $data['backingType'] = $arguments->getOption('backing-type');
+        $data['backingType'] = $arguments->getOption('integer') ? 'int' : 'string';
 
         return $data;
     }
@@ -83,11 +82,10 @@ class EnumCommand extends SimpleBakeCommand
 
         $parser->setDescription(
             'Bake backed enums for use in models.'
-        )->addOption('backing-type', [
-            'help' => 'The return type for the backed enum class',
-            'default' => 'string',
-            'choices' => ['string', 'int'],
-            'short' => 'b',
+        )->addOption('integer', [
+            'help' => 'Using backed enums with int instead of string as return type',
+            'boolean' => true,
+            'short' => 'i',
         ]);
 
         return $parser;

--- a/src/Command/EnumCommand.php
+++ b/src/Command/EnumCommand.php
@@ -65,7 +65,7 @@ class EnumCommand extends SimpleBakeCommand
     public function templateData(Arguments $arguments): array
     {
         $data = parent::templateData($arguments);
-        $data['backingType'] = $arguments->getOption('integer') ? 'int' : 'string';
+        $data['backingType'] = $arguments->getOption('int') ? 'int' : 'string';
 
         return $data;
     }
@@ -82,7 +82,7 @@ class EnumCommand extends SimpleBakeCommand
 
         $parser->setDescription(
             'Bake backed enums for use in models.'
-        )->addOption('integer', [
+        )->addOption('int', [
             'help' => 'Using backed enums with int instead of string as return type',
             'boolean' => true,
             'short' => 'i',

--- a/tests/TestCase/Command/EnumCommandTest.php
+++ b/tests/TestCase/Command/EnumCommandTest.php
@@ -61,7 +61,7 @@ class EnumCommandTest extends TestCase
     public function testBakeEnumBackedInt()
     {
         $this->generatedFile = APP . 'Model/Enum/FooBar.php';
-        $this->exec('bake enum FooBar -b int', ['y']);
+        $this->exec('bake enum FooBar -i', ['y']);
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileExists($this->generatedFile);


### PR DESCRIPTION
https://github.com/cakephp/bake/pull/968

I would still like to at least propose this for consideration.
Given that there are now only 2 - and string by default, it seems kind of overkill to have a full option for it.
It seems `-i` could suffice?