### PR TITLE
Ensure unique association aliases for self-referencing keys

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -1587,7 +1587,16 @@ class ModelCommand extends BakeCommand
             foreach ($associationsPerType as $k => $association) {
                 $alias = $association['alias'];
                 if (in_array($alias, $existing, true)) {
-                    $alias = $this->createAssociationAlias($association);
+                    // Derive a unique alias by appending a numeric suffix.
+                    // Self-referencing keys (e.g. `system_id` on `systems`)
+                    // would otherwise yield the same colliding alias again.
+                    $base = $this->createAssociationAlias($association);
+                    $alias = $base;
+                    $i = 1;
+                    while (in_array($alias, $existing, true)) {
+                        $i++;
+                        $alias = $base . $i;
+                    }
                 }
                 $existing[] = $alias;
                 if (empty($association['className'])) {

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -283,6 +283,35 @@ class ModelCommandTest extends TestCase
     }
 
     /**
+     * A non-foreign-key column matching the table name (e.g. `system_id` on
+     * `systems`) must not produce duplicate aliases that break baking.
+     *
+     * @return void
+     */
+    public function testGetAssociationsEnsuresUniqueAliasForSelfReferencingKey(): void
+    {
+        $systems = $this->getTableLocator()->get('Systems');
+
+        $command = new ModelCommand();
+        $command->connection = 'test';
+        $args = new Arguments([], [], []);
+        $io = $this->createStub(ConsoleIo::class);
+        $result = $command->getAssociations($systems, $args, $io);
+
+        $belongsToAliases = array_column($result['belongsTo'], 'alias');
+        $hasManyAliases = array_column($result['hasMany'], 'alias');
+        $allAliases = array_merge($belongsToAliases, $hasManyAliases);
+
+        $this->assertContains('Systems', $belongsToAliases);
+        $this->assertContains('Systems2', $hasManyAliases);
+        $this->assertSame($allAliases, array_unique($allAliases), 'Association aliases must be unique.');
+
+        // Applying the deduplicated associations must not throw.
+        $command->applyAssociations($systems, $result);
+        $this->assertSame(['Systems', 'Systems2'], $systems->associations()->keys());
+    }
+
+    /**
      * Test getAssociations
      *
      * @return void

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -587,6 +587,17 @@ return [
             'unique_self_referencing_parent' => ['type' => 'unique', 'columns' => ['parent_id']],
         ],
     ],
+    // "systems" has a "system_id" column that is not a real foreign key.
+    // It would otherwise produce duplicate "Systems" belongsTo/hasMany aliases.
+    [
+        'table' => 'systems',
+        'columns' => [
+            'id' => ['type' => 'integer'],
+            'system_id' => ['type' => 'string', 'length' => 255, 'null' => false],
+            'name' => ['type' => 'string', 'length' => 255, 'null' => true],
+        ],
+        'constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+    ],
     // "news" is both singular and plural - tests variable collision fix
     [
         'table' => 'news',


### PR DESCRIPTION
Fixes #1092

## Problem

When a table has a column whose conventional model name equals the table's own name (for example a non-foreign-key `system_id` column on a `systems` table), `bake` derives the alias `Systems` for both the generated `belongsTo` (from the column) and the `hasMany` (self-referencing detection). The deduplication in `ensureAliasUniqueness()` caught the collision but its fallback `createAssociationAlias()` recomputed the same conventional name from the foreign key, so the alias stayed `Systems`.

Applying the second association then threw and aborted the whole bake run:

```
[Cake\Core\Exception\CakeException] Association alias `Systems` is already set.
```

This is a follow-up to #1059 (which fixed the `parent_id`-style two-key case).

## Fix

Append a numeric suffix until the alias is actually unique. The first occurrence keeps the conventional name; subsequent collisions become `Systems2`, `Systems3`, and so on, while the original target class name is preserved via the existing `className` handling. Bake now generates valid, editable association code instead of crashing, leaving it to the developer to adjust or remove the guessed association.

## Notes

The signatures of `applyAssociations()` and `createAssociationAlias()` are intentionally left unchanged to avoid breaking subclasses that override them.
