### PR TITLE
Bump twig-view constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=8.1",
         "brick/varexporter": "^0.6.0",
         "cakephp/cakephp": "^5.1",
-        "cakephp/twig-view": "^2.0.0",
+        "cakephp/twig-view": "^2.0.2",
         "nikic/php-parser": "^5.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Bumping twig-view constraint from 2.0.0 to 2.0.2 as it requires a higher twig version.

Fixes failing twig compilation tests on prefer-lowest builds.

reference: https://github.com/cakephp/queue/pull/174