### PR TITLE
Update templates to use line stripping tags

### DIFF
--- a/templates/bake/Controller/controller.twig
+++ b/templates/bake/Controller/controller.twig
@@ -32,7 +32,7 @@
 {% endif %}
 
 {%- for component in components %}
-{% set classInfo = Bake.classInfo(component, 'Controller/Component', 'Component') %}
+    {%~ set classInfo = Bake.classInfo(component, 'Controller/Component', 'Component') %}
  * @property {{ classInfo.fqn }} ${{ classInfo.name }}
 {% endfor %}
  */
@@ -48,20 +48,20 @@ class {{ name }}Controller extends AppController
     {
         parent::initialize();
 
-{% for component in components %}
+    {%~ for component in components %}
         $this->loadComponent('{{ component }}');
-{% endfor %}
-{% if helpers %}
+    {%~ endfor %}
+    {%~ if helpers %}
         $this->viewBuilder()->setHelpers({{ Bake.exportArray(helpers)|raw }});
-{% endif %}
-{% if has_login %}
+    {%~ endif %}
+    {%~ if has_login %}
         $this->Authentication->allowUnauthenticated(['login']);
-{% endif %}
+    {%~ endif %}
     }
-{% if actions|length %}{{ "\n" }}{% endif %}
+    {%~ if actions|length %}{{ "\n" }}{% endif %}
 {% endif %}
-{%- for action in actions %}
-{% if loop.index > 1 %}{{ "\n" }}{% endif %}
+{% for action in actions %}
+    {%~ if loop.index > 1 %}{{ "\n" }}{% endif %}
     {{- element('Bake.Controller/' ~ action) -}}
 {% endfor %}
 }

--- a/templates/bake/Model/entity.twig
+++ b/templates/bake/Model/entity.twig
@@ -18,8 +18,8 @@
 {% set annotations = DocBlock.propertyHints(propertyHintMap) %}
 
 {%- if associationHintMap %}
-    {%- set annotations = annotations|merge(['']) %}
-    {%- set annotations = annotations|merge(DocBlock.propertyHints(associationHintMap)) %}
+    {%~ set annotations = annotations|merge(['']) %}
+    {%~ set annotations = annotations|merge(DocBlock.propertyHints(associationHintMap)) %}
 {% endif %}
 
 {%- set accessible = Bake.getFieldAccessibility(fields, primaryKey) %}
@@ -39,7 +39,7 @@ class {{ name }} extends Entity{{ fileBuilder.classBuilder.implements ? ' implem
 
 {% endif %}
 {% if accessible %}
-{%- set generatedProperties = generatedProperties|merge(['_accessible']) %}
+{%~ set generatedProperties = generatedProperties|merge(['_accessible']) %}
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().
      *
@@ -54,8 +54,8 @@ class {{ name }} extends Entity{{ fileBuilder.classBuilder.implements ? ' implem
 {% if accessible and hidden %}
 
 {% endif %}
-{%- if hidden %}
-{%- set generatedProperties = generatedProperties|merge(['_hidden']) %}
+{% if hidden %}
+    {%~ set generatedProperties = generatedProperties|merge(['_hidden']) %}
     /**
      * Fields that are excluded from JSON versions of the entity.
      *

--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -50,58 +50,43 @@ class {{ name }}Table extends Table{{ fileBuilder.classBuilder.implements ? ' im
 {%- if displayField %}
         $this->setDisplayField({{ (displayField is iterable ? Bake.exportArray(displayField) : Bake.exportVar(displayField))|raw }});
 {% endif %}
-
-{%- if primaryKey %}
-    {%- if primaryKey is iterable and primaryKey|length > 1 %}
+{% if primaryKey %}
+    {%~ if primaryKey is iterable and primaryKey|length > 1 %}
         $this->setPrimaryKey({{ Bake.exportArray(primaryKey)|raw }});
-        {{- "\n" }}
-    {%- else %}
+    {%~ else %}
         $this->setPrimaryKey('{{ primaryKey|as_array|first }}');
-        {{- "\n" }}
-    {%- endif %}
+    {%~ endif %}
 {% endif %}
+{% if enums %}
 
-{%- if enums %}
-
-{% endif %}
-
-{%- if enums %}
-
-{%- for name, className in enums %}
+    {%~ for name, className in enums %}
         $this->getSchema()->setColumnType('{{ name }}', \Cake\Database\Type\EnumType::from(\{{ className }}::class));
-{% endfor %}
+    {%~ endfor %}
 {% endif %}
+{% if behaviors %}
 
-{%- if behaviors %}
-
-{% endif %}
-
-{%- for behavior, behaviorData in behaviors %}
+    {%~ for behavior, behaviorData in behaviors %}
         $this->addBehavior('{{ behavior }}'{{ (behaviorData ? (", " ~ Bake.exportArray(behaviorData, 2)|raw ~ '') : '')|raw }});
-{% endfor %}
-
-{%- if associations.belongsTo or associations.hasMany or associations.belongsToMany %}
-
+    {%~ endfor %}
 {% endif %}
+{% if associations.belongsTo or associations.hasMany or associations.belongsToMany %}
 
-{%- for type, assocs in associations %}
-    {%- for assoc in assocs %}
-        {%- set assocData = [] %}
-        {%- for key, val in assoc %}
-            {%- if key is not same as('alias') %}
-                {%- set assocData = assocData|merge({(key): val}) %}
-            {%- endif %}
-        {%- endfor %}
+    {%~ for type, assocs in associations %}
+        {%~ for assoc in assocs %}
+            {%~ set assocData = [] %}
+            {%~ for key, val in assoc %}
+                {%~ if key is not same as('alias') %}
+                    {%~ set assocData = assocData|merge({(key): val}) %}
+                {%~ endif %}
+            {%~ endfor %}
         $this->{{ type }}('{{ assoc.alias }}', {{ Bake.exportArray(assocData, 2)|raw }});
-        {{- "\n" }}
-    {%- endfor %}
-{% endfor %}
+        {%~ endfor %}
+    {%~ endfor %}
+{% endif %}
     }
-{{- "\n" }}
+{% if validation %}
 
-{%- if validation %}
-{% set generatedFunctions = generatedFunctions|merge(['validationDefault']) %}
-
+    {%~ set generatedFunctions = generatedFunctions|merge(['validationDefault']) %}
     /**
      * Default validation rules.
      *
@@ -110,25 +95,24 @@ class {{ name }}Table extends Table{{ fileBuilder.classBuilder.implements ? ' im
      */
     public function validationDefault(Validator $validator): Validator
     {
-{% for field, rules in validation %}
-{% set validationMethods = Bake.getValidationMethods(field, rules) %}
-{% if validationMethods %}
+    {%~ for field, rules in validation %}
+        {%~ set validationMethods = Bake.getValidationMethods(field, rules) %}
+        {%~ if validationMethods %}
         $validator
-{% for validationMethod in validationMethods %}
-{% if loop.last %}
-{% set validationMethod = validationMethod ~ ';' %}
-{% endif %}
+            {%~ for validationMethod in validationMethods %}
+                {%~ if loop.last %}
+                    {%~ set validationMethod = validationMethod ~ ';' %}
+                {%~ endif %}
             {{ validationMethod|raw }}
-{% endfor %}
+            {%~ endfor %}
 
-{% endif %}
-{% endfor %}
+        {%~ endif %}
+    {%~ endfor %}
         return $validator;
     }
 {% endif %}
-
 {%- if rulesChecker %}
-{% set generatedFunctions = generatedFunctions|merge(['buildRules']) %}
+    {%~ set generatedFunctions = generatedFunctions|merge(['buildRules']) %}
 
     /**
      * Returns a rules checker object that will be used for validating
@@ -139,21 +123,20 @@ class {{ name }}Table extends Table{{ fileBuilder.classBuilder.implements ? ' im
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-{% for rule in rulesChecker %}
-{% set fields = Bake.exportArray(rule.fields) %}
-{% set options = '' %}
-{% for optionName, optionValue in rule.options %}
-    {%~ set options = (loop.first ? '[' : options) ~ "'#{optionName}' => " ~ Bake.exportVar(optionValue) ~ (loop.last ? ']' : ', ') %}
-{% endfor %}
+    {%~ for rule in rulesChecker %}
+        {%~ set fields = Bake.exportArray(rule.fields) %}
+        {%~ set options = '' %}
+        {%~ for optionName, optionValue in rule.options %}
+            {%~ set options = (loop.first ? '[' : options) ~ "'#{optionName}' => " ~ Bake.exportVar(optionValue) ~ (loop.last ? ']' : ', ') %}
+        {%~ endfor %}
         $rules->add($rules->{{ rule.name }}({{ fields|raw }}{{ (rule.extra|default ? ", '#{rule.extra}'" : '')|raw }}{{ (options ? ', ' ~ options : '')|raw }}), ['errorField' => '{{ rule.fields[0] }}']);
-{% endfor %}
+    {%~ endfor %}
 
         return $rules;
     }
 {% endif %}
-
-{%- if connection is not same as('default') %}
-{% set generatedFunctions = generatedFunctions|merge(['defaultConnectionName']) %}
+{% if connection is not same as('default') %}
+    {%~ set generatedFunctions = generatedFunctions|merge(['defaultConnectionName']) %}
 
     /**
      * Returns the database connection name to use by default.

--- a/templates/bake/Template/add.twig
+++ b/templates/bake/Template/add.twig
@@ -17,18 +17,15 @@
 /**
  * @var \{{ namespace }}\View\AppView $this
  * @var \{{ entityClass }} ${{ singularVar }}
-        {{- "\n" }}
-{%- if associations.BelongsTo is defined %}
-    {%- for assocName, assocData in associations.BelongsTo %}
+{% if associations.BelongsTo is defined %}
+    {%~ for assocName, assocData in associations.BelongsTo %}
  * @var \Cake\Collection\CollectionInterface|string[] ${{ assocData.variable }}
-        {{- "\n" }}
-    {%- endfor %}
+    {%~ endfor %}
 {% endif %}
-{%- if associations.BelongsToMany is defined %}
-    {%- for assocName, assocData in associations.BelongsToMany %}
+{% if associations.BelongsToMany is defined %}
+    {%~ for assocName, assocData in associations.BelongsToMany %}
  * @var \Cake\Collection\CollectionInterface|string[] ${{ assocData.variable }}
-        {{- "\n" }}
-    {%- endfor %}
+    {%~ endfor %}
 {% endif %}
  */
 ?>

--- a/templates/bake/Template/edit.twig
+++ b/templates/bake/Template/edit.twig
@@ -17,18 +17,15 @@
 /**
  * @var \{{ namespace }}\View\AppView $this
  * @var \{{ entityClass }} ${{ singularVar }}
-        {{- "\n" }}
-{%- if associations.BelongsTo is defined %}
-    {%- for assocName, assocData in associations.BelongsTo %}
+{% if associations.BelongsTo is defined %}
+    {%~ for assocName, assocData in associations.BelongsTo %}
  * @var string[]|\Cake\Collection\CollectionInterface ${{ assocData.variable }}
-        {{- "\n" }}
-    {%- endfor %}
+    {%~ endfor %}
 {% endif %}
-{%- if associations.BelongsToMany is defined %}
-    {%- for assocName, assocData in associations.BelongsToMany %}
+{% if associations.BelongsToMany is defined %}
+    {%~ for assocName, assocData in associations.BelongsToMany %}
  * @var string[]|\Cake\Collection\CollectionInterface ${{ assocData.variable }}
-        {{- "\n" }}
-    {%- endfor %}
+    {%~ endfor %}
 {% endif %}
  */
 ?>

--- a/templates/bake/Template/index.twig
+++ b/templates/bake/Template/index.twig
@@ -38,28 +38,28 @@
                 <?php foreach (${{ pluralVar }} as ${{ singularVar }}): ?>
                 <tr>
 {% for field in fields %}
-{% set isKey = false %}
-{% if associations.BelongsTo is defined %}
-{% for alias, details in associations.BelongsTo %}
-{% if field == details.foreignKey %}
-{% set isKey = true %}
+    {%~ set isKey = false %}
+    {%~ if associations.BelongsTo is defined %}
+        {%~ for alias, details in associations.BelongsTo %}
+            {%~ if field == details.foreignKey %}
+                {%~ set isKey = true %}
                     <td><?= ${{ singularVar }}->hasValue('{{ details.property }}') ? $this->Html->link(${{ singularVar }}->{{ details.property }}->{{ details.displayField }}, ['controller' => '{{ details.controller }}', 'action' => 'view', ${{ singularVar }}->{{ details.property }}->{{ details.primaryKey[0] }}]) : '' ?></td>
-{% endif %}
-{% endfor %}
-{% endif %}
-{% if isKey is not same as(true) %}
-{% set columnData = Bake.columnData(field, schema) %}
-{% set supportsLabel = Bake.enumSupportsLabel(field, schema) %}
-{% if columnData.type starts with 'enum-' %}
+            {%~ endif %}
+        {%~ endfor %}
+    {%~ endif %}
+    {%~ if isKey is not same as(true) %}
+        {%~ set columnData = Bake.columnData(field, schema) %}
+        {%~ set supportsLabel = Bake.enumSupportsLabel(field, schema) %}
+        {%~ if columnData.type starts with 'enum-' %}
                     <td><?= ${{ singularVar }}->{{ field }} === null ? '' : h(${{ singularVar }}->{{ field }}->{% if supportsLabel %}label(){% else %}value{% endif %}) ?></td>
-{% elseif columnData.type not in ['integer', 'float', 'decimal', 'biginteger', 'smallinteger', 'tinyinteger'] %}
+        {%~ elseif columnData.type not in ['integer', 'float', 'decimal', 'biginteger', 'smallinteger', 'tinyinteger'] %}
                     <td><?= h(${{ singularVar }}->{{ field }}) ?></td>
-{% elseif columnData.null %}
+        {%~ elseif columnData.null %}
                     <td><?= ${{ singularVar }}->{{ field }} === null ? '' : $this->Number->format(${{ singularVar }}->{{ field }}) ?></td>
-{% else %}
+        {%~ else %}
                     <td><?= $this->Number->format(${{ singularVar }}->{{ field }}) ?></td>
-{% endif %}
-{% endif %}
+        {%~ endif %}
+    {%~ endif %}
 {% endfor %}
 {% set pk = '$' ~ singularVar ~ '->' ~ primaryKey[0] %}
                     <td class="actions">

--- a/templates/bake/Template/view.twig
+++ b/templates/bake/Template/view.twig
@@ -24,6 +24,7 @@
 {% set associationFields = fieldsData.associationFields %}
 {% set groupedFields = fieldsData.groupedFields %}
 {% set pK = '$' ~ singularVar ~ '->' ~ primaryKey[0] %}
+{% set done = [] %}
 <div class="row">
     <aside class="column">
         <div class="side-nav">
@@ -32,7 +33,6 @@
             <?= $this->Form->postLink(__('Delete {{ singularHumanName }}'), ['action' => 'delete', {{ pK|raw }}], ['confirm' => __('Are you sure you want to delete # {0}?', {{ pK|raw }}), 'class' => 'side-nav-item']) ?>
             <?= $this->Html->link(__('List {{ pluralHumanName }}'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
             <?= $this->Html->link(__('New {{ singularHumanName }}'), ['action' => 'add'], ['class' => 'side-nav-item']) ?>
-{% set done = [] %}
         </div>
     </aside>
     <div class="column column-80">
@@ -40,104 +40,104 @@
             <h3><?= h(${{ singularVar }}->{{ displayField }}) ?></h3>
             <table>
 {% if groupedFields['string'] %}
-{% for field in groupedFields['string'] %}
-{% if associationFields[field] is defined %}
-{% set details = associationFields[field] %}
+    {%~ for field in groupedFields['string'] %}
+        {%~ if associationFields[field] is defined %}
+            {%~ set details = associationFields[field] %}
                 <tr>
                     <th><?= __('{{ details.property|humanize }}') ?></th>
                     <td><?= ${{ singularVar }}->hasValue('{{ details.property }}') ? $this->Html->link(${{ singularVar }}->{{ details.property }}->{{ details.displayField }}, ['controller' => '{{ details.controller }}', 'action' => 'view', ${{ singularVar }}->{{ details.property }}->{{ details.primaryKey[0] }}]) : '' ?></td>
                 </tr>
-{% else %}
+        {%~ else %}
                 <tr>
                     <th><?= __('{{ field|humanize }}') ?></th>
                     <td><?= h(${{ singularVar }}->{{ field }}) ?></td>
                 </tr>
-{% endif %}
-{% endfor %}
+        {%~ endif %}
+    {%~ endfor %}
 {% endif %}
 {% if associations.HasOne %}
-{% for alias, details in associations.HasOne %}
+    {%~ for alias, details in associations.HasOne %}
                 <tr>
                     <th><?= __('{{ alias|underscore|singularize|humanize }}') ?></th>
                     <td><?= ${{ singularVar }}->hasValue('{{ details.property }}') ? $this->Html->link(${{ singularVar }}->{{ details.property }}->{{ details.displayField }}, ['controller' => '{{ details.controller }}', 'action' => 'view', ${{ singularVar }}->{{ details.property }}->{{ details.primaryKey[0] }}]) : '' ?></td>
                 </tr>
-{% endfor %}
+    {%~ endfor %}
 {% endif %}
 {% if groupedFields.number %}
-{% for field in groupedFields.number %}
+    {%~ for field in groupedFields.number %}
                 <tr>
                     <th><?= __('{{ field|humanize }}') ?></th>
-{% set columnData = Bake.columnData(field, schema) %}
-{% if columnData.null %}
+        {%~ set columnData = Bake.columnData(field, schema) %}
+        {%~ if columnData.null %}
                     <td><?= ${{ singularVar }}->{{ field }} === null ? '' : $this->Number->format(${{ singularVar }}->{{ field }}) ?></td>
-{% else %}
+        {%~ else %}
                     <td><?= $this->Number->format(${{ singularVar }}->{{ field }}) ?></td>
-{% endif %}
+        {%~ endif %}
                 </tr>
-{% endfor %}
+    {%~ endfor %}
 {% endif %}
 {% if groupedFields.enum %}
-{% for field in groupedFields.enum %}
+    {%~ for field in groupedFields.enum %}
                 <tr>
                     <th><?= __('{{ field|humanize }}') ?></th>
-{% set columnData = Bake.columnData(field, schema) %}
-{% set supportsLabel = Bake.enumSupportsLabel(field, schema) %}
-{% if columnData.null %}
+        {%~ set columnData = Bake.columnData(field, schema) %}
+        {%~ set supportsLabel = Bake.enumSupportsLabel(field, schema) %}
+        {%~ if columnData.null %}
                     <td><?= ${{ singularVar }}->{{ field }} === null ? '' : h(${{ singularVar }}->{{ field }}->{% if supportsLabel %}label(){% else %}value{% endif %}) ?></td>
-{% else %}
+        {%~ else %}
                     <td><?= h(${{ singularVar }}->{{ field }}->{% if supportsLabel %}label(){% else %}value{% endif %}) ?></td>
-{% endif %}
+        {%~ endif %}
                 </tr>
-{% endfor %}
+    {%~ endfor %}
 {% endif %}
 {% if groupedFields.date %}
-{% for field in groupedFields.date %}
+    {%~ for field in groupedFields.date %}
                 <tr>
                     <th><?= __('{{ field|humanize }}') ?></th>
                     <td><?= h(${{ singularVar }}->{{ field }}) ?></td>
                 </tr>
-{% endfor %}
+    {%~ endfor %}
 {% endif %}
 {% if groupedFields.boolean %}
-{% for field in groupedFields.boolean %}
+    {%~ for field in groupedFields.boolean %}
                 <tr>
                     <th><?= __('{{ field|humanize }}') ?></th>
                     <td><?= ${{ singularVar }}->{{ field }} ? __('Yes') : __('No'); ?></td>
                 </tr>
-{% endfor %}
+    {%~ endfor %}
 {% endif %}
             </table>
 {% if groupedFields.text %}
-{% for field in groupedFields.text %}
+    {%~ for field in groupedFields.text %}
             <div class="text">
                 <strong><?= __('{{ field|humanize }}') ?></strong>
                 <blockquote>
                     <?= $this->Text->autoParagraph(h(${{ singularVar }}->{{ field }})); ?>
                 </blockquote>
             </div>
-{% endfor %}
+    {%~ endfor %}
 {% endif %}
 {% set relations = associations.BelongsToMany|merge(associations.HasMany) %}
 {% for alias, details in relations %}
-{% set otherSingularVar = alias|singularize|variable %}
-{% set otherPluralHumanName = details.controller|underscore|humanize %}
+    {%~ set otherSingularVar = alias|singularize|variable %}
+    {%~ set otherPluralHumanName = details.controller|underscore|humanize %}
             <div class="related">
                 <h4><?= __('Related {{ otherPluralHumanName }}') ?></h4>
                 <?php if (!empty(${{ singularVar }}->{{ details.property }})) : ?>
                 <div class="table-responsive">
                     <table>
                         <tr>
-{% for field in details.fields %}
+    {%~ for field in details.fields %}
                             <th><?= __('{{ field|humanize }}') ?></th>
-{% endfor %}
+    {%~ endfor %}
                             <th class="actions"><?= __('Actions') ?></th>
                         </tr>
                         <?php foreach (${{ singularVar }}->{{ details.property }} as ${{ otherSingularVar }}) : ?>
                         <tr>
-{% for field in details.fields %}
+    {%~ for field in details.fields %}
                             <td><?= h(${{ otherSingularVar }}->{{ field }}) ?></td>
-{% endfor %}
-{% set otherPk = '$' ~ otherSingularVar ~ '->' ~ details.primaryKey[0] %}
+    {%~ endfor %}
+    {%~ set otherPk = '$' ~ otherSingularVar ~ '->' ~ details.primaryKey[0] %}
                             <td class="actions">
                                 <?= $this->Html->link(__('View'), ['controller' => '{{ details.controller }}', 'action' => 'view', {{ otherPk|raw }}]) ?>
                                 <?= $this->Html->link(__('Edit'), ['controller' => '{{ details.controller }}', 'action' => 'edit', {{ otherPk|raw }}]) ?>

--- a/templates/bake/element/Controller/add.twig
+++ b/templates/bake/element/Controller/add.twig
@@ -38,11 +38,10 @@
 {% set associations = associations|merge(Bake.aliasExtractor(modelObj, 'BelongsToMany')) %}
 
 {%- for assoc in associations %}
-    {%- set otherName = Bake.getAssociatedTableAlias(modelObj, assoc) %}
-    {%- set otherPlural = otherName|variable %}
+    {%~ set otherName = Bake.getAssociatedTableAlias(modelObj, assoc) %}
+    {%~ set otherPlural = otherName|variable %}
         ${{ otherPlural }} = $this->{{ currentModelName }}->{{ otherName }}->find('list', limit: 200)->all();
-        {{- "\n" }}
-    {%- set compact = compact|merge(["'#{otherPlural}'"]) %}
+    {%~ set compact = compact|merge(["'#{otherPlural}'"]) %}
 {% endfor %}
         $this->set(compact({{ compact|join(', ')|raw }}));
     }

--- a/templates/bake/element/Controller/edit.twig
+++ b/templates/bake/element/Controller/edit.twig
@@ -39,11 +39,10 @@
             $this->Flash->error(__('The {{ singularHumanName|lower }} could not be saved. Please, try again.'));
         }
 {% for assoc in belongsTo|merge(belongsToMany) %}
-    {%- set otherName = Bake.getAssociatedTableAlias(modelObj, assoc) %}
-    {%- set otherPlural = otherName|variable %}
+    {%~ set otherName = Bake.getAssociatedTableAlias(modelObj, assoc) %}
+    {%~ set otherPlural = otherName|variable %}
         ${{ otherPlural }} = $this->{{ currentModelName }}->{{ otherName }}->find('list', limit: 200)->all();
-        {{- "\n" }}
-    {%- set compact = compact|merge(["'#{otherPlural}'"]) %}
+    {%~ set compact = compact|merge(["'#{otherPlural}'"]) %}
 {% endfor %}
         $this->set(compact({{ compact|join(', ')|raw }}));
     }

--- a/templates/bake/element/form.twig
+++ b/templates/bake/element/form.twig
@@ -26,8 +26,7 @@
             ) ?>
 {% endif %}
             <?= $this->Html->link(__('List {{ pluralHumanName }}'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
-            {{- "\n" }}
-{%- set done = [] %}
+{% set done = [] %}
         </div>
     </aside>
     <div class="column column-80">
@@ -37,34 +36,28 @@
                 <legend><?= __('{{ action|humanize }} {{ singularHumanName }}') ?></legend>
                 <?php
 {% for field in fields %}
-{%- if field not in primaryKey %}
-    {%- if keyFields[field] is defined %}
-        {%- set fieldData = Bake.columnData(field, schema) %}
-        {%- if fieldData.null %}
+    {%~ if field not in primaryKey %}
+        {%~ if keyFields[field] is defined %}
+            {%~ set fieldData = Bake.columnData(field, schema) %}
+            {%~ if fieldData.null %}
                     echo $this->Form->control('{{ field }}', ['options' => ${{ keyFields[field] }}, 'empty' => true]);
-                    {{- "\n" }}
-        {%- else %}
+            {%~ else %}
                     echo $this->Form->control('{{ field }}', ['options' => ${{ keyFields[field] }}]);
-                    {{- "\n" }}
-        {%- endif %}
-    {%- elseif field not in ['created', 'modified', 'updated'] %}
-        {%- set fieldData = Bake.columnData(field, schema) %}
-        {%- if fieldData.type in ['date', 'datetime', 'time'] and fieldData.null %}
+            {%~ endif %}
+        {%~ elseif field not in ['created', 'modified', 'updated'] %}
+            {%~ set fieldData = Bake.columnData(field, schema) %}
+            {%~ if fieldData.type in ['date', 'datetime', 'time'] and fieldData.null %}
                     echo $this->Form->control('{{ field }}', ['empty' => true]);
-                    {{- "\n" }}
-        {%- else %}
+            {%~ else %}
                     echo $this->Form->control('{{ field }}');
-                    {{- "\n" }}
-        {%- endif %}
-    {%- endif %}
-{%- endif %}
-{%- endfor %}
-
-{%- if associations.BelongsToMany is defined %}
-{%- for assocName, assocData in associations.BelongsToMany %}
+            {%~ endif %}
+        {%~ endif %}
+    {%~ endif %}
+{% endfor %}
+{% if associations.BelongsToMany is defined %}
+    {%~ for assocName, assocData in associations.BelongsToMany %}
                     echo $this->Form->control('{{ assocData.property }}._ids', ['options' => ${{ assocData.variable }}]);
-                    {{- "\n" }}
-{%- endfor %}
+    {%~ endfor %}
 {% endif %}
                 ?>
             </fieldset>

--- a/templates/bake/tests/test_case.twig
+++ b/templates/bake/tests/test_case.twig
@@ -24,7 +24,7 @@
     {%- set traitName = 'ConsoleIntegrationTestTrait' %}
     {%- set uses = uses|merge(['Cake\\Console\\TestSuite\\ConsoleIntegrationTestTrait']) %}
 {% endif %}
-{%- set uses = uses|merge(["Cake\\TestSuite\\TestCase"]) %}
+{% set uses = uses|merge(["Cake\\TestSuite\\TestCase"]) %}
 
 {{- element('Bake.file_header', {
     namespace: "#{baseNamespace}\\Test\\TestCase\\#{subNamespace}",
@@ -42,25 +42,25 @@ class {{ className }}Test extends TestCase
 {
 {% if traitName is defined %}
     use {{ traitName }};
-{% if properties or fixtures or construction or methods %}
+    {%~ if properties or fixtures or construction or methods %}
 
-{% endif %}
+    {%~ endif %}
 {% endif %}
 {% if properties %}
-{% for propertyInfo in properties %}
-{% if loop.index > 1 %}
+    {%~ for propertyInfo in properties %}
+        {%~ if loop.index > 1 %}
 
-{% endif %}
+        {%~ endif %}
     /**
      * {{ propertyInfo.description }}
      *
      * @var {{ propertyInfo.type }}
      */
     protected ${{ propertyInfo.name }}{% if propertyInfo.value is defined and propertyInfo.value %} = {{ propertyInfo.value }}{% endif %};
-{% if loop.last and (fixtures or construction or methods) %}
+        {%~ if loop.last and (fixtures or construction or methods) %}
 
-{% endif %}
-{% endfor %}
+        {%~ endif %}
+    {%~ endfor %}
 {% endif %}
 
 {%- if fixtures and not (hasFixtureFactories|default(false)) %}
@@ -70,9 +70,9 @@ class {{ className }}Test extends TestCase
      * @var array<string>
      */
     protected array $fixtures = {{ Bake.exportVar(fixtures|values, 1)|raw }};
-{% if construction or methods %}
+    {%~ if construction or methods %}
 
-{% endif %}
+    {%~ endif %}
 {% endif %}
 
 {%- if construction %}
@@ -84,19 +84,19 @@ class {{ className }}Test extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-{% if preConstruct %}
+    {%~ if preConstruct %}
         {{ preConstruct|raw }}
-{% endif %}
-{% if isCommand %}
+    {%~ endif %}
+    {%~ if isCommand %}
         {{ construction|raw }}
-{% else %}
+    {%~ else %}
         $this->{{ (subject ~ ' = ' ~ construction)|raw }}
-{% endif %}
-{% if postConstruct %}
+    {%~ endif %}
+    {%~ if postConstruct %}
         {{ postConstruct|raw }}
-{% endif %}
+    {%~ endif %}
     }
-{% if not isCommand %}
+    {%~ if not isCommand %}
 
     /**
      * tearDown method
@@ -109,16 +109,16 @@ class {{ className }}Test extends TestCase
 
         parent::tearDown();
     }
-{% if methods %}
+        {%~ if methods %}
 
-{% endif %}
-{% endif %}
-{% endif %}
+        {%~ endif %}
+    {%~ endif %}
+{%~ endif %}
 
 {%- for method in methods %}
-{% if loop.index > 1 %}
+    {%~ if loop.index > 1 %}
 
-{% endif %}
+    {%~ endif %}
     /**
      * Test {{ method }} method
      *
@@ -129,5 +129,5 @@ class {{ className }}Test extends TestCase
     {
         $this->markTestIncomplete('Not implemented yet.');
     }
-{% endfor %}
+{%~ endfor %}
 }

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -1878,7 +1878,7 @@ class ModelCommandTest extends TestCase
 
         $name = 'TestBakeArticles';
         $args = new Arguments([$name], ['table' => 'bake_articles', 'force' => true], []);
-        $io = new ConsoleIo($this->_out, $this->_err, $this->_in);
+        $io = new ConsoleIo(new StubConsoleOutput(), new StubConsoleOutput(), new StubConsoleInput([]));
 
         $table = $command->getTable($name, $args);
         $tableObject = $command->getTableObject($name, $table);
@@ -1910,7 +1910,7 @@ class ModelCommandTest extends TestCase
 
         $name = 'UniqueFields';
         $args = new Arguments([$name], ['table' => 'unique_fields', 'force' => true], []);
-        $io = new ConsoleIo($this->_out, $this->_err, $this->_in);
+        $io = new ConsoleIo(new StubConsoleOutput(), new StubConsoleOutput(), new StubConsoleInput([]));
 
         $table = $command->getTable($name, $args);
         $tableObject = $command->getTableObject($name, $table);
@@ -2548,7 +2548,7 @@ PARSE;
 
         $name = 'TestBakeArticles';
         $args = new Arguments([$name], ['table' => 'bake_articles', 'force' => true], []);
-        $io = new ConsoleIo($this->_out, $this->_err, $this->_in);
+        $io = new ConsoleIo(new StubConsoleOutput(), new StubConsoleOutput(), new StubConsoleInput([]));
 
         $table = $command->getTable($name, $args);
         $tableObject = $command->getTableObject($name, $table);


### PR DESCRIPTION
- Fix output leaks in ModelCommandTest
- Update templates to use line-stripping tags and remove explicit newline output.