### PR TITLE
Check PHP Parser v5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "brick/varexporter": "^0.4.0",
         "cakephp/cakephp": "^5.0.0",
         "cakephp/twig-view": "^2.0.0",
-        "nikic/php-parser": "^4.13.2"
+        "nikic/php-parser": "^4.13.2 || ^5.0.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.0.0",


### PR DESCRIPTION
My app reported:
```
packages are not up to date:

  - nikic/php-parser (v4.18.0) latest is v5.0.0


brick/varexporter         0.4.0   requires nikic/php-parser (^4.0)          
cakephp/bake              3.0.5   requires nikic/php-parser (^4.13.2)       
phpunit/php-code-coverage 10.1.11 requires nikic/php-parser (^4.18 || ^5.0) 
sebastian/complexity      3.2.0   requires nikic/php-parser (^4.18 || ^5.0) 
sebastian/lines-of-code   2.0.2   requires nikic/php-parser (^4.18 || ^5.0) 
```