### PR TITLE
Fix bakeTest() code example in documentation

### DIFF
--- a/docs/en/development.rst
+++ b/docs/en/development.rst
@@ -314,10 +314,10 @@ command name::
             $this->Test->classTypes[$name] = 'Foo';
         }
 
-        return parent::bakeTest($className);
+        parent::bakeTest($className, $args, $io);
     }
 
-* The **class suffix** will be appened to the name provided in your ``bake``
+* The **class suffix** will be appended to the name provided in your ``bake``
   call. In the previous example, it would create a ``ExampleFooTest.php`` file.
 * The **class type** will be the sub-namespace used that will lead to your
   file (relative to the app or the plugin you are baking into). In the previous


### PR DESCRIPTION
## Summary

- Remove invalid `return` statement from void method
- Add missing `$args` and `$io` parameters to parent `bakeTest()` call
- Fix "appened" typo -> "appended"