### PR TITLE
Fix up getDisplayField() in relation to Cake 6.0

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -641,15 +641,15 @@ class ModelCommand extends BakeCommand
      *
      * @param \Cake\ORM\Table $model The model to introspect.
      * @param \Cake\Console\Arguments $args CLI Arguments
-     * @return array<string>|string|null
+     * @return array<string>|string
      */
-    public function getDisplayField(Table $model, Arguments $args): array|string|null
+    public function getDisplayField(Table $model, Arguments $args): array|string
     {
         if ($args->getOption('display-field')) {
             return (string)$args->getOption('display-field');
         }
 
-        return $model->getDisplayField();
+        return $model->getDisplayField() ?? [];
     }
 
     /**


### PR DESCRIPTION
Given that Bake is a debug/local tool only, and that this method would rarely be overwritten/extended, this should be safe to do in a satellite plugin like this.
Refs https://github.com/cakephp/cakephp/pull/18338

It is impossible to be null anyway.