### PR TITLE
Dont add fixtures if fixture factories are used.

### DIFF
--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -318,9 +318,8 @@ class TestCommand extends BakeCommand
      */
     protected function hasFixtureFactories(): bool
     {
-        // Check if the CakephpFixtureFactories plugin class exists
-        return class_exists('CakephpFixtureFactories\Plugin') ||
-               class_exists('CakephpFixtureFactories\CakephpFixtureFactoriesPlugin');
+        return class_exists('CakephpFixtureFactories\Plugin')
+            || class_exists('CakephpFixtureFactories\CakephpFixtureFactoriesPlugin');
     }
 
     /**

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -244,7 +244,7 @@ class TestCommand extends BakeCommand
 
         // Check if fixture factories plugin is available
         $hasFixtureFactories = $this->hasFixtureFactories();
-        
+
         if (!$args->getOption('no-fixture')) {
             if ($hasFixtureFactories) {
                 $io->info('Fixture Factories plugin detected - skipping fixture property generation.');

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -242,8 +242,13 @@ class TestCommand extends BakeCommand
         $prefix = $this->getPrefix($args);
         $fullClassName = $this->getRealClassName($type, $className, $prefix);
 
+        // Check if fixture factories plugin is available
+        $hasFixtureFactories = $this->hasFixtureFactories();
+        
         if (!$args->getOption('no-fixture')) {
-            if ($args->getOption('fixtures')) {
+            if ($hasFixtureFactories) {
+                $io->info('Fixture Factories plugin detected - skipping fixture property generation.');
+            } elseif ($args->getOption('fixtures')) {
                 $fixtures = array_map('trim', explode(',', $args->getOption('fixtures')));
                 $this->_fixtures = array_filter($fixtures);
             } elseif ($this->typeCanDetectFixtures($type) && class_exists($fullClassName)) {
@@ -277,6 +282,7 @@ class TestCommand extends BakeCommand
         $contents = $this->createTemplateRenderer()
             ->set('fixtures', $this->_fixtures)
             ->set('plugin', $this->plugin)
+            ->set('hasFixtureFactories', $hasFixtureFactories)
             ->set(compact(
                 'subject',
                 'className',
@@ -303,6 +309,18 @@ class TestCommand extends BakeCommand
         }
 
         return false;
+    }
+
+    /**
+     * Check if the CakePHP Fixture Factories plugin is available
+     *
+     * @return bool
+     */
+    protected function hasFixtureFactories(): bool
+    {
+        // Check if the CakephpFixtureFactories plugin class exists
+        return class_exists('CakephpFixtureFactories\Plugin') ||
+               class_exists('CakephpFixtureFactories\CakephpFixtureFactoriesPlugin');
     }
 
     /**

--- a/src/Utility/SubsetSchemaCollection.php
+++ b/src/Utility/SubsetSchemaCollection.php
@@ -33,7 +33,7 @@ class SubsetSchemaCollection implements CollectionInterface
     protected CollectionInterface $collection;
 
     /**
-     * @var list<string>
+     * @var array<string>
      */
     protected array $tables = [];
 

--- a/templates/bake/Model/entity.twig
+++ b/templates/bake/Model/entity.twig
@@ -59,7 +59,7 @@ class {{ name }} extends Entity{{ fileBuilder.classBuilder.implements ? ' implem
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $_hidden = {{ Bake.exportVar(hidden, 1)|raw }};
 {% endif %}

--- a/templates/bake/tests/test_case.twig
+++ b/templates/bake/tests/test_case.twig
@@ -63,11 +63,11 @@ class {{ className }}Test extends TestCase
 {% endfor %}
 {% endif %}
 
-{%- if fixtures %}
+{%- if fixtures and not (hasFixtureFactories|default(false)) %}
     /**
      * Fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = {{ Bake.exportVar(fixtures|values, 1)|raw }};
 {% if construction or methods %}

--- a/tests/TestCase/Command/AllCommandTest.php
+++ b/tests/TestCase/Command/AllCommandTest.php
@@ -29,7 +29,7 @@ class AllCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.Products',
@@ -37,7 +37,7 @@ class AllCommandTest extends TestCase
     ];
 
     /**
-     * @var list<string>
+     * @var array<string>
      */
     protected array $tables = ['products', 'product_versions'];
 

--- a/tests/TestCase/Command/ControllerAllCommandTest.php
+++ b/tests/TestCase/Command/ControllerAllCommandTest.php
@@ -30,7 +30,7 @@ class ControllerAllCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.BakeArticles',
@@ -38,7 +38,7 @@ class ControllerAllCommandTest extends TestCase
     ];
 
     /**
-     * @var list<string>
+     * @var array<string>
      */
     protected array $tables = ['bake_articles', 'bake_comments'];
 

--- a/tests/TestCase/Command/ControllerCommandTest.php
+++ b/tests/TestCase/Command/ControllerCommandTest.php
@@ -32,7 +32,7 @@ class ControllerCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.BakeArticles',

--- a/tests/TestCase/Command/FixtureAllCommandTest.php
+++ b/tests/TestCase/Command/FixtureAllCommandTest.php
@@ -30,7 +30,7 @@ class FixtureAllCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.Articles',
@@ -38,7 +38,7 @@ class FixtureAllCommandTest extends TestCase
     ];
 
     /**
-     * @var list<string>
+     * @var array<string>
      */
     protected array $tables = ['articles', 'comments'];
 

--- a/tests/TestCase/Command/FixtureCommandTest.php
+++ b/tests/TestCase/Command/FixtureCommandTest.php
@@ -35,7 +35,7 @@ class FixtureCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.Articles',

--- a/tests/TestCase/Command/ModelAllCommandTest.php
+++ b/tests/TestCase/Command/ModelAllCommandTest.php
@@ -30,7 +30,7 @@ class ModelAllCommandTest extends TestCase
     /**
      * fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.TodoTasks',
@@ -38,7 +38,7 @@ class ModelAllCommandTest extends TestCase
     ];
 
     /**
-     * @var list<string>
+     * @var array<string>
      */
     protected array $tables = ['todo_tasks', 'todo_items'];
 

--- a/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
+++ b/tests/TestCase/Command/ModelCommandAssociationDetectionTest.php
@@ -36,7 +36,7 @@ class ModelCommandAssociationDetectionTest extends TestCase
      * Don't sort this list alphabetically - otherwise there are table constraints
      * which fail when using postgres
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.Categories',

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -44,7 +44,7 @@ class ModelCommandTest extends TestCase
      * Don't sort this list alphabetically - otherwise there are table constraints
      * which fail when using postgres
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.Articles',

--- a/tests/TestCase/Command/TemplateAllCommandTest.php
+++ b/tests/TestCase/Command/TemplateAllCommandTest.php
@@ -30,7 +30,7 @@ class TemplateAllCommandTest extends TestCase
     /**
      * Fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.Articles',
@@ -38,7 +38,7 @@ class TemplateAllCommandTest extends TestCase
     ];
 
     /**
-     * @var list<string>
+     * @var array<string>
      */
     protected array $tables = ['articles', 'comments'];
 

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -39,7 +39,7 @@ class TemplateCommandTest extends TestCase
     /**
      * Fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.Articles',

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -32,7 +32,7 @@ abstract class TestCase extends BaseTestCase
     protected $generatedFile = '';
 
     /**
-     * @var list<string>
+     * @var array<string>
      */
     protected $generatedFiles = [];
 

--- a/tests/TestCase/Utility/Model/AssociationFilterTest.php
+++ b/tests/TestCase/Utility/Model/AssociationFilterTest.php
@@ -30,7 +30,7 @@ class AssociationFilterTest extends TestCase
      * Don't sort this list alphabetically - otherwise there are table constraints
      * which fail when using postgres
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.Authors',

--- a/tests/TestCase/Utility/TableScannerTest.php
+++ b/tests/TestCase/Utility/TableScannerTest.php
@@ -23,7 +23,7 @@ use Cake\Datasource\ConnectionManager;
 class TableScannerTest extends TestCase
 {
     /**
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.TodoTasks',

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -33,7 +33,7 @@ class BakeHelperTest extends TestCase
      * Don't sort this list alphabetically - otherwise there are table constraints
      * which fail when using postgres
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'plugin.Bake.BakeArticles',

--- a/tests/comparisons/Model/testBakeEntityCustomHidden.php
+++ b/tests/comparisons/Model/testBakeEntityCustomHidden.php
@@ -23,7 +23,7 @@ class User extends Entity
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $_hidden = [
         'foo',

--- a/tests/comparisons/Model/testBakeEntityFullContext.php
+++ b/tests/comparisons/Model/testBakeEntityFullContext.php
@@ -42,7 +42,7 @@ class User extends Entity
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $_hidden = [
         'password',

--- a/tests/comparisons/Model/testBakeEntityHidden.php
+++ b/tests/comparisons/Model/testBakeEntityHidden.php
@@ -23,7 +23,7 @@ class User extends Entity
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $_hidden = [
         'password',

--- a/tests/comparisons/Model/testBakeEntityWithPlugin.php
+++ b/tests/comparisons/Model/testBakeEntityWithPlugin.php
@@ -42,7 +42,7 @@ class User extends Entity
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $_hidden = [
         'password',

--- a/tests/comparisons/Model/testBakeUpdateEntity.php
+++ b/tests/comparisons/Model/testBakeUpdateEntity.php
@@ -35,7 +35,7 @@ class TodoItem extends Entity implements IdentityInterface
     /**
      * Fields that are excluded from JSON versions of the entity.
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $_hidden = [
         'user_id',

--- a/tests/comparisons/Test/testBakeControllerTest.php
+++ b/tests/comparisons/Test/testBakeControllerTest.php
@@ -19,7 +19,7 @@ class PostsControllerTest extends TestCase
     /**
      * Fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'app.Posts',

--- a/tests/comparisons/Test/testBakeFixturesParam.php
+++ b/tests/comparisons/Test/testBakeFixturesParam.php
@@ -21,7 +21,7 @@ class AuthorsTableTest extends TestCase
     /**
      * Fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'app.Posts',

--- a/tests/comparisons/Test/testBakeModelTest.php
+++ b/tests/comparisons/Test/testBakeModelTest.php
@@ -21,7 +21,7 @@ class ArticlesTableTest extends TestCase
     /**
      * Fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'app.Articles',

--- a/tests/comparisons/Test/testBakePrefixControllerTest.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTest.php
@@ -19,7 +19,7 @@ class PostsControllerTest extends TestCase
     /**
      * Fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'app.Posts',

--- a/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
+++ b/tests/comparisons/Test/testBakePrefixControllerTestWithCliOption.php
@@ -19,7 +19,7 @@ class PostsControllerTest extends TestCase
     /**
      * Fixtures
      *
-     * @var list<string>
+     * @var array<string>
      */
     protected array $fixtures = [
         'app.Posts',


### PR DESCRIPTION
Having them added, breaks things (since they dont exist).
As with fixture factories we should rely on those only.

Also fixed up the wrong docblocks as the core already has

    /**
     * Fixtures used by this test case.
     *
     * @var array<string>
     */
    protected array $fixtures = [];
