### PR TITLE
Ignore vendor everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /composer.lock
 /phpunit.xml
 /tools
-/vendor
+vendor
 /.idea/
 /.phpunit.cache
 tests/test_app/App/Model/Table/CommentsTable.php


### PR DESCRIPTION
This will also ignore the vendor folder generated in the test app during test execution.