### PR TITLE
Add support and tests for enum comment.

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -1476,11 +1476,11 @@ class ModelCommand extends BakeCommand
                 continue;
             }
 
-            if (empty($columnSchema['comment']) || strpos($columnSchema['comment'], '[enum]') === false) {
+            if (empty($columnSchema['comment']) || !str_contains($columnSchema['comment'], '[enum]')) {
                 continue;
             }
 
-            $enumsDefinitionString = trim(mb_substr($columnSchema['comment'], strpos($columnSchema['comment'], '[enum]') + 6));
+            $enumsDefinitionString = EnumParser::parseDefinitionString($columnSchema['comment']);
             $isInt = in_array($columnSchema['type'], ['integer', 'tinyinteger', 'smallinteger'], true);
             if (str_starts_with($columnSchema['type'], 'enum-')) {
                 $dbType = TypeFactory::build($columnSchema['type']);

--- a/src/Utility/Model/EnumParser.php
+++ b/src/Utility/Model/EnumParser.php
@@ -42,4 +42,20 @@ enum EnumParser
 
         return $definition;
     }
+
+    /**
+     * Parses an enum definition from a DB column comment.
+     *
+     * @param string $comment
+     * @return string
+     */
+    public static function parseDefinitionString(string $comment): string
+    {
+        $string = trim(mb_substr($comment, strpos($comment, '[enum]') + 6));
+        if (str_contains($string, ';')) {
+            $string = trim(mb_substr($string, 0, strpos($string, ';')));
+        }
+
+        return $string;
+    }
 }

--- a/tests/TestCase/Utility/Model/EnumParserTest.php
+++ b/tests/TestCase/Utility/Model/EnumParserTest.php
@@ -27,6 +27,21 @@ class EnumParserTest extends TestCase
     /**
      * @return void
      */
+    public function testParseDefinitionString(): void
+    {
+        $definitionString = EnumParser::parseDefinitionString('[enum]');
+        $this->assertSame('', $definitionString);
+
+        $definitionString = EnumParser::parseDefinitionString('[enum] foo, bar');
+        $this->assertSame('foo, bar', $definitionString);
+
+        $definitionString = EnumParser::parseDefinitionString('[enum] foo, bar; Some additional comment');
+        $this->assertSame('foo, bar', $definitionString);
+    }
+
+    /**
+     * @return void
+     */
     public function testParseCases(): void
     {
         $cases = EnumParser::parseCases('', false);


### PR DESCRIPTION
Completes https://github.com/cakephp/bake/releases/tag/3.1.0 by also allowing an additional comment afterwards

    [enum] foo, bar; Some comment
   
Currently the comment would be part of the last element.