### PR TITLE
3.x: remove unnecessary parent call in table class

### DIFF
--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -41,8 +41,6 @@ class {{ name }}Table extends Table{{ fileBuilder.classBuilder.implements ? ' im
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
 {% if table %}
         $this->setTable('{{ table }}');
 {% endif %}

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesProductsTable.php
@@ -38,8 +38,6 @@ class CategoriesProductsTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('categories_products');
         $this->setDisplayField(['category_id', 'product_id']);
         $this->setPrimaryKey(['category_id', 'product_id']);

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTable.php
@@ -39,8 +39,6 @@ class CategoriesTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('categories');
         $this->setDisplayField('name');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionCategoriesTableSigned.php
@@ -39,8 +39,6 @@ class CategoriesTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('categories');
         $this->setDisplayField('name');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTable.php
@@ -37,8 +37,6 @@ class OldProductsTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('old_products');
         $this->setDisplayField('name');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionOldProductsTableSigned.php
@@ -37,8 +37,6 @@ class OldProductsTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('old_products');
         $this->setDisplayField('name');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTable.php
@@ -37,8 +37,6 @@ class ProductVersionsTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('product_versions');
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
+++ b/tests/comparisons/Model/testBakeAssociationDetectionProductVersionsTableSigned.php
@@ -37,8 +37,6 @@ class ProductVersionsTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('product_versions');
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeTableConfig.php
+++ b/tests/comparisons/Model/testBakeTableConfig.php
@@ -42,8 +42,6 @@ class ItemsTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('todo_items');
         $this->setDisplayField('title');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeTableNullableForeignKey.php
+++ b/tests/comparisons/Model/testBakeTableNullableForeignKey.php
@@ -37,8 +37,6 @@ class TestBakeArticlesTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('bake_articles');
         $this->setDisplayField('title');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeTableRules.php
+++ b/tests/comparisons/Model/testBakeTableRules.php
@@ -35,8 +35,6 @@ class UniqueFieldsTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('unique_fields');
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeTableValidation.php
+++ b/tests/comparisons/Model/testBakeTableValidation.php
@@ -37,8 +37,6 @@ class TestBakeArticlesTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('bake_articles');
         $this->setDisplayField('title');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeTableWithCounterCache.php
+++ b/tests/comparisons/Model/testBakeTableWithCounterCache.php
@@ -40,8 +40,6 @@ class TodoTasksTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('todo_tasks');
         $this->setDisplayField('title');
         $this->setPrimaryKey('uid');

--- a/tests/comparisons/Model/testBakeTableWithEnum.php
+++ b/tests/comparisons/Model/testBakeTableWithEnum.php
@@ -37,8 +37,6 @@ class TestBakeArticlesTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('bake_articles');
         $this->setDisplayField('title');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeTableWithPlugin.php
+++ b/tests/comparisons/Model/testBakeTableWithPlugin.php
@@ -41,8 +41,6 @@ class UsersTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('users');
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeUpdateTable.php
+++ b/tests/comparisons/Model/testBakeUpdateTable.php
@@ -54,8 +54,6 @@ class TodoItemsTable extends Table implements SomeInterface
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('todo_items');
         $this->setDisplayField('title');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeUpdateTableNoFile.php
+++ b/tests/comparisons/Model/testBakeUpdateTableNoFile.php
@@ -42,8 +42,6 @@ class TodoItemsTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('todo_items');
         $this->setDisplayField('title');
         $this->setPrimaryKey('id');

--- a/tests/comparisons/Model/testBakeWithRulesUnique.php
+++ b/tests/comparisons/Model/testBakeWithRulesUnique.php
@@ -41,8 +41,6 @@ class UsersTable extends Table
      */
     public function initialize(array $config): void
     {
-        parent::initialize($config);
-
         $this->setTable('users');
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');


### PR DESCRIPTION
There is no need to call `parent::initialize($config);` in a baked Table class since [we don't actually do anything in there.](https://github.com/cakephp/cakephp/blob/5.x/src/ORM/Table.php#L390-L392)