### PR TITLE
Fix type error when undefined fields are used

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <ruleset name="CakePHP Bake">
-    <config name="installed_paths" value="../../cakephp/cakephp-codesniffer" />
     <arg value="ns"/>
 
     <file>src/</file>

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -304,7 +304,7 @@ class BakeHelper extends Helper
     public function enumSupportsLabel(string $field, TableSchema $schema): bool
     {
         $typeName = $schema->getColumnType($field);
-        if (!str_starts_with($typeName, 'enum-')) {
+        if (!$typeName || !str_starts_with($typeName, 'enum-')) {
             return false;
         }
         $type = TypeFactory::build($typeName);

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -16,8 +16,10 @@ declare(strict_types=1);
  */
 namespace Bake\Test\TestCase\View\Helper;
 
+use Bake\Test\App\Model\Enum\BakeUserStatus;
 use Bake\View\BakeView;
 use Bake\View\Helper\BakeHelper;
+use Cake\Database\Type\EnumType;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest as Request;
 use Cake\TestSuite\TestCase;
@@ -40,6 +42,7 @@ class BakeHelperTest extends TestCase
         'plugin.Bake.BakeComments',
         'plugin.Bake.BakeArticlesBakeTags',
         'plugin.Bake.BakeTags',
+        'plugin.Bake.Users',
     ];
 
     /**
@@ -89,12 +92,12 @@ class BakeHelperTest extends TestCase
             'className' => '\Bake\Test\App\Model\Table\ArticlesTable',
         ]);
         $this->BakeHelper = $this->getMockBuilder('Bake\View\Helper\BakeHelper')
-                ->disableOriginalConstructor()
-                ->onlyMethods(['_filterHasManyAssociationsAliases'])
-                ->getMock();
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_filterHasManyAssociationsAliases'])
+            ->getMock();
         $this->BakeHelper->expects($this->once())
-                ->method('_filterHasManyAssociationsAliases')
-                ->with($table, ['ArticlesTags']);
+            ->method('_filterHasManyAssociationsAliases')
+            ->with($table, ['ArticlesTags']);
         $result = $this->BakeHelper->aliasExtractor($table, 'HasMany');
         $this->assertEmpty($result);
     }
@@ -107,7 +110,7 @@ class BakeHelperTest extends TestCase
     public function testAliasExtractorBelongsTo()
     {
         $table = $this->getTableLocator()->get('Articles', [
-                    'className' => '\Bake\Test\App\Model\Table\ArticlesTable',
+            'className' => '\Bake\Test\App\Model\Table\ArticlesTable',
         ]);
         $result = $this->BakeHelper->aliasExtractor($table, 'BelongsTo');
         $expected = ['authors'];
@@ -122,7 +125,7 @@ class BakeHelperTest extends TestCase
     public function testAliasExtractorBelongsToMany()
     {
         $table = $this->getTableLocator()->get('Articles', [
-                    'className' => '\Bake\Test\App\Model\Table\ArticlesTable',
+            'className' => '\Bake\Test\App\Model\Table\ArticlesTable',
         ]);
         $result = $this->BakeHelper->aliasExtractor($table, 'BelongsToMany');
         $expected = ['tags'];
@@ -184,5 +187,18 @@ PARSE
     {
         $this->assertTrue($this->BakeHelper->hasPlugin('Bake'));
         $this->assertFalse($this->BakeHelper->hasPlugin('DebugKit'));
+    }
+
+    public function testEnumSupportsLabel(): void
+    {
+        $table = $this->getTableLocator()->get('Users', [
+            'className' => '\Bake\Test\App\Model\Table\BakeUsersTable',
+        ]);
+        $schema = $table->getSchema();
+        $schema->setColumnType('status', EnumType::from(BakeUserStatus::class));
+
+        $this->assertFalse($this->BakeHelper->enumSupportsLabel('status', $schema));
+        $this->assertFalse($this->BakeHelper->enumSupportsLabel('username', $schema));
+        $this->assertFalse($this->BakeHelper->enumSupportsLabel('does_not_exist', $schema));
     }
 }

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -191,13 +191,11 @@ PARSE
 
     public function testEnumSupportsLabel(): void
     {
-        $table = $this->getTableLocator()->get('Users', [
-            'className' => '\Bake\Test\App\Model\Table\BakeUsersTable',
-        ]);
+        $table = $this->fetchTable('BakeUsers');
         $schema = $table->getSchema();
         $schema->setColumnType('status', EnumType::from(BakeUserStatus::class));
 
-        $this->assertFalse($this->BakeHelper->enumSupportsLabel('status', $schema));
+        $this->assertTrue($this->BakeHelper->enumSupportsLabel('status', $schema));
         $this->assertFalse($this->BakeHelper->enumSupportsLabel('username', $schema));
         $this->assertFalse($this->BakeHelper->enumSupportsLabel('does_not_exist', $schema));
     }


### PR DESCRIPTION
If a field that does not exist in the schema (like an association property) is passed to `enumSupportsLabel` there shouldn't be an error.