### PR TITLE
Make sure custom relations work out with new alias strictness.

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -377,8 +377,9 @@ class ModelCommand extends BakeCommand
                 ) {
                     $allowAliasRelations = $args && $args->getOption('skip-relation-check');
                     $found = $this->findTableReferencedBy($schema, $fieldName);
+                    $className = null;
                     if ($found) {
-                        $tmpModelName = Inflector::camelize($found);
+                        $className = ($this->plugin ? $this->plugin . '.' : '') . Inflector::camelize($found);
                     } elseif (!$allowAliasRelations) {
                         continue;
                     }
@@ -387,6 +388,9 @@ class ModelCommand extends BakeCommand
                     'alias' => $tmpModelName,
                     'foreignKey' => $fieldName,
                 ];
+                if ($className && $className !== $tmpModelName) {
+                    $assoc['className'] = $className;
+                }
                 if ($schema->getColumn($fieldName)['null'] === false) {
                     $assoc['joinType'] = 'INNER';
                 }
@@ -395,6 +399,7 @@ class ModelCommand extends BakeCommand
             if ($this->plugin && empty($assoc['className'])) {
                 $assoc['className'] = $this->plugin . '.' . $assoc['alias'];
             }
+
             $associations['belongsTo'][] = $assoc;
         }
 

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -346,13 +346,13 @@ class ModelCommand extends BakeCommand
      */
     public function findBelongsTo(Table $model, array $associations, ?Arguments $args = null): array
     {
-        $className = null;
         $schema = $model->getSchema();
         foreach ($schema->columns() as $fieldName) {
             if (!preg_match('/^.+_id$/', $fieldName) || ($schema->getPrimaryKey() === [$fieldName])) {
                 continue;
             }
 
+            $className = null;
             if ($fieldName === 'parent_id') {
                 $className = $this->plugin ? $this->plugin . '.' . $model->getAlias() : $model->getAlias();
                 $assoc = [

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -256,6 +256,8 @@ class ModelCommand extends BakeCommand
         $associations = $this->findHasMany($table, $associations);
         $associations = $this->findBelongsToMany($table, $associations);
 
+        $associations = $this->ensureAliasUniqueness($associations);
+
         return $associations;
     }
 
@@ -275,8 +277,6 @@ class ModelCommand extends BakeCommand
         if (get_class($model) !== Table::class) {
             return;
         }
-
-        $this->ensureAliasUniqueness($associations);
 
         foreach ($associations as $type => $assocs) {
             foreach ($assocs as $assoc) {
@@ -1561,7 +1561,7 @@ class ModelCommand extends BakeCommand
             foreach ($associationsPerType as $k => $association) {
                 $alias = $association['alias'];
                 if (in_array($alias, $existing, true)) {
-                    $alias = $this->alias($association);
+                    $alias = $this->createAssociationAlias($association);
                 }
                 $existing[] = $alias;
                 if (empty($association['className'])) {
@@ -1580,7 +1580,7 @@ class ModelCommand extends BakeCommand
      * @param array<string, mixed> $association
      * @return string
      */
-    protected function alias(array $association): string
+    protected function createAssociationAlias(array $association): string
     {
         $foreignKey = $association['foreignKey'];
 

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -1566,7 +1566,9 @@ class ModelCommand extends BakeCommand
                 $existing[] = $alias;
                 if (empty($association['className'])) {
                     $className = $this->plugin ? $this->plugin . '.' . $association['alias'] : $association['alias'];
-                    $association['className'] = $className;
+                    if ($className !== $alias) {
+                        $association['className'] = $className;
+                    }
                 }
                 $association['alias'] = $alias;
                 $associations[$type][$k] = $association;

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -275,6 +275,9 @@ class ModelCommand extends BakeCommand
         if (get_class($model) !== Table::class) {
             return;
         }
+
+        $this->ensureAliasUniqueness($associations);
+
         foreach ($associations as $type => $assocs) {
             foreach ($assocs as $assoc) {
                 $alias = $assoc['alias'];
@@ -1545,5 +1548,39 @@ class ModelCommand extends BakeCommand
             );
             $enumCommand->execute($args, $io);
         }
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $associations
+     * @return array<string, array<string, mixed>>
+     */
+    protected function ensureAliasUniqueness(array $associations): array
+    {
+        $existing = [];
+        foreach ($associations as $type => $associationsPerType) {
+            foreach ($associationsPerType as $k => $association) {
+                $alias = $association['alias'];
+                if (in_array($alias, $existing, true)) {
+                    $alias = $this->alias($association);
+                }
+                $existing[] = $alias;
+                $association['class'] = $association['alias'];
+                $association['alias'] = $alias;
+                $associations[$type][$k] = $association;
+            }
+        }
+
+        return $associations;
+    }
+
+    /**
+     * @param array<string, mixed> $association
+     * @return string
+     */
+    protected function alias(array $association): string
+    {
+        $foreignKey = $association['foreignKey'];
+
+        return $this->_modelNameFromKey($foreignKey);
     }
 }

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -346,6 +346,7 @@ class ModelCommand extends BakeCommand
      */
     public function findBelongsTo(Table $model, array $associations, ?Arguments $args = null): array
     {
+        $className = null;
         $schema = $model->getSchema();
         foreach ($schema->columns() as $fieldName) {
             if (!preg_match('/^.+_id$/', $fieldName) || ($schema->getPrimaryKey() === [$fieldName])) {
@@ -377,7 +378,6 @@ class ModelCommand extends BakeCommand
                 ) {
                     $allowAliasRelations = $args && $args->getOption('skip-relation-check');
                     $found = $this->findTableReferencedBy($schema, $fieldName);
-                    $className = null;
                     if ($found) {
                         $className = ($this->plugin ? $this->plugin . '.' : '') . Inflector::camelize($found);
                     } elseif (!$allowAliasRelations) {

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -1564,7 +1564,10 @@ class ModelCommand extends BakeCommand
                     $alias = $this->alias($association);
                 }
                 $existing[] = $alias;
-                $association['class'] = $association['alias'];
+                if (empty($association['className'])) {
+                    $className = $this->plugin ? $this->plugin . '.' . $association['alias'] : $association['alias'];
+                    $association['className'] = $className;
+                }
                 $association['alias'] = $alias;
                 $associations[$type][$k] = $association;
             }

--- a/tests/Fixture/RelationsFixture.php
+++ b/tests/Fixture/RelationsFixture.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * InvitationsFixture
+ */
+class RelationsFixture extends TestFixture
+{
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public array $records = [
+        [
+            'user_id' => 1,
+            'other_id' => 1,
+            'body' => 'Try it out!',
+        ],
+    ];
+}

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -602,9 +602,10 @@ class ModelCommandTest extends TestCase
                 'joinType' => 'INNER',
             ],
             [
-                'alias' => 'Users',
+                'alias' => 'Receivers',
                 'foreignKey' => 'receiver_id',
                 'joinType' => 'INNER',
+                'className' => 'Users',
             ],
         ];
         $this->assertEquals($expected, $result['belongsTo']);

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -597,9 +597,10 @@ class ModelCommandTest extends TestCase
 
         $expected = [
             [
-                'alias' => 'Users',
+                'alias' => 'Senders',
                 'foreignKey' => 'sender_id',
                 'joinType' => 'INNER',
+                'className' => 'Users',
             ],
             [
                 'alias' => 'Receivers',
@@ -675,14 +676,16 @@ class ModelCommandTest extends TestCase
         $expected = [
             'belongsTo' => [
                 [
-                    'alias' => 'Users',
+                    'alias' => 'Senders',
                     'foreignKey' => 'sender_id',
                     'joinType' => 'INNER',
+                    'className' => 'Users',
                 ],
                 [
-                    'alias' => 'Users',
+                    'alias' => 'Receivers',
                     'foreignKey' => 'receiver_id',
                     'joinType' => 'INNER',
+                    'className' => 'Users',
                 ],
             ],
         ];

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -669,6 +669,35 @@ class ModelCommandTest extends TestCase
      */
     public function testBelongsToGenerationConstraints()
     {
+        $model = $this->getTableLocator()->get('Relations');
+        $command = new ModelCommand();
+        $command->connection = 'test';
+        $result = $command->findBelongsTo($model, []);
+        $expected = [
+            'belongsTo' => [
+                [
+                    'alias' => 'Users',
+                    'foreignKey' => 'user_id',
+                    'joinType' => 'INNER',
+                ],
+                [
+                    'alias' => 'Others',
+                    'foreignKey' => 'other_id',
+                    'joinType' => 'INNER',
+                    'className' => 'Users',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that belongsTo association generation uses aliased constraints on the table
+     *
+     * @return void
+     */
+    public function testBelongsToGenerationConstraintsAliased()
+    {
         $model = $this->getTableLocator()->get('Invitations');
         $command = new ModelCommand();
         $command->connection = 'test';

--- a/tests/comparisons/Model/testBakeEntityCustomHidden.php
+++ b/tests/comparisons/Model/testBakeEntityCustomHidden.php
@@ -15,6 +15,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\DateTime|null $updated
  *
  * @property \Bake\Test\App\Model\Entity\Comment[] $comments
+ * @property \Bake\Test\App\Model\Entity\Relation[] $relations
  * @property \Bake\Test\App\Model\Entity\TodoItem[] $todo_items
  */
 class User extends Entity

--- a/tests/comparisons/Model/testBakeEntityFullContext.php
+++ b/tests/comparisons/Model/testBakeEntityFullContext.php
@@ -15,6 +15,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\DateTime|null $updated
  *
  * @property \Bake\Test\App\Model\Entity\Comment[] $comments
+ * @property \Bake\Test\App\Model\Entity\Relation[] $relations
  * @property \Bake\Test\App\Model\Entity\TodoItem[] $todo_items
  */
 class User extends Entity
@@ -34,6 +35,7 @@ class User extends Entity
         'created' => true,
         'updated' => true,
         'comments' => true,
+        'relations' => true,
         'todo_items' => true,
     ];
 

--- a/tests/comparisons/Model/testBakeEntityHidden.php
+++ b/tests/comparisons/Model/testBakeEntityHidden.php
@@ -15,6 +15,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\DateTime|null $updated
  *
  * @property \Bake\Test\App\Model\Entity\Comment[] $comments
+ * @property \Bake\Test\App\Model\Entity\Relation[] $relations
  * @property \Bake\Test\App\Model\Entity\TodoItem[] $todo_items
  */
 class User extends Entity

--- a/tests/comparisons/Model/testBakeEntitySimple.php
+++ b/tests/comparisons/Model/testBakeEntitySimple.php
@@ -15,6 +15,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\DateTime|null $updated
  *
  * @property \Bake\Test\App\Model\Entity\Comment[] $comments
+ * @property \Bake\Test\App\Model\Entity\Relation[] $relations
  * @property \Bake\Test\App\Model\Entity\TodoItem[] $todo_items
  */
 class User extends Entity

--- a/tests/comparisons/Model/testBakeEntitySimpleUnchanged.php
+++ b/tests/comparisons/Model/testBakeEntitySimpleUnchanged.php
@@ -15,6 +15,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\DateTime|null $updated
  *
  * @property \Bake\Test\App\Model\Entity\Comment[] $comments
+ * @property \Bake\Test\App\Model\Entity\Relation[] $relations
  * @property \Bake\Test\App\Model\Entity\TodoItem[] $todo_items
  */
 class User extends Entity

--- a/tests/comparisons/Model/testBakeEntityWithPlugin.php
+++ b/tests/comparisons/Model/testBakeEntityWithPlugin.php
@@ -15,6 +15,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\DateTime|null $updated
  *
  * @property \BakeTest\Model\Entity\Comment[] $comments
+ * @property \BakeTest\Model\Entity\Relation[] $relations
  * @property \BakeTest\Model\Entity\TodoItem[] $todo_items
  */
 class User extends Entity
@@ -34,6 +35,7 @@ class User extends Entity
         'created' => true,
         'updated' => true,
         'comments' => true,
+        'relations' => true,
         'todo_items' => true,
     ];
 

--- a/tests/comparisons/Model/testBakeTableWithPlugin.php
+++ b/tests/comparisons/Model/testBakeTableWithPlugin.php
@@ -12,6 +12,7 @@ use Cake\Validation\Validator;
  * Users Model
  *
  * @property \BakeTest\Model\Table\CommentsTable&\Cake\ORM\Association\HasMany $Comments
+ * @property \BakeTest\Model\Table\RelationsTable&\Cake\ORM\Association\HasMany $Relations
  * @property \BakeTest\Model\Table\TodoItemsTable&\Cake\ORM\Association\HasMany $TodoItems
  *
  * @method \BakeTest\Model\Entity\User newEmptyEntity()
@@ -51,6 +52,10 @@ class UsersTable extends Table
         $this->hasMany('Comments', [
             'foreignKey' => 'user_id',
             'className' => 'BakeTest.Comments',
+        ]);
+        $this->hasMany('Relations', [
+            'foreignKey' => 'user_id',
+            'className' => 'BakeTest.Relations',
         ]);
         $this->hasMany('TodoItems', [
             'foreignKey' => 'user_id',

--- a/tests/comparisons/Model/testBakeWithRulesUnique.php
+++ b/tests/comparisons/Model/testBakeWithRulesUnique.php
@@ -12,6 +12,7 @@ use Cake\Validation\Validator;
  * Users Model
  *
  * @property \Bake\Test\App\Model\Table\CommentsTable&\Cake\ORM\Association\HasMany $Comments
+ * @property \Bake\Test\App\Model\Table\RelationsTable&\Cake\ORM\Association\HasMany $Relations
  * @property \Bake\Test\App\Model\Table\TodoItemsTable&\Cake\ORM\Association\HasMany $TodoItems
  *
  * @method \Bake\Test\App\Model\Entity\User newEmptyEntity()
@@ -49,6 +50,9 @@ class UsersTable extends Table
         $this->addBehavior('Timestamp');
 
         $this->hasMany('Comments', [
+            'foreignKey' => 'user_id',
+        ]);
+        $this->hasMany('Relations', [
             'foreignKey' => 'user_id',
         ]);
         $this->hasMany('TodoItems', [

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -384,6 +384,34 @@ return [
         'constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ],
     [
+        'table' => 'relations',
+        'columns' => [
+            'id' => ['type' => 'integer'],
+            'user_id' => ['type' => 'integer', 'null' => false],
+            'other_id' => ['type' => 'integer', 'null' => false],
+            'body' => 'text',
+            'created' => 'datetime',
+            'updated' => 'datetime',
+        ],
+        'constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'user_idx' => [
+                'type' => 'foreign',
+                'columns' => ['user_id'],
+                'references' => ['users', 'id'],
+                'update' => 'noAction',
+                'delete' => 'noAction',
+            ],
+            'other_idx' => [
+                'type' => 'foreign',
+                'columns' => ['other_id'],
+                'references' => ['users', 'id'],
+                'update' => 'noAction',
+                'delete' => 'noAction',
+            ],
+        ],
+    ],
+    [
         'table' => 'invitations',
         'columns' => [
             'id' => ['type' => 'integer'],

--- a/tests/test_app/App/Controller/RelationsController.php
+++ b/tests/test_app/App/Controller/RelationsController.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Bake\Test\App\Controller;
+
+/**
+ * Relations Controller
+ *
+ */
+class RelationsController extends AppController
+{
+    /**
+     * Index method
+     *
+     * @return \Cake\Http\Response|null|void Renders view
+     */
+    public function index()
+    {
+        $query = $this->Relations->find();
+        $relations = $this->paginate($query);
+
+        $this->set(compact('relations'));
+    }
+
+    /**
+     * View method
+     *
+     * @param string|null $id Relation id.
+     * @return \Cake\Http\Response|null|void Renders view
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     */
+    public function view($id = null)
+    {
+        $relation = $this->Relations->get($id, contain: []);
+        $this->set(compact('relation'));
+    }
+
+    /**
+     * Add method
+     *
+     * @return \Cake\Http\Response|null|void Redirects on successful add, renders view otherwise.
+     */
+    public function add()
+    {
+        $relation = $this->Relations->newEmptyEntity();
+        if ($this->request->is('post')) {
+            $relation = $this->Relations->patchEntity($relation, $this->request->getData());
+            if ($this->Relations->save($relation)) {
+                $this->Flash->success(__('The relation has been saved.'));
+
+                return $this->redirect(['action' => 'index']);
+            }
+            $this->Flash->error(__('The relation could not be saved. Please, try again.'));
+        }
+        $this->set(compact('relation'));
+    }
+
+    /**
+     * Edit method
+     *
+     * @param string|null $id Relation id.
+     * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     */
+    public function edit($id = null)
+    {
+        $relation = $this->Relations->get($id, contain: []);
+        if ($this->request->is(['patch', 'post', 'put'])) {
+            $relation = $this->Relations->patchEntity($relation, $this->request->getData());
+            if ($this->Relations->save($relation)) {
+                $this->Flash->success(__('The relation has been saved.'));
+
+                return $this->redirect(['action' => 'index']);
+            }
+            $this->Flash->error(__('The relation could not be saved. Please, try again.'));
+        }
+        $this->set(compact('relation'));
+    }
+
+    /**
+     * Delete method
+     *
+     * @param string|null $id Relation id.
+     * @return \Cake\Http\Response|null Redirects to index.
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     */
+    public function delete($id = null)
+    {
+        $this->request->allowMethod(['post', 'delete']);
+        $relation = $this->Relations->get($id);
+        if ($this->Relations->delete($relation)) {
+            $this->Flash->success(__('The relation has been deleted.'));
+        } else {
+            $this->Flash->error(__('The relation could not be deleted. Please, try again.'));
+        }
+
+        return $this->redirect(['action' => 'index']);
+    }
+}


### PR DESCRIPTION
Refs https://github.com/cakephp/bake/issues/1012

So basically 5.1 and the more strict relation-handling ("Association alias `Countries` is already set") kinda broke the non documented feature of custom relationship baking.
Even though it was just baked wrongly with always the same Countries relation.

This PR adds the expected aliasing (back) ensuring there is no collision, and having the correct name in the process for most cases:
```
[
  'belongsTo' => [
    (int) 0 => [
      'alias' => 'Countries',
      'foreignKey' => 'country_id',
      'className' => 'Countries'
    ],
    (int) 1 => [
      'alias' => 'BillingCountries',
      'foreignKey' => 'billing_country_id',
      'className' => 'Countries'
    ],
    (int) 2 => [
      'alias' => 'ShippingCountries',
      'foreignKey' => 'shipping_country_id',
      'className' => 'Countries'
    ]
  ],
  'hasOne' => [],
  'hasMany' => [],
  'belongsToMany' => []
]
```
as example for

Countries
- id

Users
- id
- country_id
- billing_country_id
- shipping_country_id

