### PR TITLE
Luizmarin 1

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Bake\Command;
 
 use Bake\CodeGen\FileBuilder;
@@ -385,15 +387,18 @@ class ModelCommand extends BakeCommand
                 }
                 $assoc = [
                     'alias' => $tmpModelName,
+                    'className' => $tmpModelName,
                     'foreignKey' => $fieldName,
                 ];
                 if ($schema->getColumn($fieldName)['null'] === false) {
                     $assoc['joinType'] = 'INNER';
                 }
             }
-
             if ($this->plugin && empty($assoc['className'])) {
                 $assoc['className'] = $this->plugin . '.' . $assoc['alias'];
+            }
+            if (!empty($assoc['className'])) {
+                $assoc['alias'] = $assoc['className'] . '_' .  $model->getAlias() . '_' . $fieldName;
             }
             $associations['belongsTo'][] = $assoc;
         }
@@ -711,7 +716,7 @@ class ModelCommand extends BakeCommand
             if ($entityClass === '\Cake\ORM\Entity') {
                 $namespace = Configure::read('App.namespace');
 
-                [$plugin, ] = pluginSplit($association->getTarget()->getRegistryAlias());
+                [$plugin,] = pluginSplit($association->getTarget()->getRegistryAlias());
                 if ($plugin !== null) {
                     $namespace = $plugin;
                 }
@@ -1355,7 +1360,7 @@ class ModelCommand extends BakeCommand
         ])->addOption('skip-relation-check', [
             'boolean' => true,
             'help' => 'Generate relations for all "example_id" fields'
-            . ' without checking the database if a table "examples" exists.',
+                . ' without checking the database if a table "examples" exists.',
         ])->setEpilog(
             'Omitting all arguments and options will list the table names you can generate models for.'
         );

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -275,6 +275,9 @@ class ModelCommand extends BakeCommand
         if (get_class($model) !== Table::class) {
             return;
         }
+
+        $this->ensureAliasUniqueness($associations);
+
         foreach ($associations as $type => $assocs) {
             foreach ($assocs as $assoc) {
                 $alias = $assoc['alias'];
@@ -1545,5 +1548,39 @@ class ModelCommand extends BakeCommand
             );
             $enumCommand->execute($args, $io);
         }
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $associations
+     * @return array<string, array<string, mixed>>
+     */
+    protected function ensureAliasUniqueness(array $associations): array
+    {
+        $existing = [];
+        foreach ($associations as $type => $associationsPerType) {
+            foreach ($associationsPerType as $k => $association) {
+                $alias = $association['alias'];
+                if (in_array($alias, $existing, true)) {
+                    $alias = $this->alias($association);
+                }
+                $existing[] = $alias;
+                $association['class'] = $association['alias'];
+                $association['alias'] = $alias;
+                $associations[$type][$k] = $association;
+            }
+        }
+
+        return $associations;
+    }
+
+    /**
+     * @param array<string, mixed> $association
+     * @return string
+     */
+    protected function alias(array $association): string
+    {
+        $foreignKey = $association['foreignKey'];
+
+        return $this->_modelNameFromKey($foreignKey);
     }
 }

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -1564,7 +1564,10 @@ class ModelCommand extends BakeCommand
                     $alias = $this->alias($association);
                 }
                 $existing[] = $alias;
-                $association['class'] = $association['alias'];
+                if (empty($association['className'])) {
+                    $className = $this->plugin ? $this->plugin . '.' . $association['alias'] : $association['alias'];
+                    $association['className'] = $className;
+                }
                 $association['alias'] = $alias;
                 $associations[$type][$k] = $association;
             }


### PR DESCRIPTION
ref: [#1012](https://github.com/cakephp/bake/issues/1012)


Just look, I imagine something like this. 
But the generated name may seem a bit 'strange'. Lack of creativity, I think. It became 'table.RelatedTable_link_field'.
For example, "$this->belongsTo('UsersPermissionGroups_permission_group_id', [...."
(*OR should it be the other way around? :) :) )

The reason for adding the field name is illustrated below:
```

  $this->belongsTo('Users_Users_inserted_id', [
    'className' => 'Users',
    'foreignKey' => 'inserted_id',
  ]);
  $this->belongsTo('Users_Users_updated_id', [
    'className' => 'Users',
    'foreignKey' => 'updated_id',
  ]); 
  $this->belongsTo('Users_Users_designated_id', [
    'className' => 'Users',
    'foreignKey' => 'designated_id',
  ]);
  $this->belongsTo('Users_Users_converted_id', [
    'className' => 'Users',
    'foreignKey' => 'converted_id',
  ]);

```

Well, if the idea is useful, I hope you can refine it and adapt it to cakePHP standards.

[UsersTable.txt](https://github.com/user-attachments/files/17883024/UsersTable.txt)

