### PR TITLE
Wrap addPlugin() call in has() check.

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpstan" version="1.10.56" installed="1.10.56" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="5.20.0" installed="5.20.0" location="./tools/psalm" copy="false"/>
+  <phar name="phpstan" version="1.11.6" installed="1.11.6" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="5.25.0" installed="5.25.0" location="./tools/psalm" copy="false"/>
 </phive>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,8 +3,9 @@ includes:
 
 parameters:
     level: 6
-    checkMissingIterableValueType: false
     paths:
         - src/
     bootstrapFiles:
         - tests/bootstrap.php
+    ignoreErrors:
+        - identifier: missingType.iterableValue

--- a/src/BakePlugin.php
+++ b/src/BakePlugin.php
@@ -55,7 +55,9 @@ class BakePlugin extends BasePlugin
      */
     public function bootstrap(PluginApplicationInterface $app): void
     {
-        $app->addPlugin('Cake/TwigView');
+        if (!$app->getPlugins()->has('Cake/TwigView')) {
+            $app->addPlugin('Cake/TwigView');
+        }
     }
 
     /**

--- a/src/BakePlugin.php
+++ b/src/BakePlugin.php
@@ -23,6 +23,7 @@ use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Core\PluginApplicationInterface;
+use Cake\Http\BaseApplication;
 use DirectoryIterator;
 use ReflectionClass;
 use ReflectionException;
@@ -55,6 +56,8 @@ class BakePlugin extends BasePlugin
      */
     public function bootstrap(PluginApplicationInterface $app): void
     {
+        assert($app instanceof BaseApplication);
+
         if (!$app->getPlugins()->has('Cake/TwigView')) {
             $app->addPlugin('Cake/TwigView');
         }


### PR DESCRIPTION
Cake 5.1 throws exception for duplicate plugin loading and this avoids exception if the TwigView plugin is already loaded from the application.