### PR TITLE
Allow all --everything to run through using force mode.

### DIFF
--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -21,6 +21,7 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
+use Throwable;
 
 /**
  * Command for `bake all`
@@ -49,7 +50,7 @@ class AllCommand extends BakeCommand
         $parser = $this->_setCommonOptions($parser);
 
         $parser = $parser->setDescription(
-            'Generate the model, controller, template, tests and fixture for a table.'
+            'Generate the model, controller, template, tests and fixture for a table.',
         )->addArgument('name', [
             'help' => 'Name of the table to generate code for.',
         ])->addOption('everything', [
@@ -83,7 +84,7 @@ class AllCommand extends BakeCommand
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get($this->connection);
         $scanner = new TableScanner($connection);
-        if (empty($name) && !$args->getOption('everything')) {
+        if (!$name && !$args->getOption('everything')) {
             $io->out('Choose a table to generate from the following:');
             foreach ($scanner->listUnskipped() as $table) {
                 $io->out('- ' . $this->_camelize($table));
@@ -110,15 +111,31 @@ class AllCommand extends BakeCommand
                 unset($options['prefix']);
             }
 
+            $errors = 0;
             foreach ($tables as $table) {
                 $parser = $command->getOptionParser();
                 $subArgs = new Arguments([$table], $options, $parser->argumentNames());
-                $command->execute($subArgs, $io);
+
+                try {
+                    $command->execute($subArgs, $io);
+                } catch (Throwable $e) {
+                    if (!$args->getOption('everything') || !$args->getOption('force')) {
+                        throw $e;
+                    }
+
+                    $message = sprintf('Error generating %s for %s: %s', $commandName, $table, $e->getMessage());
+                    $io->err('<error>' . $message . '</error>');
+                    $errors++;
+                }
             }
         }
 
-        $io->out('<success>Bake All complete.</success>', 1, ConsoleIo::NORMAL);
+        if ($errors) {
+            $io->out(sprintf('<warning>Bake All completed, but with %s errors.</warning>', $errors), 1, ConsoleIo::NORMAL);
+        } else {
+            $io->out('<success>Bake All complete.</success>', 1, ConsoleIo::NORMAL);
+        }
 
-        return static::CODE_SUCCESS;
+        return $errors ? static::CODE_ERROR : static::CODE_SUCCESS;
     }
 }

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -98,6 +98,7 @@ class AllCommand extends BakeCommand
             $tables = [$name];
         }
 
+        $errors = 0;
         foreach ($this->commands as $commandName) {
             /** @var \Cake\Command\Command $command */
             $command = new $commandName();
@@ -111,7 +112,6 @@ class AllCommand extends BakeCommand
                 unset($options['prefix']);
             }
 
-            $errors = 0;
             foreach ($tables as $table) {
                 $parser = $command->getOptionParser();
                 $subArgs = new Arguments([$table], $options, $parser->argumentNames());


### PR DESCRIPTION
Resolves https://github.com/cakephp/bake/issues/86

This is actually great for testing on a new prototyping.
As it shows early on which tables might make issues instead of having to type out all manually.

> bin/cake bake all --everything -f

We can already use -q to not ask for interactive mode, we can use -f now instead to also allow running through and just collecting the errors to display.

See screenshot below:

![bake-all](https://github.com/user-attachments/assets/cd08bc46-9a6e-4e45-856b-8cd625673140)
