### PR TITLE
Fix up wrapper usage for io.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.0.0",
         "cakephp/debug_kit": "^5.0.0",
-        "phpunit/phpunit": "^10.5.5 || ^11.1.3"
+        "phpunit/phpunit": "^10.5.40 || ^11.5.20 || ^12.2.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -131,9 +131,9 @@ class AllCommand extends BakeCommand
         }
 
         if ($errors) {
-            $io->warning(sprintf('Bake All completed, but with %s errors.', $errors), 1, ConsoleIo::NORMAL);
+            $io->warning(sprintf('Bake All completed, but with %s errors.', $errors));
         } else {
-            $io->success('Bake All complete.', 1, ConsoleIo::NORMAL);
+            $io->success('Bake All complete.');
         }
 
         return $errors ? static::CODE_ERROR : static::CODE_SUCCESS;

--- a/src/Command/AllCommand.php
+++ b/src/Command/AllCommand.php
@@ -124,16 +124,16 @@ class AllCommand extends BakeCommand
                     }
 
                     $message = sprintf('Error generating %s for %s: %s', $commandName, $table, $e->getMessage());
-                    $io->err('<error>' . $message . '</error>');
+                    $io->error($message);
                     $errors++;
                 }
             }
         }
 
         if ($errors) {
-            $io->out(sprintf('<warning>Bake All completed, but with %s errors.</warning>', $errors), 1, ConsoleIo::NORMAL);
+            $io->warning(sprintf('Bake All completed, but with %s errors.', $errors), 1, ConsoleIo::NORMAL);
         } else {
-            $io->out('<success>Bake All complete.</success>', 1, ConsoleIo::NORMAL);
+            $io->success('Bake All complete.', 1, ConsoleIo::NORMAL);
         }
 
         return $errors ? static::CODE_ERROR : static::CODE_SUCCESS;

--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -180,7 +180,7 @@ abstract class BakeCommand extends Command
     {
         if (file_exists($path)) {
             unlink($path);
-            $io->out(sprintf('<success>Deleted</success> `%s`', $path), 1, ConsoleIo::NORMAL);
+            $io->out(sprintf('<success>Deleted</success> `%s`', $path));
         }
     }
 

--- a/src/Command/EntryCommand.php
+++ b/src/Command/EntryCommand.php
@@ -82,7 +82,7 @@ class EntryCommand extends Command implements CommandCollectionAwareInterface
                 $parser->argumentNames(),
             );
         } catch (ConsoleException $e) {
-            $io->err('Error: ' . $e->getMessage());
+            $io->error('Error: ' . $e->getMessage());
 
             return static::CODE_ERROR;
         }
@@ -109,14 +109,14 @@ class EntryCommand extends Command implements CommandCollectionAwareInterface
     {
         if ($args->hasArgumentAt(0)) {
             $name = $args->getArgumentAt(0);
-            $io->err(
-                "<error>Could not find bake command named `$name`."
-                . ' Run `bake --help` to get a list of commands.</error>',
+            $io->error(
+                "Could not find bake command named `$name`."
+                . ' Run `bake --help` to get a list of commands.',
             );
 
             return static::CODE_ERROR;
         }
-        $io->err('<warning>No command provided. Run `bake --help` to get a list of commands.</warning>');
+        $io->warning('No command provided. Run `bake --help` to get a list of commands.');
 
         return static::CODE_ERROR;
     }

--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -269,7 +269,7 @@ class FixtureCommand extends BakeCommand
             ->set($vars)
             ->generate('Bake.tests/fixture');
 
-        $io->out("\n" . sprintf('Baking test fixture for %s...', $model), 1, ConsoleIo::NORMAL);
+        $io->out("\n" . sprintf('Baking test fixture for %s...', $model));
         $io->createFile($path . $filename, $contents, $this->force);
         $emptyFile = $path . '.gitkeep';
         $this->deleteEmptyFile($emptyFile, $io);

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -1146,7 +1146,7 @@ class ModelCommand extends BakeCommand
         }
 
         $name = $this->_entityName($model->getAlias());
-        $io->out("\n" . sprintf('Baking entity class for %s...', $name), 1, ConsoleIo::NORMAL);
+        $io->out("\n" . sprintf('Baking entity class for %s...', $name));
 
         $namespace = Configure::read('App.namespace');
         $pluginPath = '';
@@ -1198,7 +1198,7 @@ class ModelCommand extends BakeCommand
         }
 
         $name = $model->getAlias();
-        $io->out("\n" . sprintf('Baking table class for %s...', $name), 1, ConsoleIo::NORMAL);
+        $io->out("\n" . sprintf('Baking table class for %s...', $name));
 
         $namespace = Configure::read('App.namespace');
         $pluginPath = '';

--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -56,8 +56,8 @@ class PluginCommand extends BakeCommand
     {
         $name = $args->getArgument('name');
         if (empty($name)) {
-            $io->err('<error>You must provide a plugin name in CamelCase format.</error>');
-            $io->err('To make an "MyExample" plugin, run <info>`cake bake plugin MyExample`</info>.');
+            $io->error('You must provide a plugin name in CamelCase format.');
+            $io->out('To make an "MyExample" plugin, run <info>`cake bake plugin MyExample`</info>.');
 
             return static::CODE_ERROR;
         }
@@ -70,7 +70,7 @@ class PluginCommand extends BakeCommand
             $this->isVendor = true;
 
             if (!is_dir($this->path)) {
-                $io->err(sprintf('Path `%s` does not exist.', $this->path));
+                $io->error(sprintf('Path `%s` does not exist.', $this->path));
 
                 return static::CODE_ERROR;
             }

--- a/src/Command/SimpleBakeCommand.php
+++ b/src/Command/SimpleBakeCommand.php
@@ -78,7 +78,7 @@ abstract class SimpleBakeCommand extends BakeCommand
         $this->extractCommonProperties($args);
         $name = $args->getArgumentAt(0);
         if (empty($name)) {
-            $io->err('You must provide a name to bake a ' . $this->name());
+            $io->error('You must provide a name to bake a ' . $this->name());
             $this->abort();
         }
         $name = $this->_getName($name);

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -367,7 +367,7 @@ class TemplateCommand extends BakeCommand
         $path = $this->getTemplatePath($args);
         $filename = $path . Inflector::underscore($outputFile) . '.' . $this->ext;
 
-        $io->out("\n" . sprintf('Baking `%s` view template file...', $outputFile), 1, ConsoleIo::NORMAL);
+        $io->out("\n" . sprintf('Baking `%s` view template file...', $outputFile));
         $io->createFile($filename, $content, $this->force);
     }
 

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -360,7 +360,7 @@ class TemplateCommand extends BakeCommand
         }
         if (empty($content)) {
             // phpcs:ignore Generic.Files.LineLength
-            $io->err("<warning>No generated content for '{$template}.{$this->ext}', not generating template.</warning>");
+            $io->warning("No generated content for '{$template}.{$this->ext}', not generating template.");
 
             return;
         }

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -124,7 +124,7 @@ class TestCommand extends BakeCommand
         $name = $this->_getName($name);
 
         if ($this->bake($type, $name, $args, $io)) {
-            $io->out('<success>Done</success>');
+            $io->success('Done');
         }
 
         return static::CODE_SUCCESS;
@@ -188,13 +188,13 @@ class TestCommand extends BakeCommand
 
         foreach ($classes as $class) {
             if ($this->bake($type, $class, $args, $io)) {
-                $io->out('<success>Done - ' . $class . '</success>');
+                $io->success('Done - ' . $class);
             } else {
-                $io->out('<error>Failed - ' . $class . '</error>');
+                $io->error('Failed - ' . $class);
             }
         }
 
-        $io->out('<info>Bake finished</info>');
+        $io->info('Bake finished');
     }
 
     /**


### PR DESCRIPTION
I noticed that IO is not used via wrappers, probably legacy wise.
Also some errors are written into stdout instead of stderr

I propose to consolidate this using the wrappers as intended to be used, also simplifies the code.

Added PHPUnit 12