### PR TITLE
Skip self-referencing associations for unconstrained keys

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -358,6 +358,15 @@ class ModelCommand extends BakeCommand
                 ];
             } else {
                 $tmpModelName = $this->_modelNameFromKey($fieldName);
+                // A key that resolves to the table itself (e.g. a `system_id`
+                // column on `systems`) is only a real self-reference when it is
+                // actually constrained as a foreign key to this table. Otherwise
+                // (e.g. an external id that merely follows the `<table>_id`
+                // naming) skip it to avoid generating an invalid self-association
+                // that collides with the table's own alias.
+                if ($tmpModelName === $model->getAlias() && !$this->findTableReferencedBy($schema, $fieldName)) {
+                    continue;
+                }
                 if (!$this->getTableLocator()->exists($tmpModelName)) {
                     $this->getTableLocator()->get(
                         $tmpModelName,
@@ -520,7 +529,11 @@ class ModelCommand extends BakeCommand
                 }
 
                 $assoc = false;
-                if (!in_array($fieldName, $primaryKey) && $fieldName === $foreignKey) {
+                if (
+                    $otherTableName !== $tableName &&
+                    !in_array($fieldName, $primaryKey) &&
+                    $fieldName === $foreignKey
+                ) {
                     $assoc = [
                         'alias' => $otherModel->getAlias(),
                         'foreignKey' => $fieldName,
@@ -564,6 +577,7 @@ class ModelCommand extends BakeCommand
             foreach ($otherSchema->columns() as $fieldName) {
                 $assoc = false;
                 if (
+                    $otherTableName !== $tableName &&
                     !in_array($fieldName, $primaryKey) &&
                     $fieldName === $foreignKey &&
                     !$this->hasUniqueConstraintFor($otherSchema, $fieldName)

--- a/tests/TestCase/Command/ModelCommandTest.php
+++ b/tests/TestCase/Command/ModelCommandTest.php
@@ -283,6 +283,82 @@ class ModelCommandTest extends TestCase
     }
 
     /**
+     * A non-foreign-key column matching the table name (e.g. `system_id` on
+     * `systems`) must not generate an invalid self-referencing association.
+     *
+     * @return void
+     */
+    public function testGetAssociationsSkipsSelfReferencingKey(): void
+    {
+        $systems = $this->getTableLocator()->get('Systems');
+
+        $command = new ModelCommand();
+        $command->connection = 'test';
+        $args = new Arguments([], [], []);
+        $io = $this->createStub(ConsoleIo::class);
+        $result = $command->getAssociations($systems, $args, $io);
+
+        $aliases = array_merge(
+            array_column($result['belongsTo'], 'alias'),
+            array_column($result['hasMany'], 'alias'),
+        );
+        $this->assertNotContains('Systems', $aliases, 'Self-referencing association must not be generated.');
+
+        // Applying the associations must not throw.
+        $command->applyAssociations($systems, $result);
+        $this->assertSame([], $systems->associations()->keys());
+    }
+
+    /**
+     * A real self-referencing foreign key (constrained, not named `parent_id`)
+     * must still produce a belongsTo association.
+     *
+     * @return void
+     */
+    public function testGetAssociationsKeepsConstrainedSelfReference(): void
+    {
+        $nodes = $this->getTableLocator()->get('Nodes');
+
+        $command = new ModelCommand();
+        $command->connection = 'test';
+        $args = new Arguments([], [], []);
+        $io = $this->createStub(ConsoleIo::class);
+        $result = $command->getAssociations($nodes, $args, $io);
+
+        $this->assertSame(['Nodes'], array_column($result['belongsTo'], 'alias'));
+
+        $command->applyAssociations($nodes, $result);
+        $this->assertSame(['Nodes'], $nodes->associations()->keys());
+    }
+
+    /**
+     * A unique non-foreign-key column matching the table name (e.g. a unique
+     * `gadget_id` on `gadgets`) must not generate a self-referencing hasOne.
+     *
+     * @return void
+     */
+    public function testGetAssociationsSkipsUniqueSelfReferencingKey(): void
+    {
+        $gadgets = $this->getTableLocator()->get('Gadgets');
+
+        $command = new ModelCommand();
+        $command->connection = 'test';
+        $args = new Arguments([], [], []);
+        $io = $this->createStub(ConsoleIo::class);
+        $result = $command->getAssociations($gadgets, $args, $io);
+
+        $aliases = array_merge(
+            array_column($result['belongsTo'], 'alias'),
+            array_column($result['hasOne'], 'alias'),
+            array_column($result['hasMany'], 'alias'),
+        );
+        $this->assertNotContains('Gadgets', $aliases, 'Self-referencing association must not be generated.');
+
+        $command->applyAssociations($gadgets, $result);
+        $this->assertSame([], $gadgets->associations()->keys());
+    }
+
+    /**
      * Test getAssociations
      *
      * @return void

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -587,6 +587,51 @@ return [
             'unique_self_referencing_parent' => ['type' => 'unique', 'columns' => ['parent_id']],
         ],
     ],
+    // "systems" has a "system_id" column that is not a real foreign key.
+    // Bake must not generate a self-referencing Systems association for it.
+    [
+        'table' => 'systems',
+        'columns' => [
+            'id' => ['type' => 'integer'],
+            'system_id' => ['type' => 'string', 'length' => 255, 'null' => false],
+            'name' => ['type' => 'string', 'length' => 255, 'null' => true],
+        ],
+        'constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+    ],
+    // "nodes" has a real self-referencing foreign key (node_id -> nodes.id)
+    // that is not named parent_id. The belongsTo association must still be kept.
+    [
+        'table' => 'nodes',
+        'columns' => [
+            'id' => ['type' => 'integer'],
+            'node_id' => ['type' => 'integer', 'null' => true],
+            'name' => ['type' => 'string', 'length' => 255, 'null' => true],
+        ],
+        'constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'node_id_fk' => [
+                'type' => 'foreign',
+                'columns' => ['node_id'],
+                'references' => ['nodes', 'id'],
+                'update' => 'cascade',
+                'delete' => 'cascade',
+            ],
+        ],
+    ],
+    // "gadgets" has a unique "gadget_id" column that is not a real foreign key.
+    // Bake must not generate a self-referencing hasOne Gadgets association.
+    [
+        'table' => 'gadgets',
+        'columns' => [
+            'id' => ['type' => 'integer'],
+            'gadget_id' => ['type' => 'string', 'length' => 255, 'null' => false],
+            'name' => ['type' => 'string', 'length' => 255, 'null' => true],
+        ],
+        'constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'unique_gadget_id' => ['type' => 'unique', 'columns' => ['gadget_id']],
+        ],
+    ],
     // "news" is both singular and plural - tests variable collision fix
     [
         'table' => 'news',


### PR DESCRIPTION
Addresses #1092

## Problem

When a column follows the `<table>_id` naming on its own table - for example an external `system_id` on a `systems` table that is not a real foreign key - bake derived the alias `Systems` for both the generated `belongsTo` (from the column) and the self-referencing `hasMany`/`hasOne` detection. Applying the second association threw and aborted the whole bake run:

```
[Cake\Core\Exception\CakeException] Association alias `Systems` is already set.
```

Per the discussion in #1092 (cc the maintainer thread), legitimate self-references conventionally use `parent_id`, which already gets dedicated `Parent*`/`Child*` aliases. A plain `<table>_id` that is not backed by a foreign key is almost always an external identifier, not a self-association.

## Fix

Skip generating a self-referencing association when the resolved alias equals the table's own alias **and** the column is not actually constrained as a foreign key to that table. The guard is applied consistently across all three detection passes:

- `findBelongsTo()` - skip the column unless `findTableReferencedBy()` confirms a real constraint.
- `findHasMany()` - skip self-table matches (the `parent_id` self-ref keeps its existing `Child*` handling).
- `findHasOne()` - skip self-table matches for unique columns.

Real, constrained self-references (a `node_id` foreign key referencing `nodes.id`) still produce their `belongsTo`, so no valid association is lost.

## Relationship to #1093

This is the upstream prevention (do not generate the bogus association). #1093 is independent downstream hardening (never fatal on a duplicate alias from any other cause). They compose and do not conflict.
