### PR TITLE
docs: Add Bake Enums section to usage documentation

### DIFF
--- a/docs/en/usage.rst
+++ b/docs/en/usage.rst
@@ -64,6 +64,55 @@ For non-conventional relations, you can use references in the constraints / fore
     ->addForeignKey('shipping_country_id', 'countries', 'cid')
 
 
+Bake Enums
+==========
+
+You can use bake to generate `backed enums <https://www.php.net/manual/en/language.enumerations.backed.php>`_
+for use in your models. Enums are placed in **src/Model/Enum/** and implement
+``EnumLabelInterface`` which provides a ``label()`` method for human-readable display.
+
+To bake a string-backed enum::
+
+    bin/cake bake enum ArticleStatus draft,published,archived
+
+This generates **src/Model/Enum/ArticleStatus.php**::
+
+    namespace App\Model\Enum;
+
+    use Cake\Database\Type\EnumLabelInterface;
+    use Cake\Utility\Inflector;
+
+    enum ArticleStatus: string implements EnumLabelInterface
+    {
+        case Draft = 'draft';
+        case Published = 'published';
+        case Archived = 'archived';
+
+        public function label(): string
+        {
+            return Inflector::humanize(Inflector::underscore($this->name));
+        }
+    }
+
+For int-backed enums, use the ``-i`` option and provide values with colons::
+
+    bin/cake bake enum Priority low:1,medium:2,high:3 -i
+
+This generates an int-backed enum::
+
+    enum Priority: int implements EnumLabelInterface
+    {
+        case Low = 1;
+        case Medium = 2;
+        case High = 3;
+
+        // ...
+    }
+
+You can also bake enums into plugins::
+
+    bin/cake bake enum MyPlugin.OrderStatus pending,processing,shipped
+
 Bake Themes
 ===========
 


### PR DESCRIPTION
## Summary

- Add documentation for the `bake enum` command to `docs/en/usage.rst`
- The enum command was added in 3.1.0 but was not documented in the usage guide

The new section covers:
- String-backed enum generation with examples
- Int-backed enum generation using the `-i` option
- Plugin enum baking syntax
- Generated code structure showing `EnumLabelInterface` implementation