### PR TITLE
Update brick/var-exporter to 0.5.0 and fix deprecations.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "brick/varexporter": "^0.4.0",
+        "brick/varexporter": "^0.5.0",
         "cakephp/cakephp": "^5.0.3",
         "cakephp/twig-view": "^2.0.0",
         "nikic/php-parser": "^4.13.2 || ^5.0.0"

--- a/src/CodeGen/CodeParser.php
+++ b/src/CodeGen/CodeParser.php
@@ -66,7 +66,7 @@ class CodeParser extends NodeVisitorAbstract
      */
     public function __construct()
     {
-        $version = PhpVersion::fromComponents(8,1);
+        $version = PhpVersion::fromComponents(8, 1);
         $this->parser = (new ParserFactory())->createForVersion($version);
         $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor($this);

--- a/src/CodeGen/CodeParser.php
+++ b/src/CodeGen/CodeParser.php
@@ -17,18 +17,19 @@ declare(strict_types=1);
 namespace Bake\CodeGen;
 
 use PhpParser\Error;
-use PhpParser\Lexer\Emulative;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
-use PhpParser\Node\Stmt\UseUse;
+use PhpParser\Node\UseItem;
 use PhpParser\NodeAbstract;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
 
 /**
  * @internal
@@ -65,12 +66,8 @@ class CodeParser extends NodeVisitorAbstract
      */
     public function __construct()
     {
-        $this->parser = (new ParserFactory())->create(
-            ParserFactory::PREFER_PHP7,
-            new Emulative([
-                'usedAttributes' => ['comments', 'startLine', 'endLine', 'startFilePos', 'endFilePos'],
-            ])
-        );
+        $version = PhpVersion::fromComponents(8,1);
+        $this->parser = (new ParserFactory())->createForVersion($version);
         $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor($this);
     }
@@ -137,7 +134,11 @@ class CodeParser extends NodeVisitorAbstract
                 throw new ParseException('Multiple use statements per line are not supported, update your file');
             }
 
-            [$alias, $target] = $this->normalizeUse(current($node->uses));
+            if ($node->uses === []) {
+                throw new ParseException('Use statement without uses!');
+            }
+
+            [$alias, $target] = $this->normalizeUse($node->uses[0]);
             switch ($node->type) {
                 case Use_::TYPE_NORMAL:
                     $this->parsed['imports']['class'][$alias] = $target;
@@ -150,7 +151,7 @@ class CodeParser extends NodeVisitorAbstract
                     break;
             }
 
-            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+            return NodeVisitor::DONT_TRAVERSE_CHILDREN;
         }
 
         if ($node instanceof GroupUse) {
@@ -203,7 +204,7 @@ class CodeParser extends NodeVisitorAbstract
                 $methods
             );
 
-            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+            return NodeVisitor::DONT_TRAVERSE_CHILDREN;
         }
 
         return null;
@@ -230,11 +231,11 @@ class CodeParser extends NodeVisitorAbstract
     }
 
     /**
-     * @param \PhpParser\Node\Stmt\UseUse $use Use node
+     * @param \PhpParser\Node\UseItem $use Use item
      * @param string|null $prefix Group use prefix
      * @return array{string, string}
      */
-    protected function normalizeUse(UseUse $use, ?string $prefix = null): array
+    protected function normalizeUse(UseItem $use, ?string $prefix = null): array
     {
         $name = (string)$use->name;
         if ($prefix) {

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -98,7 +98,7 @@ class BakeHelper extends Helper
     {
         $options = 0;
         if ($inline) {
-            $options = VarExporter::INLINE_NUMERIC_SCALAR_ARRAY;
+            $options = VarExporter::INLINE_SCALAR_LIST;
         }
 
         return $this->exportVar($var, $indentLevel, $options);
@@ -369,7 +369,7 @@ class BakeHelper extends Helper
                 return $this->exportVar(
                     $item,
                     is_array($item) ? 3 : 0,
-                    VarExporter::INLINE_NUMERIC_SCALAR_ARRAY
+                    VarExporter::INLINE_SCALAR_LIST
                 );
             }, $rule['args']);
             $validationMethods[] = sprintf(


### PR DESCRIPTION
I took the liberty to update the PHP version for the code generation to 8.1 because it's also the minimum version for CakePHP 5.x.