### PR TITLE
remove defaultName method from baked command

### DIFF
--- a/templates/bake/Command/command.twig
+++ b/templates/bake/Command/command.twig
@@ -36,16 +36,6 @@ class {{ name }}Command extends Command
     protected string $name = '{{ command_name }}';
 
     /**
-     * Get the default command name.
-     *
-     * @return string
-     */
-    public static function defaultName(): string
-    {
-        return '{{ command_name }}';
-    }
-
-    /**
      * Get the command description.
      *
      * @return string

--- a/tests/comparisons/Command/testBakePlugin.php
+++ b/tests/comparisons/Command/testBakePlugin.php
@@ -21,16 +21,6 @@ class ExampleCommand extends Command
     protected string $name = 'test_bake example';
 
     /**
-     * Get the default command name.
-     *
-     * @return string
-     */
-    public static function defaultName(): string
-    {
-        return 'test_bake example';
-    }
-
-    /**
      * Get the command description.
      *
      * @return string


### PR DESCRIPTION
It was added in https://github.com/cakephp/bake/pull/1030 but its not really needed, as it gets statically inflected by the classname anyways.

This makes the user generated code clearer as there is only 1 place where the command name is defined, not 2.