### PR TITLE
Fix command name.

### DIFF
--- a/templates/bake/Command/command.twig
+++ b/templates/bake/Command/command.twig
@@ -33,7 +33,7 @@ class {{ name }}Command extends Command
      *
      * @var string
      */
-    protected string $name = '{{ command_name }}';
+    protected string $name = 'cake {{ command_name }}';
 
     /**
      * Get the command description.

--- a/tests/TestCase/Command/CommandCommandTest.php
+++ b/tests/TestCase/Command/CommandCommandTest.php
@@ -53,6 +53,7 @@ class CommandCommandTest extends TestCase
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains('class ExampleCommand extends Command', $this->generatedFiles[0]);
+        $this->assertFileContains("protected string \$name = 'cake example'", $this->generatedFiles[0]);
     }
 
     /**

--- a/tests/comparisons/Command/testBakePlugin.php
+++ b/tests/comparisons/Command/testBakePlugin.php
@@ -18,7 +18,7 @@ class ExampleCommand extends Command
      *
      * @var string
      */
-    protected string $name = 'test_bake example';
+    protected string $name = 'cake test_bake example';
 
     /**
      * Get the command description.


### PR DESCRIPTION
As seen in the default value for `BaseCommand::$name` and asserted in `BaseCommand::setName()`, the command names need a "root" part which is usually "cake".

Refs https://github.com/cakephp/cakephp/pull/19418