### PR TITLE
ignore shadow translations tables *_translations

### DIFF
--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -84,17 +84,17 @@ class AllCommand extends BakeCommand
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get($this->connection);
         $scanner = new TableScanner($connection);
+        $tables = $scanner->removeShadowTranslationTables($scanner->listUnskipped());
+
         if (!$name && !$args->getOption('everything')) {
             $io->out('Choose a table to generate from the following:');
-            foreach ($scanner->listUnskipped() as $table) {
+            foreach ($tables as $table) {
                 $io->out('- ' . $this->_camelize($table));
             }
 
             return static::CODE_SUCCESS;
         }
-        if ($args->getOption('everything')) {
-            $tables = $scanner->listUnskipped();
-        } else {
+        if (!$args->getOption('everything')) {
             $tables = [$name];
         }
 

--- a/src/Command/FixtureAllCommand.php
+++ b/src/Command/FixtureAllCommand.php
@@ -86,7 +86,9 @@ class FixtureAllCommand extends BakeCommand
         $connection = ConnectionManager::get($args->getOption('connection') ?? 'default');
         $scanner = new TableScanner($connection);
         $fixture = new FixtureCommand();
-        foreach ($scanner->listUnskipped() as $table) {
+
+        $tables = $scanner->removeShadowTranslationTables($scanner->listUnskipped());
+        foreach ($tables as $table) {
             $fixtureArgs = new Arguments([$table], $args->getOptions(), ['name']);
             $fixture->execute($fixtureArgs, $io);
         }

--- a/src/Command/ModelAllCommand.php
+++ b/src/Command/ModelAllCommand.php
@@ -83,7 +83,8 @@ class ModelAllCommand extends BakeCommand
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get($this->connection);
         $scanner = new TableScanner($connection);
-        foreach ($scanner->listUnskipped() as $table) {
+        $tables = $scanner->removeShadowTranslationTables($scanner->listUnskipped());
+        foreach ($tables as $table) {
             $this->getTableLocator()->clear();
             $modelArgs = new Arguments([$table], $args->getOptions(), ['name']);
             $this->modelCommand->execute($modelArgs, $io);

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -1251,7 +1251,7 @@ class ModelCommand extends BakeCommand
     }
 
     /**
-     * Outputs the a list of possible models or controllers from database
+     * Outputs the list of possible models or controllers from database
      *
      * @return array<string>
      */
@@ -1270,7 +1270,7 @@ class ModelCommand extends BakeCommand
     }
 
     /**
-     * Outputs the a list of unskipped models or controllers from database
+     * Outputs the list of unskipped models or controllers from database
      *
      * @return array<string>
      */

--- a/src/Command/TemplateAllCommand.php
+++ b/src/Command/TemplateAllCommand.php
@@ -65,7 +65,8 @@ class TemplateAllCommand extends BakeCommand
         $connection = ConnectionManager::get($this->connection);
         $scanner = new TableScanner($connection);
 
-        foreach ($scanner->listUnskipped() as $table) {
+        $tables = $scanner->removeShadowTranslationTables($scanner->listUnskipped());
+        foreach ($tables as $table) {
             $parser = $this->templateCommand->getOptionParser();
             $templateArgs = new Arguments(
                 [$table],

--- a/src/Utility/TableScanner.php
+++ b/src/Utility/TableScanner.php
@@ -58,13 +58,13 @@ class TableScanner
     /**
      * Get all tables in the connection without applying ignores.
      *
-     * @return array<string>
+     * @return array<string, string>
      */
     public function listAll(): array
     {
         $schema = $this->connection->getSchemaCollection();
         $tables = $schema->listTables();
-        if (empty($tables)) {
+        if (!$tables) {
             throw new RuntimeException('Your database does not have any tables.');
         }
         sort($tables);
@@ -75,7 +75,7 @@ class TableScanner
     /**
      * Get all tables in the connection that aren't ignored.
      *
-     * @return array<string>
+     * @return array<string, string>
      */
     public function listUnskipped(): array
     {
@@ -91,13 +91,36 @@ class TableScanner
     }
 
     /**
+     * Call from any All command that needs the shadow translation tables to be skipped.
+     *
+     * @param array<string, string> $tables
+     * @return array<string, string>
+     */
+    public function removeShadowTranslationTables(array $tables): array
+    {
+        foreach ($tables as $key => $table) {
+            if (!preg_match('/^(.+)_translations$/', $table, $matches)) {
+                continue;
+            }
+
+            if (empty($tables[$matches[1]])) {
+                continue;
+            }
+
+            unset($tables[$key]);
+        }
+
+        return $tables;
+    }
+
+    /**
      * @param string $table Table name.
      * @return bool
      */
     protected function shouldSkip(string $table): bool
     {
         foreach ($this->ignore as $ignore) {
-            if (strpos($ignore, '/') === 0) {
+            if (str_starts_with($ignore, '/')) {
                 if ((bool)preg_match($ignore, $table)) {
                     return true;
                 }

--- a/tests/TestCase/Utility/TableScannerTest.php
+++ b/tests/TestCase/Utility/TableScannerTest.php
@@ -125,4 +125,26 @@ class TableScannerTest extends TestCase
             }
         }
     }
+
+    /**
+     * @return void
+     */
+    public function testRemoveShadowTranslationTables(): void
+    {
+        $this->tableScanner = new TableScanner($this->connection);
+
+        $tables = [
+            'items' => 'items',
+            'users' => 'users',
+            'users_translations' => 'users_translations',
+            'item_translations' => 'item_translations',
+        ];
+        $result = $this->tableScanner->removeShadowTranslationTables($tables);
+        $expected = [
+            'items' => 'items',
+            'users' => 'users',
+            'item_translations' => 'item_translations',
+        ];
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/cakephp/bake/issues/1011

We probably want to document that we cannot bake any actual tables anymore that would end this way.
I have for example
https://github.com/dereuromark/cakephp-translate/blob/734d8610e6de7b81878052546890a55662e52eda/config/Migrations/20170414190437_TranslateCache.php#L11
which would then not work anymore.

Is there a way we could be more specific maybe?
Intospecting the table schema to see if it matches a shadow table schema might be overkill, no?