### PR TITLE
fix composer.json not being generated for private plugins

### DIFF
--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -238,7 +238,7 @@ class PluginCommand extends BakeCommand
 
                 if (!$this->isVendor) {
                     $vendorFiles = [
-                        '.gitignore.twig', 'README.md.twig', 'composer.json.twig', 'phpunit.xml.dist.twig',
+                        '.gitignore.twig', 'README.md.twig', 'phpunit.xml.dist.twig',
                         'bootstrap.php.twig', 'schema.sql.twig',
                     ];
 

--- a/tests/comparisons/Plugin/SimpleExample/composer.json
+++ b/tests/comparisons/Plugin/SimpleExample/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "your-name-here/simple-example",
+    "description": "SimpleExample plugin for CakePHP",
+    "type": "cakephp-plugin",
+    "license": "MIT",
+    "require": {
+        "php": ">=8.1",
+        "cakephp/cakephp": "^5.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "SimpleExample\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SimpleExample\\Test\\": "tests/",
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
+        }
+    }
+}


### PR DESCRIPTION
I'd love to see users move the namespace definition of their private plugins inside the plugin where its actually used, not in the root composer.json like in the old days.

This is supported since CakePHP 5 / Plugin Installver v2 as you can see [here](https://github.com/cakephp/plugin-installer/pull/64)

Currently when baking a plugin it doesn't generate a composer.json AND doesn't adjust the composer.json of the root app, so the generated namespace in the plugin is actually not hooked up at all.