### PR TITLE
Update ModelCommand.php

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -382,6 +382,7 @@ class ModelCommand extends BakeCommand
                 }
                 $assoc = [
                     'alias' => $tmpModelName,
+                    'className' => $tmpModelName,
                     'foreignKey' => $fieldName,
                 ];
                 if ($schema->getColumn($fieldName)['null'] === false) {
@@ -391,6 +392,9 @@ class ModelCommand extends BakeCommand
 
             if ($this->plugin && empty($assoc['className'])) {
                 $assoc['className'] = $this->plugin . '.' . $assoc['alias'];
+            }
+            if (!empty($assoc['className'])) {
+                $assoc['alias'] = $assoc['className'] . '_' .  $model->getAlias() . '_' . $fieldName;
             }
             $associations['belongsTo'][] = $assoc;
         }


### PR DESCRIPTION
ref: [#1015](https://github.com/cakephp/bake/pull/1015)

Just look, I imagine something like this.
But the generated name may seem a bit 'strange'. Lack of creativity, I think. It became 'table.RelatedTable_link_field'. For example, "$this->belongsTo('UsersPermissionGroups_permission_group_id', [...." (*OR should it be the other way around? :) :) )

The reason for adding the field name is illustrated below:


  $this->belongsTo('Users_Users_inserted_id', [
    'className' => 'Users',
    'foreignKey' => 'inserted_id',
  ]);
  $this->belongsTo('Users_Users_updated_id', [
    'className' => 'Users',
    'foreignKey' => 'updated_id',
  ]); 
  $this->belongsTo('Users_Users_designated_id', [
    'className' => 'Users',
    'foreignKey' => 'designated_id',
  ]);
  $this->belongsTo('Users_Users_converted_id', [
    'className' => 'Users',
    'foreignKey' => 'converted_id',
  ]);

Well, if the idea is useful, I hope you can refine it and adapt it to cakePHP standards.


[UsersTable.txt](https://github.com/user-attachments/files/17883091/UsersTable.txt)
