### PR TITLE
fix class only generate not working

### DIFF
--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -77,7 +77,7 @@ class PluginCommand extends BakeCommand
         }
 
         $pluginPath = $this->_pluginPath($plugin);
-        if (is_dir($pluginPath)) {
+        if (is_dir($pluginPath) && !$args->getOption('class-only')) {
             $io->out(sprintf('Plugin: %s already exists, no action taken', $plugin));
             $io->out(sprintf('Path: %s', $pluginPath));
 


### PR DESCRIPTION
While testing CakePHP 5.3 RC1 I got the following message:
```
Since 5.3.0: Loading plugins without a plugin class is deprecated. You can create the missing class using `bin/cake bake plugin AlfredTemplates --class-only`.
```
which I tried, but didn't work:
```
Plugin: AlfredTemplates already exists, no action taken
Path: /Users/kevin/Documents/sunlime/alfred/plugins/AlfredTemplates/
```

so this fixes this bug