### PR TITLE
Add short descriptions to bake commands

### DIFF
--- a/src/Command/BehaviorCommand.php
+++ b/src/Command/BehaviorCommand.php
@@ -29,6 +29,14 @@ class BehaviorCommand extends SimpleBakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a model behavior and test.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function name(): string
     {
         return 'behavior';

--- a/src/Command/CellCommand.php
+++ b/src/Command/CellCommand.php
@@ -34,6 +34,14 @@ class CellCommand extends SimpleBakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a view cell, template and test.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function name(): string
     {
         return 'cell';

--- a/src/Command/CommandCommand.php
+++ b/src/Command/CommandCommand.php
@@ -32,6 +32,14 @@ class CommandCommand extends SimpleBakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a console command and test.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function name(): string
     {
         return 'command';

--- a/src/Command/CommandHelperCommand.php
+++ b/src/Command/CommandHelperCommand.php
@@ -29,6 +29,14 @@ class CommandHelperCommand extends SimpleBakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a console command helper and test.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function name(): string
     {
         return 'command_helper';

--- a/src/Command/ControllerAllCommand.php
+++ b/src/Command/ControllerAllCommand.php
@@ -35,6 +35,14 @@ class ControllerAllCommand extends BakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create all controllers for an application or plugin.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public static function defaultName(): string
     {
         return 'bake controller all';

--- a/src/Command/ControllerCommand.php
+++ b/src/Command/ControllerCommand.php
@@ -35,6 +35,14 @@ class ControllerCommand extends BakeCommand
     public string $pathFragment = 'Controller/';
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Create a controller and test';
+    }
+
+    /**
      * Execute the command.
      *
      * @param \Cake\Console\Arguments $args The command arguments.

--- a/src/Command/EnumCommand.php
+++ b/src/Command/EnumCommand.php
@@ -36,6 +36,14 @@ class EnumCommand extends SimpleBakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a model Enum';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function name(): string
     {
         return 'enum';

--- a/src/Command/FixtureAllCommand.php
+++ b/src/Command/FixtureAllCommand.php
@@ -39,6 +39,14 @@ class FixtureAllCommand extends BakeCommand
     }
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Create all fixtures for an application or plugin.';
+    }
+
+    /**
      * Gets the option parser instance and configures it.
      *
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to update

--- a/src/Command/FixtureCommand.php
+++ b/src/Command/FixtureCommand.php
@@ -40,6 +40,14 @@ use ReflectionEnum;
 class FixtureCommand extends BakeCommand
 {
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Create a test fixture class.';
+    }
+
+    /**
      * Get the file path.
      *
      * @param \Cake\Console\Arguments $args Arguments instance to read the prefix option from.

--- a/src/Command/FormCommand.php
+++ b/src/Command/FormCommand.php
@@ -29,6 +29,14 @@ class FormCommand extends SimpleBakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a form class and test.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function name(): string
     {
         return 'form';

--- a/src/Command/HelperCommand.php
+++ b/src/Command/HelperCommand.php
@@ -29,6 +29,14 @@ class HelperCommand extends SimpleBakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a view helper and test.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function name(): string
     {
         return 'helper';

--- a/src/Command/MailerCommand.php
+++ b/src/Command/MailerCommand.php
@@ -32,6 +32,14 @@ class MailerCommand extends SimpleBakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a mailer and test.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function name(): string
     {
         return 'mailer';
@@ -54,7 +62,7 @@ class MailerCommand extends SimpleBakeCommand
     }
 
     /**
-     * Bake the Mailer class and html/text layout files.
+     * Bake the Mailer class.
      *
      * @param string $name The name of the mailer to make.
      * @param \Cake\Console\Arguments $args The console arguments

--- a/src/Command/MiddlewareCommand.php
+++ b/src/Command/MiddlewareCommand.php
@@ -29,6 +29,14 @@ class MiddlewareCommand extends SimpleBakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a middleware class and test.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function name(): string
     {
         return 'middleware';

--- a/src/Command/ModelAllCommand.php
+++ b/src/Command/ModelAllCommand.php
@@ -35,6 +35,14 @@ class ModelAllCommand extends BakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create all models, fixtures and tests in an application or plugin.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public static function defaultName(): string
     {
         return 'bake model all';

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -64,6 +64,14 @@ class ModelCommand extends BakeCommand
     protected array $_tables = [];
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Create a table class and its related entity, enums, test fixture and tests.';
+    }
+
+    /**
      * Execute the command.
      *
      * @param \Cake\Console\Arguments $args The command arguments.

--- a/src/Command/PluginCommand.php
+++ b/src/Command/PluginCommand.php
@@ -44,6 +44,14 @@ class PluginCommand extends BakeCommand
     protected bool $isVendor = false;
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Create a plugin.';
+    }
+
+    /**
      * Execute the command.
      *
      * @param \Cake\Console\Arguments $args The command arguments.

--- a/src/Command/TemplateAllCommand.php
+++ b/src/Command/TemplateAllCommand.php
@@ -32,6 +32,14 @@ class TemplateAllCommand extends BakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create all view templates for all controllers in an application or plugin.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public static function defaultName(): string
     {
         return 'bake template all';

--- a/src/Command/TemplateCommand.php
+++ b/src/Command/TemplateCommand.php
@@ -82,6 +82,14 @@ class TemplateCommand extends BakeCommand
     public string $ext = 'php';
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Create a view template.';
+    }
+
+    /**
      * Override initialize
      *
      * @return void

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -96,6 +96,14 @@ class TestCommand extends BakeCommand
     protected array $_fixtures = [];
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Create a test case skeleton for a class.';
+    }
+
+    /**
      * Execute test generation
      *
      * @param \Cake\Console\Arguments $args The command arguments.


### PR DESCRIPTION
Implement the `getDescription()` method on bake commands so that they create more useful output when `cake` is run with no parameters.