### PR TITLE
Use link instead of uses to avoid PHPUnit clash.

### DIFF
--- a/templates/bake/tests/test_case.twig
+++ b/templates/bake/tests/test_case.twig
@@ -35,7 +35,7 @@
  * {{ fullClassName }} Test Case
 {% if isController or isCommand %}
  *
- * @uses \{{ fullClassName }}
+ * @link \{{ fullClassName }}
 {% endif %}
  */
 class {{ className }}Test extends TestCase
@@ -123,7 +123,7 @@ class {{ className }}Test extends TestCase
      * Test {{ method }} method
      *
      * @return void
-     * @uses \{{ fullClassName }}::{{ method }}()
+     * @link \{{ fullClassName }}::{{ method }}()
      */
     public function test{{ method|camelize }}(): void
     {

--- a/tests/TestCase/Command/AllCommandTest.php
+++ b/tests/TestCase/Command/AllCommandTest.php
@@ -187,11 +187,11 @@ class AllCommandTest extends TestCase
     }
 
     /**
-     * Test docblock @ uses generated for test methods
+     * Test docblock @ link generated for test methods
      *
      * @return void
      */
-    public function testGenerateUsesDocBlockController()
+    public function testGenerateLinkDocBlockController()
     {
         $path = APP;
         $testsPath = ROOT . 'tests' . DS;
@@ -213,11 +213,11 @@ class AllCommandTest extends TestCase
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains(
-            '@uses \Bake\Test\App\Controller\ProductsController::index()',
+            '@link \Bake\Test\App\Controller\ProductsController::index()',
             $testsPath . 'TestCase/Controller/ProductsControllerTest.php',
         );
         $this->assertFileContains(
-            '@uses \Bake\Test\App\Model\Table\ProductsTable::validationDefault()',
+            '@link \Bake\Test\App\Model\Table\ProductsTable::validationDefault()',
             $testsPath . 'TestCase/Model/Table/ProductsTableTest.php',
         );
         $this->assertOutputContains('Bake All complete');

--- a/tests/TestCase/Command/CommandCommandTest.php
+++ b/tests/TestCase/Command/CommandCommandTest.php
@@ -113,11 +113,11 @@ class CommandCommandTest extends TestCase
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains(
-            '@uses \Bake\Test\App\Command\DocblockCommand::buildOptionParser()',
+            '@link \Bake\Test\App\Command\DocblockCommand::buildOptionParser()',
             $testsPath . 'TestCase/Command/DocblockCommandTest.php',
         );
         $this->assertFileContains(
-            '@uses \Bake\Test\App\Command\DocblockCommand::execute()',
+            '@link \Bake\Test\App\Command\DocblockCommand::execute()',
             $testsPath . 'TestCase/Command/DocblockCommandTest.php',
         );
     }
@@ -142,11 +142,11 @@ class CommandCommandTest extends TestCase
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains(
-            '@uses \BakeTest\Command\DocblockCommand::buildOptionParser()',
+            '@link \BakeTest\Command\DocblockCommand::buildOptionParser()',
             $testsPath . 'TestCase/Command/DocblockCommandTest.php',
         );
         $this->assertFileContains(
-            '@uses \BakeTest\Command\DocblockCommand::execute()',
+            '@link \BakeTest\Command\DocblockCommand::execute()',
             $testsPath . 'TestCase/Command/DocblockCommandTest.php',
         );
     }

--- a/tests/TestCase/Command/TestCommandTest.php
+++ b/tests/TestCase/Command/TestCommandTest.php
@@ -735,7 +735,7 @@ class TestCommandTest extends TestCase
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains(
-            '@uses \Bake\Test\App\Controller\ProductsController::index()',
+            '@link \Bake\Test\App\Controller\ProductsController::index()',
             $testsPath . 'TestCase/Controller/ProductsControllerTest.php',
         );
     }
@@ -757,7 +757,7 @@ class TestCommandTest extends TestCase
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFileContains(
-            '@uses \Bake\Test\App\Model\Table\ProductsTable::validationDefault()',
+            '@link \Bake\Test\App\Model\Table\ProductsTable::validationDefault()',
             $testsPath . 'TestCase/Model/Table/ProductsTableTest.php',
         );
     }

--- a/tests/comparisons/Test/testBakeCommandHelperTest.php
+++ b/tests/comparisons/Test/testBakeCommandHelperTest.php
@@ -63,7 +63,7 @@ class ErrorHelperTest extends TestCase
      * Test output method
      *
      * @return void
-     * @uses \Bake\Test\App\Command\Helper\ErrorHelper::output()
+     * @link \Bake\Test\App\Command\Helper\ErrorHelper::output()
      */
     public function testOutput(): void
     {

--- a/tests/comparisons/Test/testBakeCommandTest.php
+++ b/tests/comparisons/Test/testBakeCommandTest.php
@@ -10,7 +10,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Bake\Test\App\Command\OtherExampleCommand Test Case
  *
- * @uses \Bake\Test\App\Command\OtherExampleCommand
+ * @link \Bake\Test\App\Command\OtherExampleCommand
  */
 class OtherExampleCommandTest extends TestCase
 {

--- a/tests/comparisons/Test/testBakeComponentTest.php
+++ b/tests/comparisons/Test/testBakeComponentTest.php
@@ -47,7 +47,7 @@ class AppleComponentTest extends TestCase
      * Test startup method
      *
      * @return void
-     * @uses \Bake\Test\App\Controller\Component\AppleComponent::startup()
+     * @link \Bake\Test\App\Controller\Component\AppleComponent::startup()
      */
     public function testStartup(): void
     {

--- a/tests/comparisons/Test/testBakeControllerTest.php
+++ b/tests/comparisons/Test/testBakeControllerTest.php
@@ -10,7 +10,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Bake\Test\App\Controller\PostsController Test Case
  *
- * @uses \Bake\Test\App\Controller\PostsController
+ * @link \Bake\Test\App\Controller\PostsController
  */
 class PostsControllerTest extends TestCase
 {
@@ -29,7 +29,7 @@ class PostsControllerTest extends TestCase
      * Test index method
      *
      * @return void
-     * @uses \Bake\Test\App\Controller\PostsController::index()
+     * @link \Bake\Test\App\Controller\PostsController::index()
      */
     public function testIndex(): void
     {

--- a/tests/comparisons/Test/testBakeControllerWithoutModelTest.php
+++ b/tests/comparisons/Test/testBakeControllerWithoutModelTest.php
@@ -10,7 +10,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Bake\Test\App\Controller\NoModelController Test Case
  *
- * @uses \Bake\Test\App\Controller\NoModelController
+ * @link \Bake\Test\App\Controller\NoModelController
  */
 class NoModelControllerTest extends TestCase
 {
@@ -20,7 +20,7 @@ class NoModelControllerTest extends TestCase
      * Test index method
      *
      * @return void
-     * @uses \Bake\Test\App\Controller\NoModelController::index()
+     * @link \Bake\Test\App\Controller\NoModelController::index()
      */
     public function testIndex(): void
     {

--- a/tests/comparisons/Test/testBakeModelTest.php
+++ b/tests/comparisons/Test/testBakeModelTest.php
@@ -58,7 +58,7 @@ class ArticlesTableTest extends TestCase
      * Test findPublished method
      *
      * @return void
-     * @uses \Bake\Test\App\Model\Table\ArticlesTable::findPublished()
+     * @link \Bake\Test\App\Model\Table\ArticlesTable::findPublished()
      */
     public function testFindPublished(): void
     {
@@ -69,7 +69,7 @@ class ArticlesTableTest extends TestCase
      * Test doSomething method
      *
      * @return void
-     * @uses \Bake\Test\App\Model\Table\ArticlesTable::doSomething()
+     * @link \Bake\Test\App\Model\Table\ArticlesTable::doSomething()
      */
     public function testDoSomething(): void
     {
@@ -80,7 +80,7 @@ class ArticlesTableTest extends TestCase
      * Test doSomethingElse method
      *
      * @return void
-     * @uses \Bake\Test\App\Model\Table\ArticlesTable::doSomethingElse()
+     * @link \Bake\Test\App\Model\Table\ArticlesTable::doSomethingElse()
      */
     public function testDoSomethingElse(): void
     {

--- a/tests/comparisons/Test/testBakePrefixControllerTest.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTest.php
@@ -10,7 +10,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Bake\Test\App\Controller\Admin\PostsController Test Case
  *
- * @uses \Bake\Test\App\Controller\Admin\PostsController
+ * @link \Bake\Test\App\Controller\Admin\PostsController
  */
 class PostsControllerTest extends TestCase
 {
@@ -29,7 +29,7 @@ class PostsControllerTest extends TestCase
      * Test index method
      *
      * @return void
-     * @uses \Bake\Test\App\Controller\Admin\PostsController::index()
+     * @link \Bake\Test\App\Controller\Admin\PostsController::index()
      */
     public function testIndex(): void
     {
@@ -40,7 +40,7 @@ class PostsControllerTest extends TestCase
      * Test add method
      *
      * @return void
-     * @uses \Bake\Test\App\Controller\Admin\PostsController::add()
+     * @link \Bake\Test\App\Controller\Admin\PostsController::add()
      */
     public function testAdd(): void
     {

--- a/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
@@ -10,7 +10,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Bake\Test\App\Controller\Admin\PostsController Test Case
  *
- * @uses \Bake\Test\App\Controller\Admin\PostsController
+ * @link \Bake\Test\App\Controller\Admin\PostsController
  */
 class PostsControllerTest extends TestCase
 {
@@ -29,7 +29,7 @@ class PostsControllerTest extends TestCase
      * Test index method
      *
      * @return void
-     * @uses \Bake\Test\App\Controller\Admin\PostsController::index()
+     * @link \Bake\Test\App\Controller\Admin\PostsController::index()
      */
     public function testIndex(): void
     {
@@ -40,7 +40,7 @@ class PostsControllerTest extends TestCase
      * Test add method
      *
      * @return void
-     * @uses \Bake\Test\App\Controller\Admin\PostsController::add()
+     * @link \Bake\Test\App\Controller\Admin\PostsController::add()
      */
     public function testAdd(): void
     {


### PR DESCRIPTION
Refs https://github.com/dereuromark/cakephp-ide-helper/issues/351

We are mainly adding it for traceability in apps, to follow to the code, and see if the code has a test.
The new PHPStorm and IDE versions want to convert `@uses` into

    #[UsesFunction('execute')] 

PHPUnit attributes

To avoid this clash we should use `@link`. I checked and it works the same for PHPStorm at least.