### PR TITLE
Fix singular/plural variable collision in baked templates

### DIFF
--- a/src/Command/ControllerCommand.php
+++ b/src/Command/ControllerCommand.php
@@ -129,6 +129,12 @@ class ControllerCommand extends BakeCommand
         $singularHumanName = $this->_singularHumanName($controllerName);
         $pluralHumanName = $this->_variableName($controllerName);
 
+        // Handle cases where singular and plural are identical (e.g., "news", "sheep")
+        // to avoid variable collisions in generated controller code
+        if ($singularName === $pluralName) {
+            $singularName .= 'Entity';
+        }
+
         $defaultModel = sprintf('%s\Model\Table\%sTable', $namespace, $controllerName);
         if (!class_exists($defaultModel)) {
             $defaultModel = null;

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -328,7 +328,7 @@ class TemplateCommand extends BakeCommand
         // Handle cases where singular and plural are identical (e.g., "news", "sheep")
         // to avoid generating invalid code like `foreach ($news as $news)`
         if ($singularVar === $pluralVar) {
-            $singularVar .= 'Item';
+            $singularVar .= 'Entity';
         }
 
         return compact(

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -325,6 +325,12 @@ class TemplateCommand extends BakeCommand
         $pluralVar = Inflector::variable($this->controllerName);
         $pluralHumanName = $this->_pluralHumanName($this->controllerName);
 
+        // Handle cases where singular and plural are identical (e.g., "news", "sheep")
+        // to avoid generating invalid code like `foreach ($news as $news)`
+        if ($singularVar === $pluralVar) {
+            $singularVar .= 'Item';
+        }
+
         return compact(
             'modelObject',
             'modelClass',

--- a/templates/bake/Template/view.twig
+++ b/templates/bake/Template/view.twig
@@ -120,6 +120,9 @@
 {% set relations = associations.BelongsToMany|merge(associations.HasMany) %}
 {% for alias, details in relations %}
     {%~ set otherSingularVar = alias|singularize|variable %}
+    {%~ if otherSingularVar == singularVar %}
+        {%~ set otherSingularVar = otherSingularVar ~ 'Related' %}
+    {%~ endif %}
     {%~ set otherPluralHumanName = details.controller|underscore|humanize %}
             <div class="related">
                 <h4><?= __('Related {{ otherPluralHumanName }}') ?></h4>

--- a/templates/bake/element/Controller/add.twig
+++ b/templates/bake/element/Controller/add.twig
@@ -40,6 +40,9 @@
 {%- for assoc in associations %}
     {%~ set otherName = Bake.getAssociatedTableAlias(modelObj, assoc) %}
     {%~ set otherPlural = otherName|variable %}
+    {%~ if otherPlural == singularName %}
+        {%~ set otherPlural = otherPlural ~ 'List' %}
+    {%~ endif %}
         ${{ otherPlural }} = $this->{{ currentModelName }}->{{ otherName }}->find('list', limit: 200)->all();
     {%~ set compact = compact|merge(["'#{otherPlural}'"]) %}
 {% endfor %}

--- a/templates/bake/element/Controller/edit.twig
+++ b/templates/bake/element/Controller/edit.twig
@@ -41,6 +41,9 @@
 {% for assoc in belongsTo|merge(belongsToMany) %}
     {%~ set otherName = Bake.getAssociatedTableAlias(modelObj, assoc) %}
     {%~ set otherPlural = otherName|variable %}
+    {%~ if otherPlural == singularName %}
+        {%~ set otherPlural = otherPlural ~ 'List' %}
+    {%~ endif %}
         ${{ otherPlural }} = $this->{{ currentModelName }}->{{ otherName }}->find('list', limit: 200)->all();
     {%~ set compact = compact|merge(["'#{otherPlural}'"]) %}
 {% endfor %}

--- a/tests/Fixture/NewsFixture.php
+++ b/tests/Fixture/NewsFixture.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Bake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * NewsFixture - tests singular/plural variable collision
+ * "news" is both singular and plural
+ */
+class NewsFixture extends TestFixture
+{
+    public array $records = [
+        ['title' => 'First News', 'body' => 'First News Body'],
+        ['title' => 'Second News', 'body' => 'Second News Body'],
+    ];
+}

--- a/tests/TestCase/Command/ControllerCommandTest.php
+++ b/tests/TestCase/Command/ControllerCommandTest.php
@@ -39,6 +39,7 @@ class ControllerCommandTest extends TestCase
         'plugin.Bake.BakeArticlesBakeTags',
         'plugin.Bake.BakeComments',
         'plugin.Bake.BakeTags',
+        'plugin.Bake.News',
         'plugin.Bake.Users',
     ];
 
@@ -434,5 +435,32 @@ class ControllerCommandTest extends TestCase
         $this->assertFileContains('namespace Company\Pastry\Controller;', $this->generatedFile);
         $this->assertFileContains('use Company\Pastry\Controller\AppController;', $this->generatedFile);
         $this->assertFileContains('BakeArticlesController extends AppController', $this->generatedFile);
+    }
+
+    /**
+     * Test baking controller for models where singular and plural are identical.
+     *
+     * This tests the fix for generating variable collisions like `$news` for both
+     * the entity and the paginated collection when the model name is both singular
+     * and plural (e.g., "news", "sheep", "fish").
+     *
+     * @return void
+     */
+    public function testBakeControllerWithSingularPluralCollision(): void
+    {
+        $this->generatedFile = APP . 'Controller/NewsController.php';
+        $this->exec('bake controller --connection test --no-test News');
+
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+
+        $result = file_get_contents($this->generatedFile);
+
+        // In view/edit/add/delete actions, the entity should use 'newsEntity' to avoid collision
+        $this->assertStringContainsString('$newsEntity = $this->News->get(', $result);
+
+        // In index action, the paginated collection should still use 'news'
+        $this->assertStringContainsString('$news = $this->paginate(', $result);
+        $this->assertStringContainsString("compact('news')", $result);
     }
 }

--- a/tests/TestCase/Command/ControllerCommandTest.php
+++ b/tests/TestCase/Command/ControllerCommandTest.php
@@ -449,6 +449,9 @@ class ControllerCommandTest extends TestCase
     public function testBakeControllerWithSingularPluralCollision(): void
     {
         $this->generatedFile = APP . 'Controller/NewsController.php';
+        if (file_exists($this->generatedFile)) {
+            unlink($this->generatedFile);
+        }
         $this->exec('bake controller --connection test --no-test News');
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -914,7 +914,7 @@ class TemplateCommandTest extends TestCase
         // Should NOT have `foreach ($news as $news)` which would overwrite the collection
         $this->assertStringNotContainsString('foreach ($news as $news)', $result);
 
-        // Should have `foreach ($news as $newsItem)` instead
-        $this->assertStringContainsString('foreach ($news as $newsItem)', $result);
+        // Should have `foreach ($news as $newsEntity)` instead
+        $this->assertStringContainsString('foreach ($news as $newsEntity)', $result);
     }
 }

--- a/tests/TestCase/Command/TemplateCommandTest.php
+++ b/tests/TestCase/Command/TemplateCommandTest.php
@@ -54,6 +54,7 @@ class TemplateCommandTest extends TestCase
         'plugin.Bake.BakeTemplateProfiles',
         'plugin.Bake.CategoryThreads',
         'plugin.Bake.HiddenFields',
+        'plugin.Bake.News',
     ];
 
     /**
@@ -890,5 +891,30 @@ class TemplateCommandTest extends TestCase
         $this->exec('bake template MissingTableClass');
 
         $this->assertExitCode(CommandInterface::CODE_ERROR);
+    }
+
+    /**
+     * Test baking templates for models where singular and plural are identical.
+     *
+     * This tests the fix for generating invalid code like `foreach ($news as $news)`
+     * when the model name is both singular and plural (e.g., "news", "sheep", "fish").
+     *
+     * @return void
+     */
+    public function testBakeIndexWithSingularPluralCollision()
+    {
+        $this->generatedFile = ROOT . 'templates/News/index.php';
+        $this->exec('bake template News index');
+
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+
+        $result = file_get_contents($this->generatedFile);
+
+        // Should NOT have `foreach ($news as $news)` which would overwrite the collection
+        $this->assertStringNotContainsString('foreach ($news as $news)', $result);
+
+        // Should have `foreach ($news as $newsItem)` instead
+        $this->assertStringContainsString('foreach ($news as $newsItem)', $result);
     }
 }

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -587,4 +587,16 @@ return [
             'unique_self_referencing_parent' => ['type' => 'unique', 'columns' => ['parent_id']],
         ],
     ],
+    // "news" is both singular and plural - tests variable collision fix
+    [
+        'table' => 'news',
+        'columns' => [
+            'id' => ['type' => 'integer'],
+            'title' => ['type' => 'string', 'length' => 255, 'null' => false],
+            'body' => ['type' => 'text'],
+            'created' => ['type' => 'datetime'],
+            'modified' => ['type' => 'datetime'],
+        ],
+        'constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+    ],
 ];


### PR DESCRIPTION
## Summary

- Fixes template generation for models where singular and plural forms are identical (e.g., "news", "sheep", "fish")
- Previously generated invalid code like `foreach ($news as $news):` which overwrites the collection variable
- Now appends "Entity" suffix to the singular variable when collision detected: `foreach ($news as $newsEntity):`

### Additional collision fixes

- **ControllerCommand**: Same fix applied to controller action generation (view/edit/add/delete use `$newsEntity`)
- **view.twig**: Related entity loops detect collision and append "Related" suffix
- **Controller add/edit templates**: Association list variables detect collision and append "List" suffix

Refs https://discourse.cakephp.org/t/paginator-error/12806/4