### PR TITLE
Update ModelCommand.php

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -346,6 +346,7 @@ class ModelCommand extends BakeCommand
      */
     public function findBelongsTo(Table $model, array $associations, ?Arguments $args = null): array
     {
+        $className = null;
         $schema = $model->getSchema();
         foreach ($schema->columns() as $fieldName) {
             if (!preg_match('/^.+_id$/', $fieldName) || ($schema->getPrimaryKey() === [$fieldName])) {
@@ -377,7 +378,6 @@ class ModelCommand extends BakeCommand
                 ) {
                     $allowAliasRelations = $args && $args->getOption('skip-relation-check');
                     $found = $this->findTableReferencedBy($schema, $fieldName);
-                    $className = null;
                     if ($found) {
                         $className = ($this->plugin ? $this->plugin . '.' : '') . Inflector::camelize($found);
                     } elseif (!$allowAliasRelations) {


### PR DESCRIPTION
correction due to the error shown below.

```
Creating file C:\marin\www\GitHub\lixo\tests\TestCase\Model\Table\AnnouncementsTableTest.php Wrote `C:\marin\www\GitHub\lixo\tests\TestCase\Model\Table\AnnouncementsTableTest.php` Done
One moment while associations are detected. 2024-11-26 10:24:32 warning: Undefined variable $className Trace:
Bake\Command\ModelCommand->findBelongsTo() C:\marin\www\GitHub\trash\vendor\cakephp\bake\src\Command\ModelCommand.php, line 247 Bake\Command\ModelCommand->getAssociations() C:\marin\www\GitHub\trash\vendor\cakephp\bake\src\Command\ModelCommand.php, line 166 Bake\Command\ModelCommand->getTableContext() C:\marin\www\GitHub\trash\vendor\cakephp\bake\src\Command\ModelCommand.php, line 119 Bake\Command\ModelCommand->bake() C:\marin\www\GitHub\lixo\vendor\cakephp\bake\src\Command\ModelCommand.php, line 101 Bake\Command\ModelCommand->execute() C:\marin\www\GitHub\trash\vendor\cakephp\bake\src\Command\AllCommand.php, line 116 Bake\Command\AllCommand->execute() C:\marin\www\GitHub\trash\vendor\cakephp\cakephp\src\Console\BaseCommand.php, line 204 Cake\Console\BaseCommand->run() C:\marin\www\GitHub\trash\vendor\cakephp\cakephp\src\Console\CommandRunner.php, line 330 Cake\Console\CommandRunner->runCommand() C:\marin\www\GitHub\trash\vendor\cakephp\cakephp\src\Console\CommandRunner.php, line 168 Cake\Console\CommandRunner->run() C:\marin\www\GitHub\lixo\bin\cake.php, line 10 [main]
```