### PR TITLE
skip new migrations tables

### DIFF
--- a/src/Utility/TableScanner.php
+++ b/src/Utility/TableScanner.php
@@ -47,7 +47,7 @@ class TableScanner
     {
         $this->connection = $connection;
         if ($ignore === null) {
-            $ignore = ['i18n', 'cake_sessions', 'sessions', '/phinxlog/'];
+            $ignore = ['i18n', 'cake_sessions', 'cake_migrations', 'cake_seeds', 'sessions', '/phinxlog/'];
         }
         $this->ignore = $ignore;
     }


### PR DESCRIPTION
Resolves #1083 

With Migrations v5 with have 2 new tables present. Those 2 new tables should not be baked by default when generating code via  e.g.`bin/cake bake all --everything`