### PR TITLE
Ensure fallback class is enabled for the table locator.

### DIFF
--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -27,6 +27,7 @@ use Cake\Core\Configure;
 use Cake\Core\ConventionsTrait;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
+use Cake\ORM\Locator\TableLocator;
 use InvalidArgumentException;
 use function Cake\Core\pluginSplit;
 
@@ -47,6 +48,22 @@ abstract class BakeCommand extends Command
      * @var string
      */
     protected string $pathFragment;
+
+    /**
+     * Initialize the command.
+     *
+     * @return void
+     */
+    public function initialize(): void
+    {
+        parent::initialize();
+
+        $locator = $this->getTableLocator();
+        if ($locator instanceof TableLocator) {
+            $locator->allowFallbackClass(true);
+            $this->setTableLocator($locator);
+        }
+    }
 
     /**
      * Get the command name.

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -100,6 +100,8 @@ class TemplateCommand extends BakeCommand
      */
     public function initialize(): void
     {
+        parent::initialize();
+
         $this->path = current(App::path('templates'));
     }
 


### PR DESCRIPTION
It's recommended to disable fallback class during normal functioning of the app but fallback needs to be enabled when baking as the required table classes might still not have been created.