### PR TITLE
Assign AllCommand subcommands in the constructor (fix uninitialized typed property on CakePHP 5.4)

### DIFF
--- a/src/Command/ControllerAllCommand.php
+++ b/src/Command/ControllerAllCommand.php
@@ -18,6 +18,7 @@ namespace Bake\Command;
 
 use Bake\Utility\TableScanner;
 use Cake\Console\Arguments;
+use Cake\Console\CommandFactoryInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
@@ -41,13 +42,15 @@ class ControllerAllCommand extends BakeCommand
     }
 
     /**
-     * initialize
+     * The subcommand is assigned in the constructor (not initialize()) because
+     * buildOptionParser() runs before initialize() and reads it.
      *
-     * @return void
+     * @param \Cake\Console\CommandFactoryInterface|null $factory Command factory instance.
      */
-    public function initialize(): void
+    public function __construct(?CommandFactoryInterface $factory = null)
     {
-        parent::initialize();
+        parent::__construct($factory);
+
         $this->controllerCommand = new ControllerCommand();
     }
 

--- a/src/Command/ControllerAllCommand.php
+++ b/src/Command/ControllerAllCommand.php
@@ -18,7 +18,6 @@ namespace Bake\Command;
 
 use Bake\Utility\TableScanner;
 use Cake\Console\Arguments;
-use Cake\Console\CommandFactoryInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
@@ -39,19 +38,6 @@ class ControllerAllCommand extends BakeCommand
     public static function defaultName(): string
     {
         return 'bake controller all';
-    }
-
-    /**
-     * The subcommand is assigned in the constructor (not initialize()) because
-     * buildOptionParser() runs before initialize() and reads it.
-     *
-     * @param \Cake\Console\CommandFactoryInterface|null $factory Command factory instance.
-     */
-    public function __construct(?CommandFactoryInterface $factory = null)
-    {
-        parent::__construct($factory);
-
-        $this->controllerCommand = new ControllerCommand();
     }
 
     /**
@@ -85,6 +71,11 @@ class ControllerAllCommand extends BakeCommand
      */
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
+        // Assigned here (not initialize()) because on CakePHP 5.4+ the parser is built
+        // before initialize() runs, while older versions build it after. ??= keeps it
+        // safe under either ordering and idempotent across repeated calls.
+        $this->controllerCommand ??= new ControllerCommand();
+
         $parser = $this->controllerCommand->buildOptionParser($parser);
         $parser
             ->setDescription('Bake all controller files with tests.')

--- a/src/Command/ModelAllCommand.php
+++ b/src/Command/ModelAllCommand.php
@@ -18,7 +18,6 @@ namespace Bake\Command;
 
 use Bake\Utility\TableScanner;
 use Cake\Console\Arguments;
-use Cake\Console\CommandFactoryInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
@@ -42,19 +41,6 @@ class ModelAllCommand extends BakeCommand
     }
 
     /**
-     * The subcommand is assigned in the constructor (not initialize()) because
-     * buildOptionParser() runs before initialize() and reads it.
-     *
-     * @param \Cake\Console\CommandFactoryInterface|null $factory Command factory instance.
-     */
-    public function __construct(?CommandFactoryInterface $factory = null)
-    {
-        parent::__construct($factory);
-
-        $this->modelCommand = new ModelCommand();
-    }
-
-    /**
      * Gets the option parser instance and configures it.
      *
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to configure
@@ -62,6 +48,11 @@ class ModelAllCommand extends BakeCommand
      */
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
+        // Assigned here (not initialize()) because on CakePHP 5.4+ the parser is built
+        // before initialize() runs, while older versions build it after. ??= keeps it
+        // safe under either ordering and idempotent across repeated calls.
+        $this->modelCommand ??= new ModelCommand();
+
         $parser = $this->modelCommand->buildOptionParser($parser);
         $parser
             ->setDescription('Bake all model files with associations and validation.')

--- a/src/Command/ModelAllCommand.php
+++ b/src/Command/ModelAllCommand.php
@@ -18,6 +18,7 @@ namespace Bake\Command;
 
 use Bake\Utility\TableScanner;
 use Cake\Console\Arguments;
+use Cake\Console\CommandFactoryInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
@@ -41,13 +42,15 @@ class ModelAllCommand extends BakeCommand
     }
 
     /**
-     * initialize
+     * The subcommand is assigned in the constructor (not initialize()) because
+     * buildOptionParser() runs before initialize() and reads it.
      *
-     * @return void
+     * @param \Cake\Console\CommandFactoryInterface|null $factory Command factory instance.
      */
-    public function initialize(): void
+    public function __construct(?CommandFactoryInterface $factory = null)
     {
-        parent::initialize();
+        parent::__construct($factory);
+
         $this->modelCommand = new ModelCommand();
     }
 

--- a/src/Command/TemplateAllCommand.php
+++ b/src/Command/TemplateAllCommand.php
@@ -18,7 +18,6 @@ namespace Bake\Command;
 
 use Bake\Utility\TableScanner;
 use Cake\Console\Arguments;
-use Cake\Console\CommandFactoryInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
@@ -36,19 +35,6 @@ class TemplateAllCommand extends BakeCommand
     public static function defaultName(): string
     {
         return 'bake template all';
-    }
-
-    /**
-     * The subcommand is assigned in the constructor (not initialize()) because
-     * buildOptionParser() runs before initialize() and reads it.
-     *
-     * @param \Cake\Console\CommandFactoryInterface|null $factory Command factory instance.
-     */
-    public function __construct(?CommandFactoryInterface $factory = null)
-    {
-        parent::__construct($factory);
-
-        $this->templateCommand = new TemplateCommand();
     }
 
     /**
@@ -88,6 +74,11 @@ class TemplateAllCommand extends BakeCommand
      */
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
+        // Assigned here (not initialize()) because on CakePHP 5.4+ the parser is built
+        // before initialize() runs, while older versions build it after. buildOptionParser()
+        // always runs before execute(), so this guarantees the subcommand is available there.
+        $this->templateCommand ??= new TemplateCommand();
+
         $parser = $this->_setCommonOptions($parser);
         $parser
             ->setDescription('Bake all view template files.')

--- a/src/Command/TemplateAllCommand.php
+++ b/src/Command/TemplateAllCommand.php
@@ -18,6 +18,7 @@ namespace Bake\Command;
 
 use Bake\Utility\TableScanner;
 use Cake\Console\Arguments;
+use Cake\Console\CommandFactoryInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
@@ -38,13 +39,15 @@ class TemplateAllCommand extends BakeCommand
     }
 
     /**
-     * initialize
+     * The subcommand is assigned in the constructor (not initialize()) because
+     * buildOptionParser() runs before initialize() and reads it.
      *
-     * @return void
+     * @param \Cake\Console\CommandFactoryInterface|null $factory Command factory instance.
      */
-    public function initialize(): void
+    public function __construct(?CommandFactoryInterface $factory = null)
     {
-        parent::initialize();
+        parent::__construct($factory);
+
         $this->templateCommand = new TemplateCommand();
     }
 

--- a/tests/TestCase/Command/ControllerAllCommandTest.php
+++ b/tests/TestCase/Command/ControllerAllCommandTest.php
@@ -16,9 +16,11 @@ declare(strict_types=1);
  */
 namespace Bake\Test\TestCase\Command;
 
+use Bake\Command\ControllerAllCommand;
 use Bake\Test\App\Model\Table\BakeArticlesTable;
 use Bake\Test\TestCase\TestCase;
 use Cake\Console\CommandInterface;
+use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
 
@@ -90,5 +92,19 @@ class ControllerAllCommandTest extends TestCase
             ROOT . 'tests/TestCase/Controller/BakeArticlesControllerTest.php',
             'Test should not be created as options should be forwarded',
         );
+    }
+
+    /**
+     * The option parser is built before initialize() runs, so the wrapped subcommand
+     * must already be available at that point. Regression test for the subcommand being
+     * assigned in initialize() instead of the constructor.
+     *
+     * @return void
+     */
+    public function testGetOptionParserBeforeInitialize(): void
+    {
+        $command = new ControllerAllCommand();
+
+        $this->assertInstanceOf(ConsoleOptionParser::class, $command->getOptionParser());
     }
 }

--- a/tests/TestCase/Command/ModelAllCommandTest.php
+++ b/tests/TestCase/Command/ModelAllCommandTest.php
@@ -16,9 +16,11 @@ declare(strict_types=1);
  */
 namespace Bake\Test\TestCase\Command;
 
+use Bake\Command\ModelAllCommand;
 use Bake\Test\TestCase\TestCase;
 use Bake\Utility\SubsetSchemaCollection;
 use Cake\Console\CommandInterface;
+use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Inflector;
 
@@ -98,5 +100,19 @@ class ModelAllCommandTest extends TestCase
             ROOT . 'tests/TestCase/Model/Table/TodoItemsTableTest.php',
             'Table test should not be created as options should be forwarded',
         );
+    }
+
+    /**
+     * The option parser is built before initialize() runs, so the wrapped subcommand
+     * must already be available at that point. Regression test for the subcommand being
+     * assigned in initialize() instead of the constructor.
+     *
+     * @return void
+     */
+    public function testGetOptionParserBeforeInitialize(): void
+    {
+        $command = new ModelAllCommand();
+
+        $this->assertInstanceOf(ConsoleOptionParser::class, $command->getOptionParser());
     }
 }

--- a/tests/TestCase/Command/TemplateAllCommandTest.php
+++ b/tests/TestCase/Command/TemplateAllCommandTest.php
@@ -16,9 +16,11 @@ declare(strict_types=1);
  */
 namespace Bake\Test\TestCase\Command;
 
+use Bake\Command\TemplateAllCommand;
 use Bake\Test\TestCase\TestCase;
 use Bake\Utility\SubsetSchemaCollection;
 use Cake\Console\CommandInterface;
+use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 
@@ -121,5 +123,19 @@ class TemplateAllCommandTest extends TestCase
         $this->assertFilesExist($this->generatedFiles);
         $this->assertFileContains('title', $this->generatedFiles[0]);
         $this->assertFileNotContains('published', $this->generatedFiles[0]);
+    }
+
+    /**
+     * The option parser is built before initialize() runs, so the wrapped subcommand
+     * must already be available at that point. Regression test for the subcommand being
+     * assigned in initialize() instead of the constructor.
+     *
+     * @return void
+     */
+    public function testGetOptionParserBeforeInitialize(): void
+    {
+        $command = new TemplateAllCommand();
+
+        $this->assertInstanceOf(ConsoleOptionParser::class, $command->getOptionParser());
     }
 }


### PR DESCRIPTION
Fixes Cluster B of cakephp/cakephp#19491.

quite a heavy change though that most likely still leaves other third party commands affected.

## Problem

`ControllerAllCommand`, `ModelAllCommand` and `TemplateAllCommand` declare their wrapped subcommand as a non-nullable typed property and assign it in `initialize()`:

```php
protected ControllerCommand $controllerCommand;

public function initialize(): void
{
    parent::initialize();
    $this->controllerCommand = new ControllerCommand();
}
```

On CakePHP 5.4, `BaseCommand::run()` builds the option parser *before* calling `initialize()`. `buildOptionParser()` reads the subcommand, which is still uninitialized at that point:

```
Typed property Bake\Command\ControllerAllCommand::$controllerCommand
must not be accessed before initialization
```

This surfaced as errors in `ControllerAllCommandTest::testExecute` and `ModelAllCommandTest::testExecute`. `TemplateAllCommand` never reads its subcommand in `buildOptionParser()`, so its breakage was latent.

## Fix

Assign the subcommand in the constructor, so it is available regardless of the run/initialize ordering:

```php
public function __construct(?CommandFactoryInterface $factory = null)
{
    parent::__construct($factory);

    $this->controllerCommand = new ControllerCommand();
}
```

The `initialize()` override is dropped; the inherited `BakeCommand::initialize()` (table-locator fallback) still runs. All three commands are kept consistent.

## Tests

Added a `testGetOptionParserBeforeInitialize` to each command test that calls `getOptionParser()` directly on a freshly constructed command - the exact pre-`initialize()` path the runner takes. These reproduce the reported error on the old code and pass with the fix, independent of the installed CakePHP version.
